### PR TITLE
Adds a restrictions ID check into handshake protocols

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3300,7 +3300,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3331,7 +3331,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3361,7 +3361,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3375,7 +3375,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3386,7 +3386,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3396,7 +3396,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3406,7 +3406,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "indexmap 2.2.6",
  "itertools 0.11.0",
@@ -3424,12 +3424,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3440,7 +3440,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3455,7 +3455,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3470,7 +3470,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3483,7 +3483,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3492,7 +3492,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3502,7 +3502,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3514,7 +3514,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3526,7 +3526,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3537,7 +3537,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3549,7 +3549,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3562,7 +3562,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3573,7 +3573,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3586,7 +3586,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3597,7 +3597,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -3620,7 +3620,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3638,7 +3638,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -3659,7 +3659,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3674,7 +3674,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3685,7 +3685,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -3693,7 +3693,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3703,7 +3703,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3714,7 +3714,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3725,7 +3725,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3736,7 +3736,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3747,7 +3747,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "rand",
  "rayon",
@@ -3761,7 +3761,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3778,7 +3778,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3803,7 +3803,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "anyhow",
  "rand",
@@ -3815,7 +3815,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3834,7 +3834,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -3853,7 +3853,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -3866,7 +3866,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3879,7 +3879,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3892,7 +3892,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3903,7 +3903,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3918,7 +3918,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3931,7 +3931,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -3940,7 +3940,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3960,7 +3960,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "anyhow",
  "colored",
@@ -3975,7 +3975,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -3988,7 +3988,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4015,7 +4015,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "once_cell",
  "snarkvm-circuit",
