### PR TITLE
fix: block sync on big blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3205,6 +3205,7 @@ dependencies = [
  "parking_lot",
  "peak_alloc",
  "rand",
+ "rayon",
  "reqwest",
  "serde",
  "snarkos-account",

--- a/node/router/Cargo.toml
+++ b/node/router/Cargo.toml
@@ -58,6 +58,9 @@ version = "0.12"
 [dependencies.rand]
 version = "0.8"
 
+[dependencies.rayon]
+version = "1.10"
+
 [dependencies.reqwest]
 version = "0.11"
 

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -500,6 +500,12 @@ impl<N: Network> Router<N> {
         Ok(())
     }
 
+    pub fn update_last_seen_for_connected_peer(&self, peer_ip: SocketAddr) {
+        if let Some(peer) = self.connected_peers.write().get_mut(&peer_ip) {
+            peer.set_last_seen(Instant::now());
+        }
+    }
+
     /// Removes the connected peer and adds them to the candidate peers.
     pub fn remove_connected_peer(&self, peer_ip: SocketAddr) {
         // Removes the bidirectional map between the listener address and (ambiguous) peer address.

--- a/node/src/validator/router.rs
+++ b/node/src/validator/router.rs
@@ -111,6 +111,26 @@ impl<N: Network, C: ConsensusStorage<N>> Reading for Validator<N, C> {
 
     /// Processes a message received from the network.
     async fn process_message(&self, peer_addr: SocketAddr, message: Self::Message) -> io::Result<()> {
+        let clone = self.clone();
+        if matches!(message, Message::BlockRequest(_) | Message::BlockResponse(_)) {
+            // Handle BlockRequest and BlockResponse messages in a separate task to not block the
+            // inbound queue.
+            tokio::spawn(async move {
+                clone.process_message_inner(peer_addr, message).await;
+            });
+        } else {
+            self.process_message_inner(peer_addr, message).await;
+        }
+        Ok(())
+    }
+}
+
+impl<N: Network, C: ConsensusStorage<N>> Validator<N, C> {
+    async fn process_message_inner(
+        &self,
+        peer_addr: SocketAddr,
+        message: <Validator<N, C> as snarkos_node_tcp::protocols::Reading>::Message,
+    ) {
         // Process the message. Disconnect if the peer violated the protocol.
         if let Err(error) = self.inbound(peer_addr, message).await {
             if let Some(peer_ip) = self.router().resolve_to_listener(&peer_addr) {
@@ -120,7 +140,6 @@ impl<N: Network, C: ConsensusStorage<N>> Reading for Validator<N, C> {
                 self.router().disconnect(peer_ip);
             }
         }
-        Ok(())
     }
 }
 


### PR DESCRIPTION
When big blocks are received during sync, sometimes deserialization can take very long. Doing this much work in a `spawn_blocking` task is not ideal, so we switched to using rayon for the deserialization.

Addionally, nodes handling big `BlockRequest`s stop responding to `Ping` and `PeerRequest` as the inbound messages are handled sequentially. This can lead to the syncing node disconnecting the peer before the blocks are deserialized. Then all outstanding `BlockRequest`s are flushed from this peer, and when the blocks are finally ready to be processed they are thrown away as now it seems we didn't even request these blocks. Leading to an infinite loop of requesting the big blocks, dropping the peer, dropping the blocks and re-requesting.

### Testing
This was tested on isonet `snarkos-client-val8-client0`. Ledger was cleared and node got initially stuck on blocks 189886 where a series of big (50+ MB) blocks was located. The rayon change was not enough to fix as the peer got disconnected and so the blocks were always thrown away. I had to patch 4 nodes (validator 8 and his 3 clients) to test (so they would answer to the `Ping`/`PeerRequest` messages).