### PR TITLE
fix: cleanup obsolete block requests

### DIFF
--- a/node/sync/src/block_sync.rs
+++ b/node/sync/src/block_sync.rs
@@ -646,6 +646,7 @@ impl<N: Network> BlockSync<N> {
 
             let retain = !peer_ips.is_empty() || responses.get(height).is_some();
             if !retain {
+                trace!("Removed block request timestamp for {peer_ip} at height {height}");
                 self.request_timestamps.write().remove(height);
             }
             retain
@@ -665,11 +666,15 @@ impl<N: Network> BlockSync<N> {
         // Retrieve the current time.
         let now = Instant::now();
 
+        // Retrieve the current block height
+        let current_height = self.canon.latest_block_height();
+
         // Track the number of timed out block requests.
         let mut num_timed_out_block_requests = 0;
 
         // Remove timed out block requests.
         request_timestamps.retain(|height, timestamp| {
+            let is_obsolete = *height < current_height;
             // Determine if the duration since the request timestamp has exceeded the request timeout.
             let is_time_passed = now.duration_since(*timestamp).as_secs() > BLOCK_REQUEST_TIMEOUT_IN_SECS;
             // Determine if the request is incomplete.
@@ -678,8 +683,9 @@ impl<N: Network> BlockSync<N> {
             // Determine if the request has timed out.
             let is_timeout = is_time_passed && is_request_incomplete;
 
-            // If the request has timed out, then remove it.
-            if is_timeout {
+            // If the request has timed out, or is obsolete, then remove it.
+            if is_timeout || is_obsolete {
+                trace!("Block request {height} has timed out: is_time_passed = {is_time_passed}, is_request_incomplete = {is_request_incomplete}, is_obsolete = {is_obsolete}");
                 // Remove the request entry for the given height.
                 requests.remove(height);
                 // Remove the response entry for the given height.
@@ -687,8 +693,8 @@ impl<N: Network> BlockSync<N> {
                 // Increment the number of timed out block requests.
                 num_timed_out_block_requests += 1;
             }
-            // Retain if this is not a timeout.
-            !is_timeout
+            // Retain if this is not a timeout and is not obsolete.
+            !is_timeout && !is_obsolete
         });
 
         num_timed_out_block_requests


### PR DESCRIPTION
When syncing, the `BlockSync.requests` is not always correctly cleaned up (it can contain MANY very old requests):

```
2024-05-27T17:43:26.458864Z TRACE ThreadId(64) snarkos_node_sync::block_sync: No block requests to send - try advancing with block responses (at block 3571)
2024-05-27T17:43:26.459006Z TRACE ThreadId(64) snarkos_node_sync::block_sync: Requests: [16, 45, 72, 103, 127, 154, 183, 208, 233, 277, 306, 339, 369, 394, 415, 432, 451, 471, 495, 513, 536, 566, 590, 606, 624, 651, 672, 715, 738, 757, 777, 806, 840, 856, 873, 888, 905, 938, 951, 981, 1014, 1082, 1120, 1139, 1171, 1191, 1212, 1228, 1241, 1261, 1278, 1288, 1302, 1317, 1339, 1353, 1373, 1395, 1425, 1441, 1495, 1516, 1526, 1542, 1552, 1576, 1597, 1620, 1641, 1681, 1712, 1750, 1766, 1794, 1826, 1844, 1862, 1876, 1898, 1917, 1940, 1960, 2001, 2013, 2032, 2067, 2085, 2101, 2116, 2130, 2148, 2165, 2185, 2199, 2250, 2257, 2290, 2307, 2341, 2360, 2413, 2437, 2457, 2468, 2476, 2493, 2512, 2538, 2557, 2594, 2610, 2625, 2658, 2679, 2699, 2715, 2728, 2748, 2767, 2781, 2810, 2825, 2838, 2855, 2871, 2887, 2903, 2919, 2964, 2985, 3011, 3027, 3041, 3057, 3088, 3099, 3116, 3131, 3148, 3182, 3208, 3220, 3236, 3258, 3277, 3291, 3331, 3347, 3366, 3406, 3425, 3442, 3508, 3528, 3545, 3564, 3572, 3573, 3574, 3575, 3576, 3577, 3578, 3579, 3580, 3581, 3582, 3583, 3584, 3585, 3586, 3587, 3588, 3589, 3590, 3591, 3592, 3593, 3594, 3595, 3596, 3597, 3598, 3599, 3600, 3601, 3602, 3603, 3604, 3605, 3606, 3607, 3608, 3609, 3610, 3611, 3612, 3613, 3614, 3615, 3616, 3617, 3618, 3619, 3620, 3621, 3622, 3623, 3624, 3625, 3626, 3627, 3628, 3629, 3630, 3631, 3632, 3633, 3634, 3635, 3636, 3637, 3638, 3639, 3640, 3641, 3642, 3643, 3644, 3645, 3646, 3647, 3648, 3649, 3650, 3651, 3652, 3653, 3654, 3655, 3656, 3657, 3658, 3659, 3660, 3661, 3662, 3663, 3664, 3665, 3666, 3667, 3668, 3669, 3670, 3671, 3672, 3673, 3674, 3675, 3676, 3677, 3678, 3679, 3680, 3681, 3682, 3683, 3684, 3685, 3686, 3687, 3688, 3689, 3690, 3691, 3692, 3693, 3694, 3695, 3696, 3697, 3698, 3699, 3700, 3701, 3702, 3703, 3704, 3705, 3706, 3707, 3708, 3709, 3710, 3711, 3712, 3713, 3714, 3715, 3716, 3717, 3718, 3719, 3720, 3721, 3722, 3723, 3724, 3725, 3726, 3727, 3728, 3729, 3730, 3731, 3732, 3733, 3734, 3735, 3736, 3737, 3738, 3739, 3740, 3741, 3742, 3743, 3744, 3745, 3746, 3747, 3748, 3749, 3750, 3751, 3752, 3753, 3754, 3755, 3756, 3757, 3758, 3759, 3760, 3761, 3762, 3763, 3764, 3765, 3766, 3767, 3768, 3769, 3770, 3771, 3772, 3773, 3774, 3775, 3776, 3777, 3778, 3779, 3780, 3781, 3782, 3783, 3784, 3785, 3786, 3787, 3788, 3789, 3790, 3791, 3792, 3793, 3794, 3795, 3796, 3797, 3798, 3799, 3800, 3801, 3802, 3803, 3804, 3805, 3806, 3807, 3808, 3809, 3810, 3811, 3812, 3813, 3814, 3815, 3816, 3817, 3818, 3819, 3820, 3821]
```

This is a memory leak and it can cause the sync to fail it seems.

This PR is a simple fix, remove all block requests that are below the current block height.