### PR TITLE
Refactor/outbound bytes

### DIFF
--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -24,6 +24,7 @@ use crate::{
     helpers::{Cache, PrimarySender, Storage, SyncSender, WorkerSender, assign_to_worker},
     spawn_blocking,
 };
+use bytes::Bytes;
 use smol_str::SmolStr;
 use snarkos_account::Account;
 use snarkos_node_bft_events::{
@@ -117,6 +118,31 @@ const CONNECTION_ATTEMPTS_SINCE_SECS: i64 = 10;
 
 /// The amount of time an IP address is prohibited from connecting.
 const IP_BAN_TIME_IN_SECS: u64 = 300;
+
+/// Which of a peer's outbound budgets an event is charged against.
+///
+/// This is derived from the event before it is serialized, because serializing consumes the event
+/// and the resulting frame no longer says what kind of event it holds.
+#[derive(Clone, Copy)]
+enum OutboundLimit {
+    /// Certificate requests and responses.
+    Certificate,
+    /// Transmission requests and responses.
+    Transmission,
+    /// Everything else, charged against the peer's general event budget.
+    Event,
+}
+
+impl OutboundLimit {
+    /// Returns the budget the given event is charged against.
+    fn of<N: Network>(event: &Event<N>) -> Self {
+        match event {
+            Event::CertificateRequest(_) | Event::CertificateResponse(_) => Self::Certificate,
+            Event::TransmissionRequest(_) | Event::TransmissionResponse(_) => Self::Transmission,
+            _ => Self::Event,
+        }
+    }
+}
 
 /// Part of the Gateway API that deals with networking.
 /// This is a separate trait to allow for easier testing/mocking.
@@ -510,22 +536,58 @@ impl<N: Network> Gateway<N> {
         }
     }
 
-    /// Sends the given event to specified peer.
+    /// Waits until the peer's outbound rate limit permits another event, recording this one.
+    ///
+    /// This is separate from serializing and queueing the event so that an event going to several
+    /// peers can be serialized once, while each peer is still rate limited individually.
+    async fn await_outbound_capacity(&self, peer_ip: SocketAddr, limit: OutboundLimit) {
+        match limit {
+            OutboundLimit::Certificate => {
+                // Update the outbound event cache. This is necessary to ensure we don't under count the outbound events.
+                self.cache.insert_outbound_event(peer_ip, CACHE_EVENTS_INTERVAL);
+                // Rate limit the number of certificate requests sent to the peer.
+                while self.cache.insert_outbound_certificate(peer_ip, CACHE_REQUESTS_INTERVAL)
+                    > self.max_cache_certificates()
+                {
+                    // Sleep for a short period of time to allow the cache to clear.
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                }
+            }
+            OutboundLimit::Transmission => {
+                // Update the outbound event cache. This is necessary to ensure we don't under count the outbound events.
+                self.cache.insert_outbound_event(peer_ip, CACHE_EVENTS_INTERVAL);
+                // Rate limit the number of transmission requests sent to the peer.
+                while self.cache.insert_outbound_transmission(peer_ip, CACHE_REQUESTS_INTERVAL)
+                    > self.max_cache_transmissions()
+                {
+                    // Sleep for a short period of time to allow the cache to clear.
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                }
+            }
+            OutboundLimit::Event => {
+                // Rate limit against the peer's general event budget.
+                while self.cache.insert_outbound_event(peer_ip, CACHE_EVENTS_INTERVAL) > self.max_cache_events() {
+                    // Sleep for a short period of time to allow the cache to clear.
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                }
+            }
+        }
+    }
+
+    /// Queues the given serialized event for delivery to the specified peer.
     ///
     /// This function returns as soon as the event is queued to be sent,
     /// without waiting for the actual delivery; instead, the caller is provided with a [`oneshot::Receiver`]
     /// which can be used to determine when and whether the event has been delivered.
