### PR TITLE
fix(tcp): disconnect peers that stop accepting writes

### DIFF
--- a/node/tcp/src/protocols/writing.rs
+++ b/node/tcp/src/protocols/writing.rs
@@ -57,9 +57,12 @@ where
         1024
     }
 
-    /// The maximum time (in milliseconds) allowed for a single message write to flush
-    /// to the underlying stream before the connection is considered dead.
-    const TIMEOUT: Duration = Duration::from_secs(5);
+    /// The maximum time allowed for a single message write, both encoding it and flushing it to
+    /// the underlying stream, before the connection is considered dead.
+    ///
+    /// This has to leave room for encoding the largest message we can produce, as blocks can
+    /// currently be quite large.
+    const TIMEOUT: Duration = Duration::from_secs(10);
 
     /// The type of the outbound messages; unless their serialization is expensive and the message
     /// is broadcasted (in which case it would get serialized multiple times), serialization should
@@ -187,12 +190,17 @@ impl<W: Writing> WritingInternal for W {
         message: Self::Message,
         writer: &mut FramedWrite<A, Self::Codec>,
     ) -> Result<usize, <Self::Codec as Encoder<Self::Message>>::Error> {
-        writer.feed(message).await?;
-        let len = writer.write_buffer().len();
-        // Guard against write starvation
-        match timeout(W::TIMEOUT, writer.flush()).await {
-            Ok(Ok(())) => Ok(len),
-            Ok(Err(e)) => Err(e),
+        // Guard against write starvation. `feed` is covered as well as `flush`, as `FramedWrite`
+        // flushes from within `feed` once its buffer is over the backpressure boundary, so a peer
+        // that has stopped reading blocks `feed` too.
+        let write = async {
+            writer.feed(message).await?;
+            let len = writer.write_buffer().len();
+            writer.flush().await?;
+            Ok(len)
+        };
+        match timeout(W::TIMEOUT, write).await {
+            Ok(result) => result,
             Err(_) => Err(io::Error::new(io::ErrorKind::TimedOut, "write timed out")),
         }
     }
@@ -296,5 +304,97 @@ struct SenderCleanup {
 impl Drop for SenderCleanup {
     fn drop(&mut self) {
         self.senders.write().remove(&self.addr);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Config, ConnectionSide, Tcp, protocols::Reading};
+    use bytes::Bytes;
+    use std::net::{IpAddr, Ipv4Addr};
+    use tokio::time::Instant;
+    use tokio_util::codec::BytesCodec;
+
+    fn test_config() -> Config {
+        Config { listener_ip: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)), ..Default::default() }
+    }
+
+    #[derive(Clone)]
+    struct TestNode(Tcp);
+    impl P2P for TestNode {
+        fn tcp(&self) -> &Tcp {
+            &self.0
+        }
+    }
+    #[async_trait]
+    impl Writing for TestNode {
+        type Codec = BytesCodec;
+        type Message = Bytes;
+
+        const TIMEOUT: Duration = Duration::from_millis(200);
+
+        fn codec(&self, _a: SocketAddr, _s: ConnectionSide) -> Self::Codec {
+            Default::default()
+        }
+    }
+    #[async_trait]
+    impl Reading for TestNode {
+        type Codec = BytesCodec;
+        type Message = bytes::BytesMut;
+
+        fn codec(&self, _a: SocketAddr, _s: ConnectionSide) -> Self::Codec {
+            Default::default()
+        }
+
+        async fn process_message(&self, _s: SocketAddr, _m: Self::Message) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn flood(sender: &TestNode, peer: SocketAddr) {
+        let msg = Bytes::from(vec![0u8; 1024 * 1024]);
+        for _ in 0..64 {
+            if sender.unicast(peer, msg.clone()).is_err() {
+                break;
+            }
+        }
+    }
+    async fn disconnected(sender: &TestNode, peer: SocketAddr, within: Duration) -> bool {
+        let deadline = Instant::now() + within;
+        while Instant::now() < deadline {
+            if !sender.tcp().is_connected(peer) {
+                return true;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        false
+    }
+
+    #[tokio::test]
+    async fn stalled_peer_is_disconnected() {
+        let sender = TestNode(Tcp::new(test_config()));
+        sender.tcp().enable_listener().await.unwrap();
+        sender.enable_writing().await;
+        let receiver = Tcp::new(test_config());
+        let ip = receiver.enable_listener().await.unwrap();
+        sender.tcp().connect(ip).await.unwrap();
+        let peer = *sender.tcp().connected_addrs().first().unwrap();
+        flood(&sender, peer);
+        assert!(disconnected(&sender, peer, Duration::from_secs(10)).await, "stalled peer not disconnected");
+    }
+
+    #[tokio::test]
+    async fn reading_peer_is_kept() {
+        let sender = TestNode(Tcp::new(test_config()));
+        sender.tcp().enable_listener().await.unwrap();
+        sender.enable_writing().await;
+        let receiver = TestNode(Tcp::new(test_config()));
+        let ip = receiver.tcp().enable_listener().await.unwrap();
+        receiver.enable_reading().await;
+        sender.tcp().connect(ip).await.unwrap();
+        let peer = *sender.tcp().connected_addrs().first().unwrap();
+        flood(&sender, peer);
+        assert!(!disconnected(&sender, peer, Duration::from_secs(3)).await, "reading peer was disconnected");
     }
 }


### PR DESCRIPTION
## Motivation

Make outbound peer writing more resilient to timeouts / backpressure from the peer.

This extracts a minimal part of https://github.com/ProvableHQ/snarkOS/pull/4378

1. `write_to_stream` needs to put both the `feed` call and the `flush` call under the timeout.
2. Even when the timeout did fire, it produced io::ErrorKind::TimedOut, which was absent from `fatal_io_errors`, so the writer logged it and carried on. Such a peer therefore timed out every TIMEOUT forever and was never disconnected, pinning every message queued for it for as long as it kept the socket open.

(Note: after review, only part 1 was done in this PR, and 2 was done separately )

Per comments in #4378 we should not change node/tcp because it is essentially an old vendored version of pea2pea. However, I want to get these two bug fixes in because it's a very small change in terms of LOC and I don't know how I can prioritize updating the vendored version of pea2pea at this moment.

## Test Plan

Tests ensure that backpressure results in us dropping the connection, as intended.

## Backwards compatibility

I believe this is backwards compatible because it doesn't change the contents of any messages, it just helps nodes to avoid using excessive resources when the peer is not consuming messages. However, a stress test will help us determine if this causes regressions via frequent disconnects.