@@ -4030,7 +4030,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4039,7 +4039,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4064,7 +4064,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4074,6 +4074,7 @@ dependencies = [
  "parking_lot",
  "rand",
  "rayon",
+ "serde_json",
  "snarkvm-algorithms",
  "snarkvm-circuit",
  "snarkvm-console",
@@ -4093,7 +4094,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4116,7 +4117,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "indexmap 2.2.6",
  "paste",
@@ -4130,7 +4131,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4143,7 +4144,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4164,7 +4165,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.16.19"
-source = "git+https://github.com/AleoNet/snarkVM.git?rev=74a437897#74a437897e80514cb88e52a3033df5f69181aed8"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=06bba06#06bba062c24444b8f8c13f9204159845d3b11cb7"
 dependencies = [
  "proc-macro2",
  "quote 1.0.36",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 
 [workspace.dependencies.snarkvm]
 git = "https://github.com/AleoNet/snarkVM.git"
-rev = "a122c73"
+rev = "06bba06"
 #version = "=0.16.18"
 features = [ "circuit", "console", "rocks" ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ default-features = false
 
 [workspace.dependencies.snarkvm]
 git = "https://github.com/AleoNet/snarkVM.git"
-rev = "74a437897"
+rev = "a122c73"
 #version = "=0.16.18"
 features = [ "circuit", "console", "rocks" ]
 

--- a/node/bft/ledger-service/src/ledger.rs
+++ b/node/bft/ledger-service/src/ledger.rs
@@ -82,6 +82,11 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for CoreLedgerService<
         self.ledger.latest_block()
     }
 
+    /// Returns the latest restrictions ID in the ledger.
+    fn latest_restrictions_id(&self) -> Field<N> {
+        self.ledger.vm().restrictions().restrictions_id()
+    }
+
     /// Returns the latest cached leader and its associated round.
     fn latest_leader(&self) -> Option<(u64, Address<N>)> {
         *self.latest_leader.read()

--- a/node/bft/ledger-service/src/mock.rs
+++ b/node/bft/ledger-service/src/mock.rs
@@ -20,7 +20,7 @@ use snarkvm::{
         narwhal::{BatchCertificate, Data, Subdag, Transmission, TransmissionID},
         puzzle::{Solution, SolutionID},
     },
-    prelude::{bail, ensure, Address, Field, Network, Result},
+    prelude::{bail, ensure, Address, Field, Network, Result, Zero},
 };
 
 use indexmap::IndexMap;
@@ -66,6 +66,11 @@ impl<N: Network> LedgerService<N> for MockLedgerService<N> {
     /// Returns the latest block in the ledger.
     fn latest_block(&self) -> Block<N> {
         unreachable!("MockLedgerService does not support latest_block")
+    }
+
+    /// Returns the latest restrictions ID in the ledger.
+    fn latest_restrictions_id(&self) -> Field<N> {
+        Field::zero()
     }
 
     /// Returns the latest cached leader and its associated round.

--- a/node/bft/ledger-service/src/prover.rs
+++ b/node/bft/ledger-service/src/prover.rs
@@ -20,7 +20,7 @@ use snarkvm::{
         narwhal::{BatchCertificate, Data, Subdag, Transmission, TransmissionID},
         puzzle::{Solution, SolutionID},
     },
-    prelude::{bail, Address, Field, Network, Result},
+    prelude::{bail, Address, Field, Network, Result, Zero},
 };
 
 use indexmap::IndexMap;
@@ -54,6 +54,11 @@ impl<N: Network> LedgerService<N> for ProverLedgerService<N> {
     /// Returns the latest block in the ledger.
     fn latest_block(&self) -> Block<N> {
         unreachable!("Latest block does not exist in prover")
+    }
+
+    /// Returns the latest restrictions ID in the ledger.
+    fn latest_restrictions_id(&self) -> Field<N> {
+        Field::zero()
     }
 
     /// Returns the latest cached leader and its associated round.

--- a/node/bft/ledger-service/src/traits.rs
+++ b/node/bft/ledger-service/src/traits.rs
@@ -36,6 +36,9 @@ pub trait LedgerService<N: Network>: Debug + Send + Sync {
     /// Returns the latest block in the ledger.
     fn latest_block(&self) -> Block<N>;
 
+    /// Returns the latest restrictions ID in the ledger.
+    fn latest_restrictions_id(&self) -> Field<N>;
+
     /// Returns the latest cached leader and its associated round.
     fn latest_leader(&self) -> Option<(u64, Address<N>)>;
 

--- a/node/bft/ledger-service/src/translucent.rs
+++ b/node/bft/ledger-service/src/translucent.rs
@@ -67,6 +67,11 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for TranslucentLedgerS
         self.inner.latest_block()
     }
 
+    /// Returns the latest restrictions ID in the ledger.
+    fn latest_restrictions_id(&self) -> Field<N> {
+        self.inner.latest_restrictions_id()
+    }
+
     /// Returns the latest cached leader and its associated round.
     fn latest_leader(&self) -> Option<(u64, Address<N>)> {
         self.inner.latest_leader()

--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -56,7 +56,7 @@ use snarkvm::{
         committee::Committee,
         narwhal::{BatchHeader, Data},
     },
-    prelude::Address,
+    prelude::{Address, Field},
 };
 
 use colored::Colorize;
@@ -1115,11 +1115,14 @@ impl<N: Network> Handshake for Gateway<N> {
             Some(peer_addr)
         };
 
+        // Retrieve the restrictions ID.
+        let restrictions_id = self.ledger.latest_restrictions_id();
+
         // Perform the handshake; we pass on a mutable reference to peer_ip in case the process is broken at any point in time.
         let handshake_result = if peer_side == ConnectionSide::Responder {
-            self.handshake_inner_initiator(peer_addr, peer_ip, stream).await
+            self.handshake_inner_initiator(peer_addr, peer_ip, restrictions_id, stream).await
         } else {
-            self.handshake_inner_responder(peer_addr, &mut peer_ip, stream).await
+            self.handshake_inner_responder(peer_addr, &mut peer_ip, restrictions_id, stream).await
         };
 
         // Remove the address from the collection of connecting peers (if the handshake got to the point where it's known).
@@ -1183,6 +1186,7 @@ impl<N: Network> Gateway<N> {
         &'a self,
         peer_addr: SocketAddr,
         peer_ip: Option<SocketAddr>,
+        restrictions_id: Field<N>,
         stream: &'a mut TcpStream,
     ) -> io::Result<(SocketAddr, Framed<&mut TcpStream, EventCodec<N>>)> {
         // This value is immediately guaranteed to be present, so it can be unwrapped.
@@ -1210,8 +1214,9 @@ impl<N: Network> Gateway<N> {
         let peer_request = expect_event!(Event::ChallengeRequest, framed, peer_addr);
 
         // Verify the challenge response. If a disconnect reason was returned, send the disconnect message and abort.
-        if let Some(reason) =
-            self.verify_challenge_response(peer_addr, peer_request.address, peer_response, our_nonce).await
+        if let Some(reason) = self
+            .verify_challenge_response(peer_addr, peer_request.address, peer_response, restrictions_id, our_nonce)
+            .await
         {
             send_event(&mut framed, peer_addr, reason.into()).await?;
             return Err(error(format!("Dropped '{peer_addr}' for reason: {reason:?}")));
@@ -1231,7 +1236,8 @@ impl<N: Network> Gateway<N> {
             return Err(error(format!("Failed to sign the challenge request nonce from '{peer_addr}'")));
         };
         // Send the challenge response.
-        let our_response = ChallengeResponse { signature: Data::Object(our_signature), nonce: response_nonce };
+        let our_response =
+            ChallengeResponse { restrictions_id, signature: Data::Object(our_signature), nonce: response_nonce };
         send_event(&mut framed, peer_addr, Event::ChallengeResponse(our_response)).await?;
 
         // Add the peer to the gateway.
@@ -1245,6 +1251,7 @@ impl<N: Network> Gateway<N> {
         &'a self,
         peer_addr: SocketAddr,
         peer_ip: &mut Option<SocketAddr>,
+        restrictions_id: Field<N>,
         stream: &'a mut TcpStream,
     ) -> io::Result<(SocketAddr, Framed<&mut TcpStream, EventCodec<N>>)> {
         // Construct the stream.
@@ -1286,7 +1293,8 @@ impl<N: Network> Gateway<N> {
             return Err(error(format!("Failed to sign the challenge request nonce from '{peer_addr}'")));
         };
         // Send the challenge response.
-        let our_response = ChallengeResponse { signature: Data::Object(our_signature), nonce: response_nonce };
+        let our_response =
+            ChallengeResponse { restrictions_id, signature: Data::Object(our_signature), nonce: response_nonce };
         send_event(&mut framed, peer_addr, Event::ChallengeResponse(our_response)).await?;
 
         // Sample a random nonce.
@@ -1300,8 +1308,9 @@ impl<N: Network> Gateway<N> {
         // Listen for the challenge response message.
         let peer_response = expect_event!(Event::ChallengeResponse, framed, peer_addr);
         // Verify the challenge response. If a disconnect reason was returned, send the disconnect message and abort.
-        if let Some(reason) =
-            self.verify_challenge_response(peer_addr, peer_request.address, peer_response, our_nonce).await
+        if let Some(reason) = self
+            .verify_challenge_response(peer_addr, peer_request.address, peer_response, restrictions_id, our_nonce)
+            .await
         {
             send_event(&mut framed, peer_addr, reason.into()).await?;
             return Err(error(format!("Dropped '{peer_addr}' for reason: {reason:?}")));
@@ -1340,10 +1349,17 @@ impl<N: Network> Gateway<N> {
         peer_addr: SocketAddr,
         peer_address: Address<N>,
         response: ChallengeResponse<N>,
+        expected_restrictions_id: Field<N>,
         expected_nonce: u64,
     ) -> Option<DisconnectReason> {
         // Retrieve the components of the challenge response.
-        let ChallengeResponse { signature, nonce } = response;
+        let ChallengeResponse { restrictions_id, signature, nonce } = response;
+
+        // Verify the restrictions ID.
+        if restrictions_id != expected_restrictions_id {
+            warn!("{CONTEXT} Gateway handshake with '{peer_addr}' failed (incorrect restrictions ID)");
+            return Some(DisconnectReason::InvalidChallengeResponse);
+        }
         // Perform the deferred non-blocking deserialization of the signature.
         let Ok(signature) = spawn_blocking!(signature.deserialize_blocking()) else {
             warn!("{CONTEXT} Gateway handshake with '{peer_addr}' failed (cannot deserialize the signature)");

--- a/node/bft/src/worker.rs
+++ b/node/bft/src/worker.rs
@@ -526,6 +526,7 @@ mod tests {
             fn latest_round(&self) -> u64;
             fn latest_block_height(&self) -> u32;
             fn latest_block(&self) -> Block<N>;
+            fn latest_restrictions_id(&self) -> Field<N>;
             fn latest_leader(&self) -> Option<(u64, Address<N>)>;
             fn update_latest_leader(&self, round: u64, leader: Address<N>);
             fn contains_block_height(&self, height: u32) -> bool;

--- a/node/bft/tests/gateway_e2e.rs
+++ b/node/bft/tests/gateway_e2e.rs
@@ -219,7 +219,7 @@ async fn handshake_responder_side_invalid_challenge_response() {
     let _ = test_peer.unicast(gateway.local_ip(), Event::ChallengeRequest(challenge_request));
 
     // Receive the gateway's challenge response.
-    let (peer_addr, Event::ChallengeResponse(ChallengeResponse { signature, nonce })) =
+    let (peer_addr, Event::ChallengeResponse(ChallengeResponse { restrictions_id, signature, nonce })) =
         test_peer.recv_timeout(Duration::from_secs(1)).await
     else {
         panic!("Expected challenge response")
@@ -251,6 +251,7 @@ async fn handshake_responder_side_invalid_challenge_response() {
     let _ = test_peer.unicast(
         gateway.local_ip(),
         Event::ChallengeResponse(ChallengeResponse {
+            restrictions_id,
             signature: Data::Object(
                 accounts.get(2).unwrap().sign_bytes(&challenge_request.nonce.to_le_bytes(), &mut rng).unwrap(),
             ),

--- a/node/router/tests/common/router.rs
+++ b/node/router/tests/common/router.rs
@@ -40,7 +40,9 @@ use snarkos_node_tcp::{
 use snarkvm::prelude::{
     block::{Block, Header, Transaction},
     puzzle::Solution,
+    Field,
     Network,
+    Zero,
 };
 
 use async_trait::async_trait;
@@ -80,7 +82,8 @@ impl<N: Network> Handshake for TestRouter<N> {
         let conn_side = connection.side();
         let stream = self.borrow_stream(&mut connection);
         let genesis_header = *sample_genesis_block().header();
-        self.router().handshake(peer_addr, stream, conn_side, genesis_header).await?;
+        let restrictions_id = Field::<N>::zero();
+        self.router().handshake(peer_addr, stream, conn_side, genesis_header, restrictions_id).await?;
 
         Ok(connection)
     }

--- a/node/src/client/router.rs
+++ b/node/src/client/router.rs
@@ -27,13 +27,13 @@ use snarkos_node_router::{
     },
     Routing,
 };
+use snarkos_node_sync::communication_service::CommunicationService;
 use snarkos_node_tcp::{Connection, ConnectionSide, Tcp};
 use snarkvm::{
     ledger::narwhal::Data,
     prelude::{block::Transaction, Network},
 };
 
-use snarkos_node_sync::communication_service::CommunicationService;
 use std::{io, net::SocketAddr, time::Duration};
 
 impl<N: Network, C: ConsensusStorage<N>> P2P for Client<N, C> {
@@ -52,7 +52,8 @@ impl<N: Network, C: ConsensusStorage<N>> Handshake for Client<N, C> {
         let conn_side = connection.side();
         let stream = self.borrow_stream(&mut connection);
         let genesis_header = *self.genesis.header();
-        self.router.handshake(peer_addr, stream, conn_side, genesis_header).await?;
+        let restrictions_id = self.ledger.vm().restrictions().restrictions_id();
+        self.router.handshake(peer_addr, stream, conn_side, genesis_header, restrictions_id).await?;
 
         Ok(connection)
     }

--- a/node/src/prover/router.rs
+++ b/node/src/prover/router.rs
@@ -25,7 +25,7 @@ use snarkos_node_router::messages::{
     UnconfirmedTransaction,
 };
 use snarkos_node_tcp::{Connection, ConnectionSide, Tcp};
-use snarkvm::prelude::{block::Transaction, Network};
+use snarkvm::prelude::{block::Transaction, Field, Network, Zero};
 
 use std::{io, net::SocketAddr};
 
@@ -45,7 +45,8 @@ impl<N: Network, C: ConsensusStorage<N>> Handshake for Prover<N, C> {
         let conn_side = connection.side();
         let stream = self.borrow_stream(&mut connection);
         let genesis_header = *self.genesis.header();
-        self.router.handshake(peer_addr, stream, conn_side, genesis_header).await?;
+        let restrictions_id = Field::zero(); // Provers may bypass restrictions, since they do not validate transactions.
+        self.router.handshake(peer_addr, stream, conn_side, genesis_header, restrictions_id).await?;
 
         Ok(connection)
     }

--- a/node/src/validator/router.rs
+++ b/node/src/validator/router.rs
@@ -48,7 +48,8 @@ impl<N: Network, C: ConsensusStorage<N>> Handshake for Validator<N, C> {
         let conn_side = connection.side();
         let stream = self.borrow_stream(&mut connection);
         let genesis_header = self.ledger.get_header(0).map_err(|e| error(format!("{e}")))?;
-        self.router.handshake(peer_addr, stream, conn_side, genesis_header).await?;
+        let restrictions_id = self.ledger.vm().restrictions().restrictions_id();
+        self.router.handshake(peer_addr, stream, conn_side, genesis_header, restrictions_id).await?;
 
         Ok(connection)
     }


### PR DESCRIPTION
<!-- Thank you for filing a PR! Help us understand by explaining your changes. Happy contributing! -->

## Motivation

This PR introduces a restrictions ID check into the handshake protocols.

When two nodes are handshaking on the `Router` or `Gateway` level, it is expected that they transmit in their `ChallengeResponse` messages a copy of their current restrictions ID to their peer, who subsequently checks and enforces that the restrictions ID matches what they expect from their node.

As such, going forward, the following node types are responsible to adhere to the same restrictions list:
- `NodeType::Validator`
- `NodeType::Client`

Of note, as provers do not validate transitions or transactions, they do not carry ledger state and thus are not subject to the restrictions list. Note that it is critical for clients to also perform the same validation as the validators because the validator rely upon core clients to assist with validation and propagation of transactions to the validators' memory pools.

This design is defined by the foundation to require all handshake connections to enforce the current restrictions ID to be correct and matching at the time of connection; however, it doesn't require consensus to enforce a matching restrictions ID at the time of use.

This PR builds on top of https://github.com/ProvableHQ/snarkVM/pull/15 in snarkVM, which introduces the concept of the restrictions list for programs, functions, and arguments.