### PR TITLE
Add current proposal cache to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 wasm/Cargo.lock
 **/build
 **.ledger-*
+**.current-proposal-cache-*
 **.logs-*
 validator-*
 **.bft-storage-*/


### PR DESCRIPTION
## Motivation

Proposal cache was recently introduced, but unlike ledger, it is not in .gitignore.

## Test Plan

Worked for me locally.

## Related PRs

https://github.com/AleoNet/snarkOS/pull/3239
https://github.com/AleoNet/snarkOS/pull/3247