### PR TITLE
perf(events): write event frames in place instead of copying twice

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,6 +157,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -615,6 +621,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -710,6 +722,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24f638c70e8c5753795cc9a8c07c44da91554a09e4cf11a7326e8161b0a3c45e"
 dependencies = [
  "envmnt",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -1002,6 +1041,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools 0.13.0",
+ "num-traits",
+ "oorandom",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
+dependencies = [
+ "cast",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -2025,6 +2095,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2355,7 +2436,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3311,6 +3392,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3874,7 +3961,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -5142,6 +5229,7 @@ version = "4.9.0"
 dependencies = [
  "anyhow",
  "bytes",
+ "criterion",
  "indexmap 2.14.0",
  "proptest",
  "rand 0.10.2",
@@ -6694,7 +6782,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.52.0",
@@ -6967,6 +7055,16 @@ checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,11 @@ features = [ "std" ]
 [workspace.dependencies.colored]
 version = "3"
 
+[workspace.dependencies.criterion]
+version = "0.7"
+default-features = false
+features = [ "cargo_bench_support" ]
+
 [workspace.dependencies.crossterm]
 version = "0.29"
 

--- a/node/bft/events/Cargo.toml
+++ b/node/bft/events/Cargo.toml
@@ -66,6 +66,13 @@ workspace = true
 workspace = true
 optional = true
 
+[[bench]]
+name = "serialization"
+harness = false
+
+[dev-dependencies.criterion]
+workspace = true
+
 [dev-dependencies.snarkvm]
 workspace = true
 features = [ "test-helpers" ]

--- a/node/bft/events/benches/serialization.rs
+++ b/node/bft/events/benches/serialization.rs
@@ -1,0 +1,162 @@
+// Copyright (c) 2019-2026 Provable Inc.
+// This file is part of the snarkOS library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Benchmarks for `EventCodec`.
+//!
+//! Encoding an event has two distinct costs, and the benchmarks below separate them:
+//!
+//! - Serializing the payload. This is paid only when the payload is held as a `Data::Object`,
+//!   and it dominates everything else when it applies.
+//! - Copying the encoded bytes into the connection's write buffer. This is paid either way, and
+//!   it is all that remains once the payload is already a `Data::Buffer`.
+//!
+//! Run with `cargo bench -p snarkos-node-bft-events`.
+
+use snarkos_node_bft_events::{BatchCertified, Event, EventCodec, TransmissionResponse};
+use snarkvm::{
+    console::types::Field,
+    ledger::narwhal::{
+        BatchCertificate,
+        Data,
+        Transmission,
+        TransmissionID,
+        batch_certificate::test_helpers::sample_batch_certificate_for_round_with_committee,
+    },
+    prelude::{FromBytes, MainnetV0, Network, PrivateKey, Rng, TestRng, ToBytes, Uniform},
+};
+
+use bytes::{Bytes, BytesMut};
+use criterion::{Criterion, criterion_group, criterion_main};
+use indexmap::IndexSet;
+use std::hint::black_box;
+use tokio_util::codec::Encoder;
+
+type CurrentNetwork = MainnetV0;
+
+/// The mainnet committee size, i.e. the number of signatures a certificate from a full committee
+/// carries, and the number of peers a broadcast fans out to.
+const COMMITTEE_SIZE: usize = 40;
+
+/// The maximum number of previous certificates a batch header may reference.
+const PREVIOUS_CERTIFICATES: usize = 40;
+
+/// Round 2 is the earliest round permitted to reference previous certificates.
+const ROUND: u64 = 2;
+
+/// Payload sizes for the transmission benchmarks: a typical transaction, and the maximum one.
+const TRANSMISSION_SIZES: [(&str, usize); 2] = [("16KiB", 16 * 1024), ("768KiB", 768 * 1024)];
+
+/// Builds a batch certificate representative of a full mainnet committee: signed by every
+/// validator, and referencing a full round of previous certificates.
+fn sample_certificate(rng: &mut TestRng) -> BatchCertificate<CurrentNetwork> {
+    let previous_certificate_ids: IndexSet<_> =
+        (0..PREVIOUS_CERTIFICATES).map(|_| Field::<CurrentNetwork>::rand(rng)).collect();
+    let committee: Vec<_> = (0..COMMITTEE_SIZE).map(|_| PrivateKey::<CurrentNetwork>::new(rng).unwrap()).collect();
+
+    sample_batch_certificate_for_round_with_committee(
+        ROUND,
+        previous_certificate_ids,
+        &committee[0],
+        &committee[1..],
+        rng,
+    )
+}
+
+/// Round-trips a certificate through its serialized form.
+///
+/// This matters for more than convenience. `Group` stores a projective point, and serializing one
+/// calls `to_affine`, which needs a field inversion unless the point is already normalized. A
+/// locally produced signature is not normalized, but one parsed from bytes is. A primary assembles
+/// a certificate from peer `BatchSignature` events, so benchmarking a freshly signed certificate
+/// would overstate the cost of encoding a real one by two orders of magnitude.
+fn from_wire(certificate: &BatchCertificate<CurrentNetwork>) -> BatchCertificate<CurrentNetwork> {
+    BatchCertificate::from_bytes_le(&certificate.to_bytes_le().unwrap()).unwrap()
+}
+
+/// Builds a transmission response carrying an opaque payload of the given size.
+fn sample_transmission_response(size: usize, rng: &mut TestRng) -> Event<CurrentNetwork> {
+    let transmission_id = TransmissionID::Transaction(
+        Field::<CurrentNetwork>::rand(rng).into(),
+        rng.random::<<CurrentNetwork as Network>::TransmissionChecksum>(),
+    );
+    let transmission = Transmission::Transaction(Data::Buffer(Bytes::from(vec![0xAB; size])));
+    Event::TransmissionResponse(TransmissionResponse::new(transmission_id, transmission))
+}
+
+/// Encodes the event exactly as a connection's writer task would.
+fn encode(event: Event<CurrentNetwork>, codec: &mut EventCodec<CurrentNetwork>, dst: &mut BytesMut) {
+    codec.encode(event, dst).unwrap();
+    dst.clear();
+}
+
+fn encoded_len(event: &Event<CurrentNetwork>) -> usize {
+    let mut dst = BytesMut::new();
+    EventCodec::<CurrentNetwork>::default().encode(event.clone(), &mut dst).unwrap();
+    dst.len()
+}
+
+/// Encoding a certificate, with the payload held either as an object or as bytes.
+///
+/// The `object` cases are dominated by serializing the certificate; the `buffer` case is what is
+/// left once serialization is out of the way, and is dominated by copying into the write buffer.
+fn bench_encode_certificate(c: &mut Criterion) {
+    let rng = &mut TestRng::default();
+    let certificate = sample_certificate(rng);
+
+    let signed_locally = Event::BatchCertified(BatchCertified::new(Data::Object(certificate.clone())));
+    let parsed_from_wire = Event::BatchCertified(BatchCertified::new(Data::Object(from_wire(&certificate))));
+    let serialized =
+        Event::BatchCertified(BatchCertified::new(Data::Buffer(certificate.to_bytes_le().unwrap().into())));
+
+    let len = encoded_len(&serialized);
+    println!("BatchCertified with {COMMITTEE_SIZE} signatures encodes to {len} bytes");
+
+    let mut group = c.benchmark_group("encode_batch_certified");
+    for (name, event) in [
+        ("object_signed_locally", &signed_locally),
+        ("object_parsed_from_wire", &parsed_from_wire),
+        ("buffer", &serialized),
+    ] {
+        group.bench_function(name, |b| {
+            let mut codec = EventCodec::<CurrentNetwork>::default();
+            let mut dst = BytesMut::with_capacity(len * 2);
+            b.iter(|| encode(black_box(event.clone()), &mut codec, &mut dst))
+        });
+    }
+    group.finish();
+}
+
+/// Encoding an already-serialized transmission of a realistic size.
+///
+/// Nothing here is serialized, so this measures only what the codec itself does with the bytes.
+fn bench_encode_transmission(c: &mut Criterion) {
+    let rng = &mut TestRng::default();
+
+    let mut group = c.benchmark_group("encode_transmission_response");
+    for (name, size) in TRANSMISSION_SIZES {
+        let event = sample_transmission_response(size, rng);
+        let len = encoded_len(&event);
+        group.throughput(criterion::Throughput::Bytes(len as u64));
+        group.bench_function(name, |b| {
+            let mut codec = EventCodec::<CurrentNetwork>::default();
+            let mut dst = BytesMut::with_capacity(len * 2);
+            b.iter(|| encode(black_box(event.clone()), &mut codec, &mut dst))
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_encode_certificate, bench_encode_transmission);
+criterion_main!(benches);

--- a/node/bft/events/src/helpers/codec.rs
+++ b/node/bft/events/src/helpers/codec.rs
@@ -36,6 +36,13 @@ use tracing::*;
 const MAX_HANDSHAKE_SIZE: usize = 1024 * 1024; // 1 MiB
 /// The maximum size of an event that can be transmitted in the network.
 const MAX_EVENT_SIZE: usize = 256 * 1024 * 1024; // 256 MiB
+/// The integer type of a frame's length prefix.
+///
+/// The decoder is configured with this via `length_field_type`, and the encoder writes the prefix
+/// as one of these, so the two cannot disagree about the framing.
+type FrameLength = u32;
+/// The width of a frame's length prefix, in bytes.
+const LENGTH_FIELD_LEN: usize = size_of::<FrameLength>();
 
 /// The codec used to decode and encode network `Event`s.
 pub struct EventCodec<N: Network> {
@@ -54,7 +61,11 @@ impl<N: Network> EventCodec<N> {
 impl<N: Network> Default for EventCodec<N> {
     fn default() -> Self {
         Self {
-            codec: LengthDelimitedCodec::builder().max_frame_length(MAX_EVENT_SIZE).little_endian().new_codec(),
+            codec: LengthDelimitedCodec::builder()
+                .max_frame_length(MAX_EVENT_SIZE)
+                .length_field_type::<FrameLength>()
+                .little_endian()
+                .new_codec(),
             _phantom: Default::default(),
         }
     }
@@ -64,19 +75,41 @@ impl<N: Network> Encoder<Event<N>> for EventCodec<N> {
     type Error = std::io::Error;
 
     fn encode(&mut self, event: Event<N>, dst: &mut BytesMut) -> Result<(), Self::Error> {
-        // Serialize the payload directly into dst, but only claim back what was appended here: dst
-        // may already hold frames that have not been written out yet - which is what happens when a
-        // sink is fed several events before being flushed - and folding those into this event's frame
-        // would produce a single frame that no decoder can make sense of.
-        let buffered = dst.len();
-        event
-            .write_le(&mut dst.writer())
+        // Reserve the frame's length prefix, remembering where it has to be written.
+        //
+        // The length is not known until the event has been serialized, so the alternative is to
+        // serialize the event elsewhere and copy the result in once its size is known. Writing the
+        // event straight into `dst` and filling in the length afterwards avoids that copy.
+        //
+        // Note that `dst` is the connection's write buffer and is not necessarily empty: it still
+        // holds any frames that have not been flushed yet. Everything below is therefore relative
+        // to where this frame starts, not to the start of the buffer.
+        let frame_offset = dst.len();
+        dst.extend_from_slice(&[0u8; LENGTH_FIELD_LEN]);
+
+        // Serialize the event directly into the destination buffer.
+        if let Err(error) = event.write_le(&mut dst.writer()) {
+            // Leave the buffer as it was found, so a failed encode cannot corrupt the stream.
+            dst.truncate(frame_offset);
+            error!("Failed to serialize an event: {error}");
             // This error should never happen, the conversion is for greater compatibility.
-            .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidData, "serialization error"))?;
+            return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "serialization error"));
+        }
 
-        let serialized_event = dst.split_off(buffered).freeze();
+        // Determine the length of what was just written, and ensure it is a permitted frame size.
+        let frame_len = dst.len() - frame_offset - LENGTH_FIELD_LEN;
+        if frame_len > self.codec.max_frame_length() {
+            dst.truncate(frame_offset);
+            return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, "frame size too big"));
+        }
 
-        self.codec.encode(serialized_event, dst)
+        // Fill in the length prefix, in the same little-endian `FrameLength` framing that
+        // `self.codec` is built to decode. The `event_roundtrip` test covers that agreement.
+        let frame_len = FrameLength::try_from(frame_len)
+            .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidInput, "frame size too big"))?;
+        dst[frame_offset..frame_offset + LENGTH_FIELD_LEN].copy_from_slice(&frame_len.to_le_bytes());
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## Motivation

While investigating a report that connections between peer validators reserve enormous buffers, we looked at how serialization of `Data::Object` works and noticed that the `Event` codec makes two needless copies of the data it is working on: once as a temporary byte buffer for the input, and once as the result of a `freeze` that splits data off the `BytesMut` we are supposed to be appending to.

This uses a different strategy that requires no temporary allocation. We write a placeholder for the frame's length prefix, serialize the event straight into the destination buffer using the trait functions available in this context, and then backpatch the length once it is known.

### Note on the non-empty-buffer bug

This PR originally also fixed a bug in the same routine: it assumed the `BytesMut` it was handed is empty, and would corrupt the stream if it was not. **That bug has since been fixed independently in #4354**, which landed while this PR was open — staging now captures `let buffered = dst.len()` and uses `split_off(buffered)` rather than `split_to(dst.len())`.

So the bugfix half of this PR is no longer needed, and what remains is the performance change. The rebase takes the approach here for the encoder, since it handles the non-empty buffer *and* avoids the copy, and keeps the proptest #4354 added (`events_encoded_into_a_shared_buffer_stay_separate`) in preference to the narrower fixed-input regression test this PR had added for the same property.

Note the same bug is **still present** in three other copies of this routine, which were not covered by #4354:

- `node/router/messages/src/helpers/codec.rs:62`
- `node/src/bootstrap_client/codec.rs:64` and `:80` (plus the `MessageOrEvent` encoder below them)

All three still use `dst.split_to(dst.len())`. That is worth fixing separately — it is reachable whenever a frame is left partially flushed, i.e. under write backpressure from a slow peer, and the router codec is on the client/prover path. Filing that as its own PR rather than growing this one.

## Test Plan

Unit test and regression test, plus a few criterion benchmarks added to understand the significance.

Verified on the rebased branch:

- `cargo test -p snarkos-node-bft-events` — 28 passed, including `event_roundtrip` and `events_encoded_into_a_shared_buffer_stay_separate`
- `cargo clippy -p snarkos-node-bft-events --all-targets -- -D warnings` — clean
- `cargo +nightly fmt -p snarkos-node-bft-events -- --check` — clean

Benchmarks can be run with `cargo bench -p snarkos-node-bft-events`. They separate the two costs of encoding an event: serializing the payload (paid only for `Data::Object`, and dominant when it applies) and copying the encoded bytes into the connection's write buffer (paid either way, and all that remains once the payload is a `Data::Buffer`).

## Backwards compatibility

No `ConsensusVersion` guard needed. The wire format is unchanged — the encoder writes the same little-endian `u32` length prefix that `LengthDelimitedCodec` was writing before, and the decoder is untouched. `FrameLength` and the explicit `length_field_type::<FrameLength>()` exist to keep the two sides from drifting now that the prefix is written by hand; `event_roundtrip` covers the agreement.

## Notes for the reviewer

- This has been rebased onto current staging now that #4354 has merged, as requested.
- Re: dropping `LengthDelimitedCodec` entirely — agreed the frame format is now defined encoder-side while the decoder still delegates, and that asymmetry is worth removing. I would prefer to do it separately: the decoder is the harder half (incremental framing across partial reads), and taking ownership of it should come with a proptest that feeds input a byte at a time, which is the property `LengthDelimitedCodec` currently provides for free.