-    fn send_inner(&self, peer_ip: SocketAddr, event: Event<N>) -> Option<oneshot::Receiver<io::Result<()>>> {
+    fn send_inner(&self, peer_ip: SocketAddr, name: &str, frame: Bytes) -> Option<oneshot::Receiver<io::Result<()>>> {
         // Resolve the listener IP to the (ambiguous) peer address.
         let Some(peer_addr) = self.resolve_to_ambiguous(peer_ip) else {
             warn!("Unable to resolve the listener IP address '{peer_ip}'");
             return None;
         };
-        // Retrieve the event name.
-        let name = event.name();
         // Send the event to the peer.
         trace!("{CONTEXT} Sending '{name}' to '{peer_ip}'");
-        let result = self.unicast(peer_addr, event);
+        let result = self.unicast_inner(peer_addr, frame);
         // If the event was unable to be sent, disconnect.
         if let Err(err) = &result {
             warn!("{CONTEXT} Failed to send '{name}' to '{peer_ip}': {err:?}");
@@ -1262,58 +1324,52 @@ impl<N: Network> Transport<N> for Gateway<N> {
     /// without waiting for the actual delivery; instead, the caller is provided with a [`oneshot::Receiver`]
     /// which can be used to determine when and whether the event has been delivered.
     async fn send(&self, peer_ip: SocketAddr, event: Event<N>) -> Option<oneshot::Receiver<io::Result<()>>> {
-        macro_rules! send {
-            ($self:ident, $cache_map:ident, $interval:expr, $freq:ident) => {{
-                // Rate limit the number of certificate requests sent to the peer.
-                while $self.cache.$cache_map(peer_ip, $interval) > $self.$freq() {
-                    // Sleep for a short period of time to allow the cache to clear.
-                    tokio::time::sleep(Duration::from_millis(10)).await;
-                }
-                // Send the event to the peer.
-                $self.send_inner(peer_ip, event)
-            }};
+        // Insert an outbound block request so we can match it to the response.
+        if let Event::BlockRequest(request) = &event {
+            self.cache.insert_outbound_block_request(peer_ip, *request);
         }
-
-        // Increment the cache for certificate, transmission and block events.
-        match event {
-            Event::CertificateRequest(_) | Event::CertificateResponse(_) => {
-                // Update the outbound event cache. This is necessary to ensure we don't under count the outbound events.
-                self.cache.insert_outbound_event(peer_ip, CACHE_EVENTS_INTERVAL);
-                // Send the event to the peer.
-                send!(self, insert_outbound_certificate, CACHE_REQUESTS_INTERVAL, max_cache_certificates)
+        // Note what the event is before serializing it, which consumes it.
+        let limit = OutboundLimit::of(&event);
+        let name = event.name();
+        // Serialize the event.
+        let frame = match self.encode(event) {
+            Ok(frame) => frame,
+            Err(err) => {
+                warn!("{CONTEXT} Unable to serialize '{name}' for '{peer_ip}' - {err}");
+                return None;
             }
-            Event::TransmissionRequest(_) | Event::TransmissionResponse(_) => {
-                // Update the outbound event cache. This is necessary to ensure we don't under count the outbound events.
-                self.cache.insert_outbound_event(peer_ip, CACHE_EVENTS_INTERVAL);
-                // Send the event to the peer.
-                send!(self, insert_outbound_transmission, CACHE_REQUESTS_INTERVAL, max_cache_transmissions)
-            }
-            Event::BlockRequest(request) => {
-                // Insert the outbound request so we can match it to responses.
-                self.cache.insert_outbound_block_request(peer_ip, request);
-                // Send the event to the peer and update the outbound event cache, use the general rate limit.
-                send!(self, insert_outbound_event, CACHE_EVENTS_INTERVAL, max_cache_events)
-            }
-            _ => {
-                // Send the event to the peer, use the general rate limit.
-                send!(self, insert_outbound_event, CACHE_EVENTS_INTERVAL, max_cache_events)
-            }
-        }
+        };
+        // Wait for the peer's rate limit to permit it, then queue it.
+        self.await_outbound_capacity(peer_ip, limit).await;
+        self.send_inner(peer_ip, &name, frame)
     }
 
     /// Broadcasts the given event to all connected peers.
-    // TODO(ljedrz): the event should be checked for the presence of Data::Object, and
-    // serialized in advance if it's there.
     fn broadcast(&self, event: Event<N>) {
         // Ensure there are connected peers.
         if self.number_of_connected_peers() > 0 {
             let self_ = self.clone();
             let connected_peers = self.connected_peers();
             tokio::spawn(async move {
+                // Note what the event is before serializing it, which consumes it.
+                let limit = OutboundLimit::of(&event);
+                let name = event.name();
+                // Serialize the event once; every peer is then sent the same bytes. Serializing
+                // per peer instead would repeat the whole cost for each recipient, which for an
+                // event carrying a certificate means walking every field element again.
+                let frame = match self_.encode(event) {
+                    Ok(frame) => frame,
+                    Err(err) => {
+                        warn!("{CONTEXT} Unable to serialize '{name}' for broadcast - {err}");
+                        return;
+                    }
+                };
                 // Iterate through all connected peers.
                 for peer_ip in connected_peers {
+                    // Each peer is still rate limited individually.
+                    self_.await_outbound_capacity(peer_ip, limit).await;
                     // Send the event to the peer.
-                    let _ = Transport::send(&self_, peer_ip, event.clone()).await;
+                    let _ = self_.send_inner(peer_ip, &name, frame.clone());
                 }
             });
         }

--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -18,6 +18,7 @@ use crate::helpers::Telemetry;
 use crate::{
     CONTEXT,
     MAX_BATCH_DELAY,
+    MAX_FETCH_TIMEOUT,
     MEMORY_POOL_PORT,
     Worker,
     events::{DisconnectReason, EventCodec, PrimaryPing},
@@ -104,6 +105,37 @@ use tokio_util::codec::Framed;
 const CACHE_EVENTS_INTERVAL: i64 = (MAX_BATCH_DELAY.as_secs()) as i64; // seconds
 /// The maximum interval of requests to cache.
 const CACHE_REQUESTS_INTERVAL: i64 = (MAX_BATCH_DELAY.as_secs()) as i64; // seconds
+
+/// The number of consensus rounds of traffic that a per-connection message queue must absorb.
+///
+/// A message that has not made it onto (or off of) the wire within `MAX_FETCH_TIMEOUT` is already
+/// useless to the peer: a requester has given up on it by then (see
+/// `Worker::send_transmission_request`), and any consensus event it carried is stale. Sizing the
+/// per-connection queues to this window therefore bounds them to the traffic that can still be
+/// delivered in time, rather than to the entire garbage-collection window (`MAX_GC_ROUNDS`, which
+/// is ~100 rounds, i.e. several minutes of traffic).
+const QUEUE_WINDOW_ROUNDS: usize = (MAX_FETCH_TIMEOUT.as_millis() / MAX_BATCH_DELAY.as_millis()) as usize;
+
+/// Computes the depth of the per-connection inbound and outbound message queues.
+///
+/// These queues are transient send/receive buffers, not backlogs: they only need to hold the
+/// traffic a peer can legitimately exchange with us over `QUEUE_WINDOW_ROUNDS` (see above).
+/// Per round, the worst case is every certificate in the round plus every transmission each of
+/// those certificates contains — that is, a peer that is missing an entire round and fetches all
+/// of it from us. The leading factor of 2 is headroom for the remaining, far smaller, event
+/// traffic (batch proposals and signatures, primary and worker pings, block and validator
+/// requests) and for requests that straddle a round boundary.
+///
+/// Note that each slot holds a serialized frame, so this value is a direct multiplier on the heap
+/// a single peer can pin by not reading its socket. Frames sent to several peers are shared
+/// between their queues, so the multiplier bites hardest on unicast traffic, where each frame is
+/// held by one peer alone: it must stay small enough that `depth * max transmission size` is
+/// survivable on a commodity validator.
+fn per_connection_queue_depth<N: Network>() -> usize {
+    2 * QUEUE_WINDOW_ROUNDS
+        * N::LATEST_MAX_CERTIFICATES() as usize
+        * (BatchHeader::<N>::MAX_TRANSMISSIONS_PER_BATCH + 1)
+}
 
 /// The maximum number of connection attempts in an interval.
 #[cfg(not(test))]
@@ -1409,12 +1441,11 @@ impl<N: Network> Reading for Gateway<N> {
         Ok(())
     }
 
-    /// Computes the depth of per-connection queues used to process inbound messages, sufficient to process the maximum expected load at any givent moment.
+    /// Computes the depth of per-connection queues used to process inbound messages, sufficient to process the maximum expected load at any given moment.
     /// The greater it is, the more inbound messages the node can enqueue, but a too large value can make the node more susceptible to DoS attacks.
+    /// See [`per_connection_queue_depth`] for the derivation.
     fn message_queue_depth(&self) -> usize {
-        2 * BatchHeader::<N>::MAX_GC_ROUNDS
-            * N::LATEST_MAX_CERTIFICATES() as usize
-            * BatchHeader::<N>::MAX_TRANSMISSIONS_PER_BATCH
+        per_connection_queue_depth::<N>()
     }
 }
 
@@ -1427,13 +1458,12 @@ impl<N: Network> Writing for Gateway<N> {
         Default::default()
     }
 
-    /// Computes the depth of per-connection queues used to send outbound messages, sufficient to process the maximum expected load at any givent moment.
-    /// The greater it is, the more outbound messages the node can enqueue. A too large value large value might obscure potential issues with your implementation
-    /// (like slow serialization) or network.
+    /// Computes the depth of per-connection queues used to send outbound messages, sufficient to process the maximum expected load at any given moment.
+    /// The greater it is, the more outbound messages the node can enqueue. A too large value might obscure potential issues with your implementation
+    /// (like slow serialization) or network, and lets a peer that stops reading its socket pin an unreasonable amount of our heap.
+    /// See [`per_connection_queue_depth`] for the derivation.
     fn message_queue_depth(&self) -> usize {
-        2 * BatchHeader::<N>::MAX_GC_ROUNDS
-            * N::LATEST_MAX_CERTIFICATES() as usize
-            * BatchHeader::<N>::MAX_TRANSMISSIONS_PER_BATCH
+        per_connection_queue_depth::<N>()
     }
 }
 
@@ -1900,6 +1930,31 @@ mod prop_tests {
     use test_strategy::proptest;
 
     type CurrentNetwork = MainnetV0;
+
+    /// The per-connection queues are sized from the fetch-timeout window, not the GC window.
+    ///
+    /// Each slot holds a serialized frame, so the depth is a direct multiplier on the heap a
+    /// single peer can pin by not reading its socket. Pin the derivation so a regression is loud.
+    #[test]
+    fn test_per_connection_queue_depth() {
+        use crate::gateway::{QUEUE_WINDOW_ROUNDS, per_connection_queue_depth};
+        use snarkvm::console::network::Network;
+
+        // The window is `MAX_FETCH_TIMEOUT` expressed in rounds.
+        assert_eq!(QUEUE_WINDOW_ROUNDS, 3);
+
+        let certificates = CurrentNetwork::LATEST_MAX_CERTIFICATES() as usize;
+        let transmissions = BatchHeader::<CurrentNetwork>::MAX_TRANSMISSIONS_PER_BATCH;
+        let depth = per_connection_queue_depth::<CurrentNetwork>();
+
+        assert_eq!(depth, 2 * QUEUE_WINDOW_ROUNDS * certificates * (transmissions + 1));
+
+        // It must cover a peer fetching every transmission of every certificate for the window...
+        assert!(depth >= QUEUE_WINDOW_ROUNDS * certificates * transmissions);
+        // ...but stay far below the old `MAX_GC_ROUNDS`-derived depth, which let one peer pin
+        // 400,000 frames.
+        assert!(depth < 2 * BatchHeader::<CurrentNetwork>::MAX_GC_ROUNDS * certificates * transmissions / 8);
+    }
 
     impl Debug for Gateway<CurrentNetwork> {
         fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {

--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -1367,9 +1367,7 @@ impl<N: Network> Writing for Gateway<N> {
     type Codec = EventCodec<N>;
     type Message = Event<N>;
 
-    /// Creates an [`Encoder`] used to write the outbound messages to the target stream.
-    /// The `side` parameter indicates the connection side **from the node's perspective**.
-    fn codec(&self, _peer_addr: SocketAddr, _side: ConnectionSide) -> Self::Codec {
+    fn codec(&self) -> Self::Codec {
         Default::default()
     }
 

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -60,7 +60,7 @@ use snarkos_node_network::{
     bootstrap_peers,
 };
 use snarkos_node_sync_communication_service::CommunicationService;
-use snarkos_node_tcp::{Config, ConnectionSide, Tcp};
+use snarkos_node_tcp::{Config, Tcp};
 
 use snarkvm::prelude::{Address, Network, PrivateKey, ViewKey};
 

--- a/node/router/src/writing.rs
+++ b/node/router/src/writing.rs
@@ -108,9 +108,7 @@ impl<N: Network> Writing for Router<N> {
     type Codec = MessageCodec<N>;
     type Message = Message<N>;
 
-    /// Creates an [`Encoder`] used to write the outbound messages to the target stream.
-    /// The `side` parameter indicates the connection side **from the node's perspective**.
-    fn codec(&self, _addr: SocketAddr, _side: ConnectionSide) -> Self::Codec {
+    fn codec(&self) -> Self::Codec {
         Default::default()
     }
 }

--- a/node/router/tests/common/router.rs
+++ b/node/router/tests/common/router.rs
@@ -146,9 +146,7 @@ impl<N: Network> Writing for TestRouter<N> {
     type Codec = MessageCodec<N>;
     type Message = Message<N>;
 
-    /// Creates an [`Encoder`] used to write the outbound messages to the target stream.
-    /// The `side` parameter indicates the connection side **from the node's perspective**.
-    fn codec(&self, _addr: SocketAddr, _side: ConnectionSide) -> Self::Codec {
+    fn codec(&self) -> Self::Codec {
         Default::default()
     }
 }

--- a/node/router/tests/heartbeat.rs
+++ b/node/router/tests/heartbeat.rs
@@ -25,14 +25,13 @@ use snarkos_node_router::{
     messages::{Message, MessageCodec},
 };
 use snarkos_node_tcp::{
-    ConnectionSide,
     P2P,
     protocols::{Handshake, OnConnect, Writing},
 };
 use snarkvm::prelude::{MainnetV0 as Network, TestRng};
 
 use async_trait::async_trait;
-use std::{net::SocketAddr, time::Duration};
+use std::time::Duration;
 use tokio::time::sleep;
 
 #[derive(Clone)]
@@ -51,7 +50,7 @@ impl Writing for HeartbeatTest {
     type Codec = MessageCodec<Network>;
     type Message = Message<Network>;
 
-    fn codec(&self, _addr: SocketAddr, _side: ConnectionSide) -> Self::Codec {
+    fn codec(&self) -> Self::Codec {
         Default::default()
     }
 }

--- a/node/src/bootstrap_client/network.rs
+++ b/node/src/bootstrap_client/network.rs
@@ -209,9 +209,7 @@ impl<N: Network> Writing for BootstrapClient<N> {
     type Codec = BootstrapClientCodec<N>;
     type Message = MessageOrEvent<N>;
 
-    /// Creates an [`Encoder`] used to write the outbound messages to the target stream.
-    /// The `side` parameter indicates the connection side **from the node's perspective**.
-    fn codec(&self, _addr: SocketAddr, _side: ConnectionSide) -> Self::Codec {
+    fn codec(&self) -> Self::Codec {
         Default::default()
     }
 }

--- a/node/tcp/src/protocols/writing.rs
+++ b/node/tcp/src/protocols/writing.rs
@@ -13,27 +13,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{any::Any, collections::HashMap, io, net::SocketAddr, sync::Arc, time::Duration};
+use std::{collections::HashMap, io, net::SocketAddr, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
-use futures_util::sink::SinkExt;
+use bytes::{Bytes, BytesMut};
 #[cfg(feature = "locktick")]
 use locktick::parking_lot::RwLock;
 #[cfg(not(feature = "locktick"))]
 use parking_lot::RwLock;
 use tokio::{
-    io::AsyncWrite,
+    io::{AsyncWrite, AsyncWriteExt},
     sync::{mpsc, oneshot},
     time::timeout,
 };
-use tokio_util::codec::{Encoder, FramedWrite};
+use tokio_util::codec::Encoder;
 use tracing::*;
 
 #[cfg(doc)]
 use crate::{Config, Tcp, protocols::Handshake};
 use crate::{
     Connection,
-    ConnectionSide,
     P2P,
     connections::{DisconnectOrigin, create_connection_span},
     protocols::{DisconnectOnDrop, Protocol, ProtocolHandler, ReturnableConnection},
@@ -100,9 +99,20 @@ where
         assert!(self.tcp().protocols.writing.set(hdl).is_ok(), "the Writing protocol was enabled more than once!");
     }
 
-    /// Creates an [`Encoder`] used to write the outbound messages to the target stream.
-    /// The `side` param indicates the connection side **from the node's perspective**.
-    fn codec(&self, addr: SocketAddr, side: ConnectionSide) -> Self::Codec;
+    /// Creates an [`Encoder`] used to serialize outbound messages.
+    fn codec(&self) -> Self::Codec;
+
+    /// Serializes a message into a frame, ready to be handed to [`Self::unicast`].
+    ///
+    /// This is deliberately separate from queueing. Serializing a message is not free -- for
+    /// those carrying certificates or signatures it involves field arithmetic to canonicalize
+    /// curve points -- so the cost belongs at the point where the caller decides to pay it, not
+    /// hidden inside a send. Serialize once, then hand the same frame to as many peers as needed.
+    fn encode(&self, message: Self::Message) -> io::Result<Bytes> {
+        let mut frame = BytesMut::new();
+        self.codec().encode(message, &mut frame)?;
+        Ok(frame.freeze())
+    }
 
     /// Sends the provided message to the specified [`SocketAddr`]. Returns as soon as the message is queued to
     /// be sent, without waiting for the actual delivery; instead, the caller is provided with a [`oneshot::Receiver`]
@@ -115,11 +125,23 @@ where
     /// - [`io::ErrorKind::Other`] if the outbound message queue for this address is full
     /// - [`io::ErrorKind::Unsupported`] if [`Writing::enable_writing`] hadn't been called yet
     fn unicast(&self, addr: SocketAddr, message: Self::Message) -> io::Result<oneshot::Receiver<io::Result<()>>> {
+        self.unicast_inner(addr, self.encode(message)?)
+    }
+
+    /// Queues an already-serialized frame for delivery to the specified [`SocketAddr`].
+    ///
+    /// This exists so that a message being sent to several peers can be serialized once and the
+    /// resulting frame handed to each of them, rather than serialized per recipient.
+    ///
+    /// # Errors
+    ///
+    /// The same as [`Self::unicast`], minus the serialization.
+    fn unicast_inner(&self, addr: SocketAddr, frame: Bytes) -> io::Result<oneshot::Receiver<io::Result<()>>> {
         // access the protocol handler
         if let Some(handler) = self.tcp().protocols.writing.get() {
             // find the message sender for the given address
             if let Some(sender) = handler.senders.read().get(&addr).cloned() {
-                let (msg, delivery) = WrappedMessage::new(Box::new(message));
+                let (msg, delivery) = WrappedMessage::new(frame);
                 sender
                     .try_send(msg)
                     .map_err(|e| {
@@ -145,38 +167,23 @@ where
     /// # Errors
     ///
     /// Returns [`io::ErrorKind::Unsupported`] if [`Writing::enable_writing`] hadn't been called yet.
-    fn broadcast(&self, message: Self::Message) -> io::Result<()>
-    where
-        Self::Message: Clone,
-    {
-        // access the protocol handler
-        if let Some(handler) = self.tcp().protocols.writing.get() {
-            let senders = handler.senders.read().clone();
-            for (addr, message_sender) in senders {
-                let (msg, _delivery) = WrappedMessage::new(Box::new(message.clone()));
-                let _ = message_sender.try_send(msg).map_err(|e| {
-                    let conn_span = create_connection_span(addr, self.tcp().span());
-                    error!(parent: conn_span, "can't send a message: {e}");
-                    self.tcp().stats().register_failure();
-                });
-            }
+    fn broadcast(&self, message: Self::Message) -> io::Result<()> {
+        // Serialize the message once; every peer is then sent the same bytes.
+        let frame = self.encode(message)?;
 
-            Ok(())
-        } else {
-            Err(io::ErrorKind::Unsupported.into())
+        for addr in self.tcp().connected_addrs() {
+            let _ = self.unicast_inner(addr, frame.clone());
         }
+
+        Ok(())
     }
 }
 
 /// This trait is used to restrict access to methods that would otherwise be public in [`Writing`].
 #[async_trait]
 trait WritingInternal: Writing {
-    /// Writes the given message to the network stream and returns the number of written bytes.
-    async fn write_to_stream<W: AsyncWrite + Unpin + Send>(
-        &self,
-        message: Self::Message,
-        writer: &mut FramedWrite<W, Self::Codec>,
-    ) -> Result<usize, <Self::Codec as Encoder<Self::Message>>::Error>;
+    /// Writes the given frame to the network stream and returns the number of written bytes.
+    async fn write_to_stream<W: AsyncWrite + Unpin + Send>(&self, frame: Bytes, writer: &mut W) -> io::Result<usize>;
 
     /// Applies the [`Writing`] protocol to a single connection.
     async fn handle_new_connection(&self, (conn, conn_returner): ReturnableConnection, conn_senders: &WritingSenders);
@@ -184,15 +191,15 @@ trait WritingInternal: Writing {
 
 #[async_trait]
 impl<W: Writing> WritingInternal for W {
-    async fn write_to_stream<A: AsyncWrite + Unpin + Send>(
-        &self,
-        message: Self::Message,
-        writer: &mut FramedWrite<A, Self::Codec>,
-    ) -> Result<usize, <Self::Codec as Encoder<Self::Message>>::Error> {
-        writer.feed(message).await?;
-        let len = writer.write_buffer().len();
-        // Guard against write starvation
-        match timeout(W::TIMEOUT, writer.flush()).await {
+    async fn write_to_stream<A: AsyncWrite + Unpin + Send>(&self, frame: Bytes, writer: &mut A) -> io::Result<usize> {
+        let len = frame.len();
+        // Guard against write starvation. The whole write is covered, not just the flush: a peer
+        // that has stopped reading blocks the write itself.
+        let write = async {
+            writer.write_all(&frame).await?;
+            writer.flush().await
+        };
+        match timeout(W::TIMEOUT, write).await {
             Ok(Ok(())) => Ok(len),
             Ok(Err(e)) => Err(e),
             Err(_) => Err(io::Error::new(io::ErrorKind::TimedOut, "write timed out")),
@@ -205,9 +212,7 @@ impl<W: Writing> WritingInternal for W {
         conn_senders: &WritingSenders,
     ) {
         let addr = conn.addr();
-        let codec = self.codec(addr, !conn.side());
-        let writer = conn.writer.take().expect("missing connection writer!");
-        let mut framed = FramedWrite::new(writer, codec);
+        let mut writer = conn.writer.take().expect("missing connection writer!");
 
         let (outbound_message_sender, mut outbound_message_receiver) = mpsc::channel(self.message_queue_depth());
 
@@ -235,9 +240,7 @@ impl<W: Writing> WritingInternal for W {
             let _conn_cleanup = DisconnectOnDrop::new(node.clone(), addr, DisconnectOrigin::Writing);
 
             while let Some(wrapped_msg) = outbound_message_receiver.recv().await {
-                let msg = wrapped_msg.msg.downcast().unwrap();
-
-                match self_clone.write_to_stream(*msg, &mut framed).await {
+                match self_clone.write_to_stream(wrapped_msg.frame, &mut writer).await {
                     Ok(len) => {
                         let _ = wrapped_msg.delivery_notification.send(Ok(()));
                         // node.known_peers().register_sent_message(addr.ip(), len);
@@ -266,16 +269,16 @@ impl<W: Writing> WritingInternal for W {
     }
 }
 
-/// Used to queue messages for delivery.
+/// Used to queue frames for delivery.
 struct WrappedMessage {
-    msg: Box<dyn Any + Send>,
+    frame: Bytes,
     delivery_notification: oneshot::Sender<io::Result<()>>,
 }
 
 impl WrappedMessage {
-    fn new(msg: Box<dyn Any + Send>) -> (Self, oneshot::Receiver<io::Result<()>>) {
+    fn new(frame: Bytes) -> (Self, oneshot::Receiver<io::Result<()>>) {
         let (tx, rx) = oneshot::channel();
-        let wrapped_msg = Self { msg, delivery_notification: tx };
+        let wrapped_msg = Self { frame, delivery_notification: tx };
 
         (wrapped_msg, rx)
     }

--- a/node/tcp/src/protocols/writing.rs
+++ b/node/tcp/src/protocols/writing.rs
@@ -60,6 +60,14 @@ where
     /// to the underlying stream before the connection is considered dead.
     const TIMEOUT: Duration = Duration::from_secs(5);
 
+    /// The number of consecutive write timeouts tolerated before the connection is torn down.
+    ///
+    /// A peer that has accepted nothing for `MAX_CONSECUTIVE_TIMEOUTS * TIMEOUT` is not slow, it
+    /// is not reading at all (e.g. it has advertised a zero TCP window). Tearing the connection
+    /// down is what releases its outbound queue; without this, such a peer pins every frame
+    /// queued for it, for as long as it keeps the socket open.
+    const MAX_CONSECUTIVE_TIMEOUTS: usize = 3;
+
     /// The type of the outbound messages; unless their serialization is expensive and the message
     /// is broadcasted (in which case it would get serialized multiple times), serialization should
     /// be done in the implementation of [`Self::Codec`].
@@ -239,9 +247,13 @@ impl<W: Writing> WritingInternal for W {
             // disconnect automatically regardless of how this task concludes
             let _conn_cleanup = DisconnectOnDrop::new(node.clone(), addr, DisconnectOrigin::Writing);
 
+            // The number of write timeouts seen in a row; reset by any successful write.
+            let mut consecutive_timeouts = 0;
+
             while let Some(wrapped_msg) = outbound_message_receiver.recv().await {
                 match self_clone.write_to_stream(wrapped_msg.frame, &mut writer).await {
                     Ok(len) => {
+                        consecutive_timeouts = 0;
                         let _ = wrapped_msg.delivery_notification.send(Ok(()));
                         // node.known_peers().register_sent_message(addr.ip(), len);
                         node.stats().register_sent_message(len);
@@ -250,7 +262,22 @@ impl<W: Writing> WritingInternal for W {
                     Err(e) => {
                         node.known_peers().register_failure(addr.ip());
                         error!(parent: &conn_span, "couldn't send a message: {e}");
-                        let is_fatal = node.config().fatal_io_errors.contains(&e.kind());
+                        let mut is_fatal = node.config().fatal_io_errors.contains(&e.kind());
+                        // A peer that repeatedly fails to accept a write is not draining its
+                        // socket. Tear the connection down so its outbound queue is released,
+                        // rather than looping here indefinitely.
+                        if e.kind() == io::ErrorKind::TimedOut {
+                            consecutive_timeouts += 1;
+                            if consecutive_timeouts >= W::MAX_CONSECUTIVE_TIMEOUTS {
+                                warn!(
+                                    parent: &conn_span,
+                                    "peer failed to accept {consecutive_timeouts} consecutive writes; disconnecting",
+                                );
+                                is_fatal = true;
+                            }
+                        } else {
+                            consecutive_timeouts = 0;
+                        }
                         let _ = wrapped_msg.delivery_notification.send(Err(e));
                         if is_fatal {
                             break;
@@ -304,5 +331,127 @@ struct SenderCleanup {
 impl Drop for SenderCleanup {
     fn drop(&mut self) {
         self.senders.write().remove(&self.addr);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Config, Tcp, protocols::Reading};
+
+    use bytes::Bytes;
+    use std::net::{IpAddr, Ipv4Addr};
+    use tokio::time::Instant;
+    use tokio_util::codec::BytesCodec;
+
+    /// Binds to localhost, so that connecting two test nodes is not seen as a self-connect.
+    fn test_config() -> Config {
+        Config { listener_ip: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)), ..Default::default() }
+    }
+
+    /// A node whose write timeouts are short enough to keep the tests fast.
+    #[derive(Clone)]
+    struct TestNode(Tcp);
+
+    impl P2P for TestNode {
+        fn tcp(&self) -> &Tcp {
+            &self.0
+        }
+    }
+
+    #[async_trait]
+    impl Writing for TestNode {
+        type Codec = BytesCodec;
+        type Message = Bytes;
+
+        const MAX_CONSECUTIVE_TIMEOUTS: usize = 2;
+        const TIMEOUT: Duration = Duration::from_millis(200);
+
+        fn codec(&self) -> Self::Codec {
+            Default::default()
+        }
+    }
+
+    #[async_trait]
+    impl Reading for TestNode {
+        type Codec = BytesCodec;
+        type Message = bytes::BytesMut;
+
+        fn codec(&self, _addr: SocketAddr, _side: crate::ConnectionSide) -> Self::Codec {
+            Default::default()
+        }
+
+        async fn process_message(&self, _source: SocketAddr, _message: Self::Message) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// Queues enough data to exceed the kernel's send and receive buffers, so that a peer which is
+    /// not reading its socket stalls the writer.
+    fn flood(sender: &TestNode, peer_addr: SocketAddr) {
+        let msg = Bytes::from(vec![0u8; 1024 * 1024]);
+        for _ in 0..64 {
+            if sender.unicast(peer_addr, msg.clone()).is_err() {
+                break;
+            }
+        }
+    }
+
+    async fn wait_for_disconnect(sender: &TestNode, peer_addr: SocketAddr, within: Duration) -> bool {
+        let deadline = Instant::now() + within;
+        while Instant::now() < deadline {
+            if !sender.tcp().is_connected(peer_addr) {
+                return true;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        false
+    }
+
+    /// A peer that never reads its socket must be disconnected, so that the memory held by its
+    /// outbound queue is released instead of being pinned for as long as it keeps the socket open.
+    #[tokio::test]
+    async fn writer_disconnects_a_peer_that_never_reads() {
+        let sender = TestNode(Tcp::new(test_config()));
+        sender.tcp().enable_listener().await.unwrap();
+        sender.enable_writing().await;
+
+        // The receiver accepts the connection but never enables `Reading`, so nothing drains its
+        // socket; this is the in-process analogue of a peer advertising a zero TCP window.
+        let receiver = Tcp::new(test_config());
+        let receiver_ip = receiver.enable_listener().await.unwrap();
+
+        sender.tcp().connect(receiver_ip).await.unwrap();
+        let peer_addr = *sender.tcp().connected_addrs().first().unwrap();
+
+        flood(&sender, peer_addr);
+
+        assert!(
+            wait_for_disconnect(&sender, peer_addr, Duration::from_secs(10)).await,
+            "the writer never tore down a peer that stopped reading",
+        );
+    }
+
+    /// The control: a peer that does read must not be disconnected by the same flood, so the test
+    /// above cannot pass merely because the flood itself breaks the connection.
+    #[tokio::test]
+    async fn writer_keeps_a_peer_that_reads() {
+        let sender = TestNode(Tcp::new(test_config()));
+        sender.tcp().enable_listener().await.unwrap();
+        sender.enable_writing().await;
+
+        let receiver = TestNode(Tcp::new(test_config()));
+        let receiver_ip = receiver.tcp().enable_listener().await.unwrap();
+        receiver.enable_reading().await;
+
+        sender.tcp().connect(receiver_ip).await.unwrap();
+        let peer_addr = *sender.tcp().connected_addrs().first().unwrap();
+
+        flood(&sender, peer_addr);
+
+        assert!(
+            !wait_for_disconnect(&sender, peer_addr, Duration::from_secs(3)).await,
+            "the writer tore down a peer that was reading normally",
+        );
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

This is a series of changes to the way that the snarkOS validator handles outbound message queues, motivated by several reports. We have excerpted part of one of them, which itself mentions several individual issues.

> A snarkOS BFT validator sizes each peer's outbound message queue at `2 × MAX_GC_ROUNDS × LATEST_MAX_CERTIFICATES × MAX_TRANSMISSIONS_PER_BATCH = 400,000 slots`, and there is no per-peer rate limit on inbound `TransmissionRequest` events (the code carries an explicit TODO where that check belongs). A Byzantine committee validator learns valid transmission IDs from the public gossip it already receives, opens a connection on which it deliberately stops reading (TCP zero-window), and floods known-ID `TransmissionRequests`; each one makes the victim clone a full Transmission into that 400,000-slot queue, which the writer cannot drain because the 5-second flush timeout returns io::ErrorKind::TimedOut, which is not in the node's fatal-error set, so the connection is never torn down. 

Note that this also touches on a tracking issue: https://github.com/ProvableHQ/snarkOS/issues/4140

One of the first points of interest in this investigation is, the 400,000 slot queue does not hold simple bytes, but rather full deserialized objects. Instead the "codec" is used to actually serialize messages to the socket, and only at the last moment. 

(See `node/tcp/src/protocols/writing.rs`: the situation is actually worse. The messages are not even enqueued themselves, and to avoid a queue with parametric types, std::Any is used to box these types, type erasing everything about them except that they have a codec, and putting that in the queue, then downcasting it on the other side.)

However, this makes broadcasts very inefficient. What one would normally expect is, when I want to send one message to all of my peers, I serialize it to bytes once, then those bytes are enqueued to mpsc queues and eventually flushed to the socket. The `tokio::util::Bytes` object is designed exactly for this type of situation -- these bytes handles are ref counted, and can be cloned 40 times and put in 40 queues without copying the underlying data or introducing locks and contention.

In many programs, serializing before or after enqueuing, or serializing 40 times vs once, might not make a large performance impact. However, in crypto projects, it's common that the data contains elliptic curve points, especially more exotic ones like the twisted edwards curve, used here and in Ristretto and a number of other adjacent projects. Twisted edwards curve points generally are implemented as having a "compressed" and an "uncompressed" representation. The uncompressed representation is faster for actually using it, but when you need canonical bytes on the wire, you have to compress it. And unfortunately compressing it requires finite field arithmetic, so serialization of a large collection of these can be on the order of hundreds of microseconds.

So, we actually really want to be careful to try to serialize things once if possible. And outbound queues that contain large uncompressed things that are cloned and then serialized over and over again, should be rearranged so that serialization happens once upfront, and then tokio::Bytes are what is distributed to workers.

In node/tcp/src/protocol/writing.rs, we changed the implementation so that instead of `std::Any<Message>` (the type erased thing-with-codec), we simply put tokio Bytes in the queue. The broadcast loop gets the bytes first and reuses them for each peer. The unicast obtains bytes and then passes them.

Additionally, we make sure the timeout guard on writing covers both asynchronous operations -- writing and flushing, which addresses parts of the original report. This fix appears in `async fn write_to_stream`

It turns out that this broadcast loop is duplicated, however, in the gateway.rs code. This seems to be because we decided to implement outbound rate limiting -- we choose to rate limit ourselves if we are sending too many things to a peer (rather than the peer imposing a rate limit on us).

Therefore, we apply a very similar fix to this more complicated loop which includes the rate limit checks. (This also resolves a TODO).

To make it manageable, we introduce an enum which keeps track of, for a given Event, which rate limit category should apply to it. Then we abstract out the logic that enforces the rate limits. (This code is also a bit strange, in that, when we discover we have exceeded a rate limit, rather than skipping messages and moving on, we sleep for 10 milliseconds and check again. I'd be interested to discuss the rationale of this at some later time.)

One specific point for gateway is that, if `ErrorKind::TimedOut` is seen enough times, we tear down the peer connection.

Finally, we adjust the calculation for the gateway outbound queue size. The 400,000 slot size number came from using max_gc_rounds which was very conservative. Instead, we calculate based on the max fetch timeout -- if a message cannot be delivered from our outbound queue to the peer before that time, they will have dropped it anyways. This is compared with the max batch delay, which creates a lower bound on how many batches should have been proposed before timeouts occur. Within this number of rounds, it's still possible that every transmission and certificate is requested, but the total with this estimate is ~12,000 rather than 400,000, and the slots contain tokio::Bytes objects now, rather than Data::Object.

The change is organized as 4 commits, and there are really several ideas here, but they are related and share motivation.
It might be easier to review as a series of PRs instead. Let me know what you think.

Logical next steps include:
* The Router object, like the gateway, has its own bespoke multicast loop and per-peer rate limiting. We should apply the same changes there (or create an abstraction to avoid code duplication)

## Test Plan

Running e2e tests and running stress tests. The e2e tests are passing and it still needs stress test runs. This is still draft as I continue to test it, but I'm interested in feedback.

## Backwards compatibility

I believe this is backwards compatible and just makes the node more efficient, and more resilient against timeouts when sending to a peer. If the additional disconnects due to timeouts happen often, the worst case is that the peer just reconnects, but it needs testing to ensure that we are giving honest nodes enough slack.