### PR TITLE
fix: prevent BFT from certifying batches referencing unmaterializable aborted transmissions

### DIFF
--- a/node/bft/src/helpers/storage.rs
+++ b/node/bft/src/helpers/storage.rs
@@ -306,6 +306,12 @@ impl<N: Network> Storage<N> {
         self.transmissions.contains_transmission(transmission_id.into())
     }
 
+    /// Returns `true` if the storage holds the actual transmission for the specified transmission
+    /// ID, excluding IDs only recorded as aborted.
+    pub fn contains_stored_transmission(&self, transmission_id: impl Into<TransmissionID<N>>) -> bool {
+        self.transmissions.contains_stored_transmission(transmission_id.into())
+    }
+
     /// Returns the transmission for the given `transmission ID`.
     /// If the transmission ID does not exist in storage or was aborted, `None` is returned.
     pub fn get_transmission(&self, transmission_id: impl Into<TransmissionID<N>>) -> Option<Transmission<N>> {
@@ -859,12 +865,16 @@ impl<N: Network> Storage<N> {
 
         // Iterate over the transmission IDs.
         for transmission_id in certificate.transmission_ids() {
-            // If the transmission ID already exists in the map, skip it.
-            if missing_transmissions.contains_key(transmission_id) {
-                continue;
-            }
-            // If the transmission ID exists in storage, skip it.
+            // If the transmission ID is already known to storage, it does not need to be recovered
+            // from the block: either the transmission itself is stored, or the ID was recorded as
+            // aborted by an earlier certificate. In the latter case, re-declare it as aborted for
+            // this certificate - it must not be skipped outright, or it would end up in neither
+            // `missing_transmissions` nor `aborted_transmissions`, failing the
+            // `find_missing_transmissions` check in `insert_certificate` below.
             if self.contains_transmission(*transmission_id) {
+                if !self.contains_stored_transmission(*transmission_id) {
+                    aborted_transmissions.insert(*transmission_id);
+                }
                 continue;
             }
             // Retrieve the transmission.
@@ -1002,7 +1012,7 @@ pub(crate) mod tests {
     use snarkos_node_bft_storage_service::BFTMemoryService;
     use snarkvm::{
         ledger::narwhal::{Data, batch_certificate::test_helpers::sample_batch_certificate_for_round_with_committee},
-        prelude::{Rng, TestRng},
+        prelude::{Rng, TestRng, Uniform},
     };
 
     use ::bytes::Bytes;
@@ -1248,6 +1258,77 @@ pub(crate) mod tests {
                 "Non-aborted transmission {id:?} should have content in storage"
             );
         }
+    }
+
+    /// A certificate referencing a transmission that an earlier certificate recorded as aborted
+    /// must still be syncable from a block: the previously-aborted ID has no retrievable bytes in
+    /// storage, so it must be re-declared as aborted for the new certificate rather than skipped.
+    #[test]
+    fn test_sync_certificate_with_previously_aborted_transmission() {
+        use std::collections::HashSet;
+
+        let rng = &mut TestRng::default();
+
+        // Sample a committee.
+        let (committee, private_keys) =
+            snarkvm::ledger::committee::test_helpers::sample_committee_and_keys_for_round(0, 5, rng);
+        // Initialize the ledger.
+        let ledger = Arc::new(MockLedgerService::new(committee.clone()));
+        // Initialize the storage.
+        let storage = Storage::<CurrentNetwork>::new(ledger, Arc::new(BFTMemoryService::new()), 1).unwrap();
+
+        // A transaction transmission ID, referenced by both certificates.
+        let transmission_id = TransmissionID::Transaction(
+            <CurrentNetwork as Network>::TransactionID::from(Field::rand(rng)),
+            <CurrentNetwork as Network>::TransmissionChecksum::from(rng.random::<u128>()),
+        );
+
+        // Creates a quorum-signed round-1 certificate referencing the transmission ID.
+        let make_certificate = |author_index: usize, rng: &mut TestRng| {
+            let batch_header = snarkvm::ledger::narwhal::BatchHeader::new(
+                &private_keys[author_index],
+                1,
+                crate::helpers::now(),
+                committee.id(),
+                indexset![transmission_id],
+                Default::default(),
+                rng,
+            )
+            .unwrap();
+            let signatures = private_keys
+                .iter()
+                .enumerate()
+                .filter(|(index, _)| *index != author_index)
+                .map(|(_, private_key)| private_key.sign(&[batch_header.batch_id()], rng).unwrap())
+                .collect();
+            BatchCertificate::from(batch_header, signatures).unwrap()
+        };
+
+        // Insert the first certificate, recording the transmission as aborted.
+        let certificate_1 = make_certificate(0, rng);
+        storage
+            .insert_certificate(
+                certificate_1,
+                Default::default(),
+                [transmission_id].into_iter().collect::<HashSet<_>>(),
+            )
+            .unwrap();
+        assert!(storage.contains_transmission(transmission_id));
+        assert!(storage.get_transmission(transmission_id).is_none());
+
+        // Sync a later certificate that references the previously-aborted transmission. The block
+        // does not carry the transmission: it was aborted by an earlier certificate, so only the
+        // BFT storage knows about it. Any block works here, so use the sample genesis block.
+        let certificate_2 = make_certificate(1, rng);
+        let block = snarkvm::ledger::test_helpers::sample_genesis_block(rng);
+        storage
+            .sync_certificate_with_block(&block, certificate_2.clone(), &Default::default(), false)
+            .expect("syncing a certificate referencing a previously-aborted transmission must succeed");
+        assert!(storage.contains_certificate(certificate_2.id()));
+
+        // The transmission remains aborted-only: contained, with no retrievable bytes.
+        assert!(storage.contains_transmission(transmission_id));
+        assert!(storage.get_transmission(transmission_id).is_none());
     }
 
     /// Test that `check_incoming_certificate` does not reject a valid cert.

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -676,10 +676,13 @@ impl<N: Network> proposal_task::BatchPropose for Primary<N> {
                     continue;
                 }
 
-                // Check if the storage already contain the transmission.
-                // Note: We do not skip if this is the first transmission in the proposal, to ensure that
-                // the primary does not propose a batch with no transmissions.
-                if !transmissions.is_empty() && self.storage.contains_transmission(id) {
+                // Check if the storage already contains the transmission.
+                // Note: `contains_transmission` is also true for transmissions recorded as aborted,
+                // for which storage holds no retrievable bytes. Proposing such an ID would yield a
+                // certificate that cannot be materialized at commit time, so we skip it here
+                // unconditionally. Proposing an empty batch is valid, so no first-item exception is
+                // needed.
+                if self.storage.contains_transmission(id) {
                     trace!("Proposing - Skipping transmission '{}' - Already in storage", fmt_id(id));
                     continue;
                 }
@@ -2467,6 +2470,34 @@ mod tests {
         // Try to propose a batch with no transmissions.
         assert!(primary.propose_batch().await.is_ok());
         assert!(primary.proposed_batch.read().is_proposed());
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_propose_batch_skips_aborted_first_transmission() {
+        let mut rng = TestRng::default();
+        let (primary, accounts) = primary_without_handlers(&mut rng);
+        let peer_ip = accounts[1].0;
+
+        // Create a certificate and queue its transmissions before recording them as aborted in storage.
+        let (certificate, transmissions) =
+            create_batch_certificate(accounts[1].1.address(), &accounts, 1, Default::default(), &mut rng);
+        for (transmission_id, transmission) in &transmissions {
+            primary.workers()[0].process_transmission_from_peer(peer_ip, *transmission_id, transmission.clone());
+        }
+        assert_eq!(primary.workers()[0].num_transmissions(), transmissions.len());
+
+        // Record the queued transmission IDs as aborted in storage.
+        let aborted_transmissions = transmissions.keys().copied().collect::<HashSet<_>>();
+        primary.storage.insert_certificate(certificate, Default::default(), aborted_transmissions.clone()).unwrap();
+        for transmission_id in &aborted_transmissions {
+            assert!(primary.storage.contains_transmission(*transmission_id));
+            assert!(primary.storage.get_transmission(*transmission_id).is_none());
+        }
+
+        // The aborted IDs must be skipped even when one is the first item drained from the worker.
+        assert!(primary.propose_batch().await.unwrap());
+        assert!(primary.proposed_batch.read().as_proposal().unwrap().transmissions().is_empty());
+        assert_eq!(primary.workers()[0].num_transmissions(), 0);
     }
 
     #[test_log::test(tokio::test)]

--- a/node/bft/storage-service/Cargo.toml
+++ b/node/bft/storage-service/Cargo.toml
@@ -61,7 +61,7 @@ workspace = true
 
 [dev-dependencies.snarkvm]
 workspace = true
-features = [ "test", "test-helpers" ]
+features = [ "test-helpers" ]
 
 [dev-dependencies.tracing]
 workspace = true

--- a/node/bft/storage-service/Cargo.toml
+++ b/node/bft/storage-service/Cargo.toml
@@ -55,3 +55,13 @@ optional = true
 
 [dev-dependencies.bytes]
 workspace = true
+
+[dev-dependencies.parking_lot]
+workspace = true
+
+[dev-dependencies.snarkvm]
+workspace = true
+features = [ "test", "test-helpers" ]
+
+[dev-dependencies.tracing]
+workspace = true

--- a/node/bft/storage-service/src/lib.rs
+++ b/node/bft/storage-service/src/lib.rs
@@ -21,9 +21,9 @@ pub mod memory;
 #[cfg(feature = "memory")]
 pub use memory::*;
 
-#[cfg(feature = "persistent")]
+#[cfg(any(test, feature = "persistent"))]
 pub mod persistent;
-#[cfg(feature = "persistent")]
+#[cfg(any(test, feature = "persistent"))]
 pub use persistent::*;
 
 pub mod traits;

--- a/node/bft/storage-service/src/lib.rs
+++ b/node/bft/storage-service/src/lib.rs
@@ -16,15 +16,18 @@
 #![forbid(unsafe_code)]
 #![allow(clippy::type_complexity)]
 
-#[cfg(feature = "memory")]
+#[cfg(any(test, feature = "memory"))]
 pub mod memory;
 #[cfg(feature = "memory")]
 pub use memory::*;
 
 #[cfg(any(test, feature = "persistent"))]
 pub mod persistent;
-#[cfg(any(test, feature = "persistent"))]
+#[cfg(feature = "persistent")]
 pub use persistent::*;
 
 pub mod traits;
 pub use traits::*;
+
+#[cfg(test)]
+mod tests;

--- a/node/bft/storage-service/src/memory.rs
+++ b/node/bft/storage-service/src/memory.rs
@@ -15,8 +15,8 @@
 
 use crate::StorageService;
 use snarkvm::{
-    ledger::narwhal::{BatchHeader, Transmission, TransmissionID},
-    prelude::{Field, Network, Result, bail},
+    ledger::narwhal::{Transmission, TransmissionID},
+    prelude::{Field, Network},
 };
 
 use indexmap::{IndexMap, IndexSet, indexset, map::Entry};
@@ -58,44 +58,17 @@ impl<N: Network> StorageService<N> for BFTMemoryService<N> {
             || self.aborted_transmission_ids.read().contains_key(&transmission_id)
     }
 
+    /// Returns `true` if the storage holds the actual transmission for the specified
+    /// `transmission ID`, excluding IDs only recorded as aborted.
+    fn contains_stored_transmission(&self, transmission_id: TransmissionID<N>) -> bool {
+        self.transmissions.read().contains_key(&transmission_id)
+    }
+
     /// Returns the transmission for the given `transmission ID`.
     /// If the transmission does not exist in storage, `None` is returned.
     fn get_transmission(&self, transmission_id: TransmissionID<N>) -> Option<Transmission<N>> {
         // Get the transmission.
         self.transmissions.read().get(&transmission_id).map(|(transmission, _)| transmission).cloned()
-    }
-
-    /// Returns the missing transmissions in storage from the given transmissions.
-    fn find_missing_transmissions(
-        &self,
-        batch_header: &BatchHeader<N>,
-        mut transmissions: HashMap<TransmissionID<N>, Transmission<N>>,
-        aborted_transmissions: HashSet<TransmissionID<N>>,
-    ) -> Result<HashMap<TransmissionID<N>, Transmission<N>>> {
-        // Initialize a list for the missing transmissions from storage.
-        let mut missing_transmissions = HashMap::new();
-        // Lock the existing transmissions.
-        let known_transmissions = self.transmissions.read();
-        // Ensure the declared transmission IDs are all present in storage or the given transmissions map.
-        for transmission_id in batch_header.transmission_ids() {
-            // If the transmission ID does not exist, ensure it was provided by the caller or aborted.
-            if !known_transmissions.contains_key(transmission_id) {
-                // Retrieve the transmission.
-                match transmissions.remove(transmission_id) {
-                    // Append the transmission if it exists.
-                    Some(transmission) => {
-                        missing_transmissions.insert(*transmission_id, transmission);
-                    }
-                    // If the transmission does not exist, check if it was aborted.
-                    None => {
-                        if !aborted_transmissions.contains(transmission_id) {
-                            bail!("Failed to provide a transmission");
-                        }
-                    }
-                }
-            }
-        }
-        Ok(missing_transmissions)
     }
 
     /// Inserts the given certificate ID for each of the transmission IDs, using the missing transmissions map, into storage.

--- a/node/bft/storage-service/src/persistent.rs
+++ b/node/bft/storage-service/src/persistent.rs
@@ -347,7 +347,7 @@ mod tests {
 
     use snarkvm::{
         console::network::MainnetV0,
-        ledger::narwhal::Data,
+        ledger::narwhal::{Data, batch_header, transmission},
         prelude::{Rng, TestRng, Uniform},
     };
 
@@ -355,6 +355,26 @@ mod tests {
     use std::sync::{Arc, Barrier};
 
     type CurrentNetwork = MainnetV0;
+
+    /// Opens a new persistent storage service backed by an ephemeral database.
+    fn open_storage() -> BFTPersistentStorage<CurrentNetwork> {
+        BFTPersistentStorage::open(StorageMode::new_test(None)).unwrap()
+    }
+
+    /// Samples a batch header along with a transmission for each of its transmission IDs.
+    fn sample_header_and_transmissions(
+        rng: &mut TestRng,
+    ) -> (BatchHeader<CurrentNetwork>, HashMap<TransmissionID<CurrentNetwork>, Transmission<CurrentNetwork>>) {
+        let batch_header = batch_header::test_helpers::sample_batch_header(rng);
+        let transmissions: HashMap<_, _> = batch_header
+            .transmission_ids()
+            .iter()
+            .copied()
+            .zip(transmission::test_helpers::sample_transmissions(rng))
+            .collect();
+        assert_eq!(transmissions.len(), batch_header.transmission_ids().len());
+        (batch_header, transmissions)
+    }
 
     /// Every certificate that references a transmission must contribute its certificate ID to the
     /// transmission's reference set, even when the insertions happen concurrently — as they do when
@@ -444,5 +464,96 @@ mod tests {
         assert!(!storage.as_hashmap().contains_key(&transmission_id));
         assert!(storage.get_transmission(transmission_id).is_none());
         assert!(!storage.contains_transmission(transmission_id));
+    }
+
+    #[test]
+    fn test_provided_bytes_collected_for_previously_aborted_ids() {
+        let rng = &mut TestRng::default();
+        let storage = open_storage();
+        let (batch_header, transmissions) = sample_header_and_transmissions(rng);
+
+        // Record all of the transmission IDs as aborted, without any transmissions.
+        storage.insert_transmissions(
+            Field::rand(rng),
+            batch_header.transmission_ids().clone(),
+            batch_header.transmission_ids().iter().copied().collect(),
+            HashMap::new(),
+        );
+        // Sanity check - the aborted IDs are "contained", but hold no retrievable transmission.
+        for transmission_id in batch_header.transmission_ids() {
+            assert!(storage.contains_transmission(*transmission_id));
+            assert!(storage.get_transmission(*transmission_id).is_none());
+        }
+
+        // The provided transmissions must be collected as missing, despite the IDs being aborted,
+        // so that they get persisted and remain retrievable at commit time.
+        let missing = storage.find_missing_transmissions(&batch_header, transmissions.clone(), HashSet::new()).unwrap();
+        assert_eq!(missing, transmissions);
+    }
+
+    #[test]
+    fn test_stored_transmissions_are_not_missing() {
+        let rng = &mut TestRng::default();
+        let storage = open_storage();
+        let (batch_header, transmissions) = sample_header_and_transmissions(rng);
+
+        // Store the transmissions concretely.
+        storage.insert_transmissions(
+            Field::rand(rng),
+            batch_header.transmission_ids().clone(),
+            HashSet::new(),
+            transmissions.clone(),
+        );
+        // Sanity check - the transmissions are retrievable.
+        for transmission_id in batch_header.transmission_ids() {
+            assert!(storage.get_transmission(*transmission_id).is_some());
+        }
+
+        // Stored transmissions are not reported as missing, whether provided again or not.
+        let missing = storage.find_missing_transmissions(&batch_header, transmissions.clone(), HashSet::new()).unwrap();
+        assert!(missing.is_empty());
+        let missing = storage.find_missing_transmissions(&batch_header, HashMap::new(), HashSet::new()).unwrap();
+        assert!(missing.is_empty());
+    }
+
+    #[test]
+    fn test_aborted_ids_declared_by_caller_are_allowed_without_bytes() {
+        let rng = &mut TestRng::default();
+        let storage = open_storage();
+        let (batch_header, _) = sample_header_and_transmissions(rng);
+
+        // Declaring all of the transmission IDs as aborted requires no transmissions.
+        let aborted = batch_header.transmission_ids().iter().copied().collect();
+        let missing = storage.find_missing_transmissions(&batch_header, HashMap::new(), aborted).unwrap();
+        assert!(missing.is_empty());
+    }
+
+    #[test]
+    fn test_previously_aborted_ids_without_bytes_or_declaration_error() {
+        let rng = &mut TestRng::default();
+        let storage = open_storage();
+        let (batch_header, _) = sample_header_and_transmissions(rng);
+
+        // Record all of the transmission IDs as aborted, without any transmissions.
+        storage.insert_transmissions(
+            Field::rand(rng),
+            batch_header.transmission_ids().clone(),
+            batch_header.transmission_ids().iter().copied().collect(),
+            HashMap::new(),
+        );
+
+        // An aborted ID in storage does not satisfy the check by itself - the caller must
+        // either provide the transmission or declare the ID as aborted.
+        assert!(storage.find_missing_transmissions(&batch_header, HashMap::new(), HashSet::new()).is_err());
+    }
+
+    #[test]
+    fn test_unknown_unprovided_transmission_errors() {
+        let rng = &mut TestRng::default();
+        let storage = open_storage();
+        let (batch_header, _) = sample_header_and_transmissions(rng);
+
+        // The transmission IDs are unknown to storage, not provided, and not declared as aborted.
+        assert!(storage.find_missing_transmissions(&batch_header, HashMap::new(), HashSet::new()).is_err());
     }
 }

--- a/node/bft/storage-service/src/persistent.rs
+++ b/node/bft/storage-service/src/persistent.rs
@@ -27,7 +27,7 @@ use snarkvm::{
             },
         },
     },
-    prelude::{Field, Network, Result, bail},
+    prelude::{Field, Network, Result},
 };
 
 use aleo_std::StorageMode;
@@ -100,6 +100,23 @@ impl<N: Network> StorageService<N> for BFTPersistentStorage<N> {
         }
     }
 
+    /// Returns `true` if the storage holds the actual transmission for the specified
+    /// `transmission ID`, excluding IDs only recorded as aborted.
+    fn contains_stored_transmission(&self, transmission_id: TransmissionID<N>) -> bool {
+        // Check the cache first: it only ever holds transmissions that exist in persistent
+        // storage, so a hit soundly answers `true` without a storage read.
+        if self.cache_transmissions.lock().contains(&transmission_id) {
+            return true;
+        }
+        match self.transmissions.contains_key_confirmed(&transmission_id) {
+            Ok(result) => result,
+            Err(error) => {
+                error!("Failed to check if transmission ID exists in confirmed storage - {error}");
+                false
+            }
+        }
+    }
+
     /// Returns the transmission for the given `transmission ID`.
     /// If the transmission ID does not exist in storage, `None` is returned.
     fn get_transmission(&self, transmission_id: TransmissionID<N>) -> Option<Transmission<N>> {
@@ -118,49 +135,6 @@ impl<N: Network> StorageService<N> for BFTPersistentStorage<N> {
                 None
             }
         }
-    }
-
-    /// Takes a certificate and its transmissions, and returns the subset of transmissions that
-    /// did not yet exists in the storage.
-    fn find_missing_transmissions(
-        &self,
-        batch_header: &BatchHeader<N>,
-        mut transmissions: HashMap<TransmissionID<N>, Transmission<N>>,
-        aborted_transmissions: HashSet<TransmissionID<N>>,
-    ) -> Result<HashMap<TransmissionID<N>, Transmission<N>>> {
-        // Initialize a list for the missing transmissions from storage.
-        let mut missing_transmissions = HashMap::new();
-        // Ensure the declared transmission IDs are all present in storage or the given transmissions map.
-        for transmission_id in batch_header.transmission_ids() {
-            // Check only the concrete transmissions map, not the aborted transmission IDs.
-            // `contains_transmission` is also true for aborted IDs, for which storage holds no
-            // retrievable bytes; if the caller provided bytes for a previously-aborted ID, we must
-            // still collect them here so they are persisted and remain retrievable at commit time.
-            let is_stored = match self.transmissions.contains_key_confirmed(transmission_id) {
-                Ok(result) => result,
-                Err(error) => {
-                    error!("Failed to check if transmission ID exists in confirmed storage - {error}");
-                    false
-                }
-            };
-            // If the transmission ID does not exist, ensure it was provided by the caller or aborted.
-            if !is_stored {
-                // Retrieve the transmission.
-                match transmissions.remove(transmission_id) {
-                    // Append the transmission if it exists.
-                    Some(transmission) => {
-                        missing_transmissions.insert(*transmission_id, transmission);
-                    }
-                    // If the transmission does not exist, check if it was aborted.
-                    None => {
-                        if !aborted_transmissions.contains(transmission_id) {
-                            bail!("Failed to provide a transmission");
-                        }
-                    }
-                }
-            }
-        }
-        Ok(missing_transmissions)
     }
 
     /// Inserts the given certificate ID for each of the transmission IDs, using the missing transmissions map, into storage.

--- a/node/bft/storage-service/src/persistent.rs
+++ b/node/bft/storage-service/src/persistent.rs
@@ -347,7 +347,7 @@ mod tests {
 
     use snarkvm::{
         console::network::MainnetV0,
-        ledger::narwhal::{Data, batch_header, transmission},
+        ledger::narwhal::Data,
         prelude::{Rng, TestRng, Uniform},
     };
 
@@ -355,26 +355,6 @@ mod tests {
     use std::sync::{Arc, Barrier};
 
     type CurrentNetwork = MainnetV0;
-
-    /// Opens a new persistent storage service backed by an ephemeral database.
-    fn open_storage() -> BFTPersistentStorage<CurrentNetwork> {
-        BFTPersistentStorage::open(StorageMode::new_test(None)).unwrap()
-    }
-
-    /// Samples a batch header along with a transmission for each of its transmission IDs.
-    fn sample_header_and_transmissions(
-        rng: &mut TestRng,
-    ) -> (BatchHeader<CurrentNetwork>, HashMap<TransmissionID<CurrentNetwork>, Transmission<CurrentNetwork>>) {
-        let batch_header = batch_header::test_helpers::sample_batch_header(rng);
-        let transmissions: HashMap<_, _> = batch_header
-            .transmission_ids()
-            .iter()
-            .copied()
-            .zip(transmission::test_helpers::sample_transmissions(rng))
-            .collect();
-        assert_eq!(transmissions.len(), batch_header.transmission_ids().len());
-        (batch_header, transmissions)
-    }
 
     /// Every certificate that references a transmission must contribute its certificate ID to the
     /// transmission's reference set, even when the insertions happen concurrently — as they do when
@@ -464,96 +444,5 @@ mod tests {
         assert!(!storage.as_hashmap().contains_key(&transmission_id));
         assert!(storage.get_transmission(transmission_id).is_none());
         assert!(!storage.contains_transmission(transmission_id));
-    }
-
-    #[test]
-    fn test_provided_bytes_collected_for_previously_aborted_ids() {
-        let rng = &mut TestRng::default();
-        let storage = open_storage();
-        let (batch_header, transmissions) = sample_header_and_transmissions(rng);
-
-        // Record all of the transmission IDs as aborted, without any transmissions.
-        storage.insert_transmissions(
-            Field::rand(rng),
-            batch_header.transmission_ids().clone(),
-            batch_header.transmission_ids().iter().copied().collect(),
-            HashMap::new(),
-        );
-        // Sanity check - the aborted IDs are "contained", but hold no retrievable transmission.
-        for transmission_id in batch_header.transmission_ids() {
-            assert!(storage.contains_transmission(*transmission_id));
-            assert!(storage.get_transmission(*transmission_id).is_none());
-        }
-
-        // The provided transmissions must be collected as missing, despite the IDs being aborted,
-        // so that they get persisted and remain retrievable at commit time.
-        let missing = storage.find_missing_transmissions(&batch_header, transmissions.clone(), HashSet::new()).unwrap();
-        assert_eq!(missing, transmissions);
-    }
-
-    #[test]
-    fn test_stored_transmissions_are_not_missing() {
-        let rng = &mut TestRng::default();
-        let storage = open_storage();
-        let (batch_header, transmissions) = sample_header_and_transmissions(rng);
-
-        // Store the transmissions concretely.
-        storage.insert_transmissions(
-            Field::rand(rng),
-            batch_header.transmission_ids().clone(),
-            HashSet::new(),
-            transmissions.clone(),
-        );
-        // Sanity check - the transmissions are retrievable.
-        for transmission_id in batch_header.transmission_ids() {
-            assert!(storage.get_transmission(*transmission_id).is_some());
-        }
-
-        // Stored transmissions are not reported as missing, whether provided again or not.
-        let missing = storage.find_missing_transmissions(&batch_header, transmissions.clone(), HashSet::new()).unwrap();
-        assert!(missing.is_empty());
-        let missing = storage.find_missing_transmissions(&batch_header, HashMap::new(), HashSet::new()).unwrap();
-        assert!(missing.is_empty());
-    }
-
-    #[test]
-    fn test_aborted_ids_declared_by_caller_are_allowed_without_bytes() {
-        let rng = &mut TestRng::default();
-        let storage = open_storage();
-        let (batch_header, _) = sample_header_and_transmissions(rng);
-
-        // Declaring all of the transmission IDs as aborted requires no transmissions.
-        let aborted = batch_header.transmission_ids().iter().copied().collect();
-        let missing = storage.find_missing_transmissions(&batch_header, HashMap::new(), aborted).unwrap();
-        assert!(missing.is_empty());
-    }
-
-    #[test]
-    fn test_previously_aborted_ids_without_bytes_or_declaration_error() {
-        let rng = &mut TestRng::default();
-        let storage = open_storage();
-        let (batch_header, _) = sample_header_and_transmissions(rng);
-
-        // Record all of the transmission IDs as aborted, without any transmissions.
-        storage.insert_transmissions(
-            Field::rand(rng),
-            batch_header.transmission_ids().clone(),
-            batch_header.transmission_ids().iter().copied().collect(),
-            HashMap::new(),
-        );
-
-        // An aborted ID in storage does not satisfy the check by itself - the caller must
-        // either provide the transmission or declare the ID as aborted.
-        assert!(storage.find_missing_transmissions(&batch_header, HashMap::new(), HashSet::new()).is_err());
-    }
-
-    #[test]
-    fn test_unknown_unprovided_transmission_errors() {
-        let rng = &mut TestRng::default();
-        let storage = open_storage();
-        let (batch_header, _) = sample_header_and_transmissions(rng);
-
-        // The transmission IDs are unknown to storage, not provided, and not declared as aborted.
-        assert!(storage.find_missing_transmissions(&batch_header, HashMap::new(), HashSet::new()).is_err());
     }
 }

--- a/node/bft/storage-service/src/persistent.rs
+++ b/node/bft/storage-service/src/persistent.rs
@@ -132,8 +132,19 @@ impl<N: Network> StorageService<N> for BFTPersistentStorage<N> {
         let mut missing_transmissions = HashMap::new();
         // Ensure the declared transmission IDs are all present in storage or the given transmissions map.
         for transmission_id in batch_header.transmission_ids() {
+            // Check only the concrete transmissions map, not the aborted transmission IDs.
+            // `contains_transmission` is also true for aborted IDs, for which storage holds no
+            // retrievable bytes; if the caller provided bytes for a previously-aborted ID, we must
+            // still collect them here so they are persisted and remain retrievable at commit time.
+            let is_stored = match self.transmissions.contains_key_confirmed(transmission_id) {
+                Ok(result) => result,
+                Err(error) => {
+                    error!("Failed to check if transmission ID exists in confirmed storage - {error}");
+                    false
+                }
+            };
             // If the transmission ID does not exist, ensure it was provided by the caller or aborted.
-            if !self.contains_transmission(*transmission_id) {
+            if !is_stored {
                 // Retrieve the transmission.
                 match transmissions.remove(transmission_id) {
                     // Append the transmission if it exists.

--- a/node/bft/storage-service/src/tests.rs
+++ b/node/bft/storage-service/src/tests.rs
@@ -43,17 +43,26 @@ fn sample_header_and_transmissions(
     (batch_header, transmissions)
 }
 
-fn check_provided_bytes_collected_for_previously_aborted_ids(storage: &impl StorageService<CurrentNetwork>) {
-    let rng = &mut TestRng::default();
-    let (batch_header, transmissions) = sample_header_and_transmissions(rng);
-
-    // Record all of the transmission IDs as aborted, without any transmissions.
+/// Records all of the batch header's transmission IDs as aborted, without any transmissions.
+fn record_ids_as_aborted(
+    storage: &impl StorageService<CurrentNetwork>,
+    batch_header: &BatchHeader<CurrentNetwork>,
+    rng: &mut TestRng,
+) {
     storage.insert_transmissions(
         Field::rand(rng),
         batch_header.transmission_ids().clone(),
         batch_header.transmission_ids().iter().copied().collect(),
         HashMap::new(),
     );
+}
+
+fn check_provided_bytes_collected_for_previously_aborted_ids(storage: &impl StorageService<CurrentNetwork>) {
+    let rng = &mut TestRng::default();
+    let (batch_header, transmissions) = sample_header_and_transmissions(rng);
+
+    // Record all of the transmission IDs as aborted, without any transmissions.
+    record_ids_as_aborted(storage, &batch_header, rng);
     // Sanity check - the aborted IDs are "contained", but hold no retrievable transmission.
     for transmission_id in batch_header.transmission_ids() {
         assert!(storage.contains_transmission(*transmission_id));
@@ -104,16 +113,37 @@ fn check_previously_aborted_ids_without_bytes_or_declaration_error(storage: &imp
     let (batch_header, _) = sample_header_and_transmissions(rng);
 
     // Record all of the transmission IDs as aborted, without any transmissions.
-    storage.insert_transmissions(
-        Field::rand(rng),
-        batch_header.transmission_ids().clone(),
-        batch_header.transmission_ids().iter().copied().collect(),
-        HashMap::new(),
-    );
+    record_ids_as_aborted(storage, &batch_header, rng);
 
     // An aborted ID in storage does not satisfy the check by itself - the caller must
     // either provide the transmission or declare the ID as aborted.
     assert!(storage.find_missing_transmissions(&batch_header, HashMap::new(), HashSet::new()).is_err());
+}
+
+fn check_contains_stored_transmission_distinguishes_aborted_ids(storage: &impl StorageService<CurrentNetwork>) {
+    let rng = &mut TestRng::default();
+    let (batch_header, transmissions) = sample_header_and_transmissions(rng);
+
+    // Record all of the transmission IDs as aborted, without any transmissions.
+    record_ids_as_aborted(storage, &batch_header, rng);
+    // Aborted-only IDs are contained, but not stored.
+    for transmission_id in batch_header.transmission_ids() {
+        assert!(storage.contains_transmission(*transmission_id));
+        assert!(!storage.contains_stored_transmission(*transmission_id));
+    }
+
+    // Store the transmissions concretely.
+    storage.insert_transmissions(
+        Field::rand(rng),
+        batch_header.transmission_ids().clone(),
+        HashSet::new(),
+        transmissions,
+    );
+    // Stored IDs are both contained and stored.
+    for transmission_id in batch_header.transmission_ids() {
+        assert!(storage.contains_transmission(*transmission_id));
+        assert!(storage.contains_stored_transmission(*transmission_id));
+    }
 }
 
 fn check_unknown_unprovided_transmission_errors(storage: &impl StorageService<CurrentNetwork>) {
@@ -148,6 +178,11 @@ macro_rules! storage_service_tests {
             #[test]
             fn test_previously_aborted_ids_without_bytes_or_declaration_error() {
                 check_previously_aborted_ids_without_bytes_or_declaration_error(&$storage);
+            }
+
+            #[test]
+            fn test_contains_stored_transmission_distinguishes_aborted_ids() {
+                check_contains_stored_transmission_distinguishes_aborted_ids(&$storage);
             }
 
             #[test]

--- a/node/bft/storage-service/src/tests.rs
+++ b/node/bft/storage-service/src/tests.rs
@@ -1,0 +1,162 @@
+// Copyright (c) 2019-2026 Provable Inc.
+// This file is part of the snarkOS library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Shared tests for the `StorageService` trait, exercised against every implementation to keep
+//! their semantics aligned.
+
+use crate::{StorageService, memory::BFTMemoryService, persistent::BFTPersistentStorage};
+use snarkvm::{
+    console::network::MainnetV0,
+    ledger::narwhal::{BatchHeader, Transmission, TransmissionID, batch_header, transmission},
+    prelude::{Field, TestRng, Uniform},
+};
+
+use aleo_std::StorageMode;
+use std::collections::{HashMap, HashSet};
+
+type CurrentNetwork = MainnetV0;
+
+/// Samples a batch header along with a transmission for each of its transmission IDs.
+fn sample_header_and_transmissions(
+    rng: &mut TestRng,
+) -> (BatchHeader<CurrentNetwork>, HashMap<TransmissionID<CurrentNetwork>, Transmission<CurrentNetwork>>) {
+    let batch_header = batch_header::test_helpers::sample_batch_header(rng);
+    let transmissions: HashMap<_, _> = batch_header
+        .transmission_ids()
+        .iter()
+        .copied()
+        .zip(transmission::test_helpers::sample_transmissions(rng))
+        .collect();
+    assert_eq!(transmissions.len(), batch_header.transmission_ids().len());
+    (batch_header, transmissions)
+}
+
+fn check_provided_bytes_collected_for_previously_aborted_ids(storage: &impl StorageService<CurrentNetwork>) {
+    let rng = &mut TestRng::default();
+    let (batch_header, transmissions) = sample_header_and_transmissions(rng);
+
+    // Record all of the transmission IDs as aborted, without any transmissions.
+    storage.insert_transmissions(
+        Field::rand(rng),
+        batch_header.transmission_ids().clone(),
+        batch_header.transmission_ids().iter().copied().collect(),
+        HashMap::new(),
+    );
+    // Sanity check - the aborted IDs are "contained", but hold no retrievable transmission.
+    for transmission_id in batch_header.transmission_ids() {
+        assert!(storage.contains_transmission(*transmission_id));
+        assert!(storage.get_transmission(*transmission_id).is_none());
+    }
+
+    // The provided transmissions must be collected as missing, despite the IDs being aborted,
+    // so that they get persisted and remain retrievable at commit time.
+    let missing = storage.find_missing_transmissions(&batch_header, transmissions.clone(), HashSet::new()).unwrap();
+    assert_eq!(missing, transmissions);
+}
+
+fn check_stored_transmissions_are_not_missing(storage: &impl StorageService<CurrentNetwork>) {
+    let rng = &mut TestRng::default();
+    let (batch_header, transmissions) = sample_header_and_transmissions(rng);
+
+    // Store the transmissions concretely.
+    storage.insert_transmissions(
+        Field::rand(rng),
+        batch_header.transmission_ids().clone(),
+        HashSet::new(),
+        transmissions.clone(),
+    );
+    // Sanity check - the transmissions are retrievable.
+    for transmission_id in batch_header.transmission_ids() {
+        assert!(storage.get_transmission(*transmission_id).is_some());
+    }
+
+    // Stored transmissions are not reported as missing, whether provided again or not.
+    let missing = storage.find_missing_transmissions(&batch_header, transmissions.clone(), HashSet::new()).unwrap();
+    assert!(missing.is_empty());
+    let missing = storage.find_missing_transmissions(&batch_header, HashMap::new(), HashSet::new()).unwrap();
+    assert!(missing.is_empty());
+}
+
+fn check_aborted_ids_declared_by_caller_are_allowed_without_bytes(storage: &impl StorageService<CurrentNetwork>) {
+    let rng = &mut TestRng::default();
+    let (batch_header, _) = sample_header_and_transmissions(rng);
+
+    // Declaring all of the transmission IDs as aborted requires no transmissions.
+    let aborted = batch_header.transmission_ids().iter().copied().collect();
+    let missing = storage.find_missing_transmissions(&batch_header, HashMap::new(), aborted).unwrap();
+    assert!(missing.is_empty());
+}
+
+fn check_previously_aborted_ids_without_bytes_or_declaration_error(storage: &impl StorageService<CurrentNetwork>) {
+    let rng = &mut TestRng::default();
+    let (batch_header, _) = sample_header_and_transmissions(rng);
+
+    // Record all of the transmission IDs as aborted, without any transmissions.
+    storage.insert_transmissions(
+        Field::rand(rng),
+        batch_header.transmission_ids().clone(),
+        batch_header.transmission_ids().iter().copied().collect(),
+        HashMap::new(),
+    );
+
+    // An aborted ID in storage does not satisfy the check by itself - the caller must
+    // either provide the transmission or declare the ID as aborted.
+    assert!(storage.find_missing_transmissions(&batch_header, HashMap::new(), HashSet::new()).is_err());
+}
+
+fn check_unknown_unprovided_transmission_errors(storage: &impl StorageService<CurrentNetwork>) {
+    let rng = &mut TestRng::default();
+    let (batch_header, _) = sample_header_and_transmissions(rng);
+
+    // The transmission IDs are unknown to storage, not provided, and not declared as aborted.
+    assert!(storage.find_missing_transmissions(&batch_header, HashMap::new(), HashSet::new()).is_err());
+}
+
+/// Instantiates every shared `StorageService` test against the given storage backend.
+macro_rules! storage_service_tests {
+    ($module:ident, $storage:expr) => {
+        mod $module {
+            use super::*;
+
+            #[test]
+            fn test_provided_bytes_collected_for_previously_aborted_ids() {
+                check_provided_bytes_collected_for_previously_aborted_ids(&$storage);
+            }
+
+            #[test]
+            fn test_stored_transmissions_are_not_missing() {
+                check_stored_transmissions_are_not_missing(&$storage);
+            }
+
+            #[test]
+            fn test_aborted_ids_declared_by_caller_are_allowed_without_bytes() {
+                check_aborted_ids_declared_by_caller_are_allowed_without_bytes(&$storage);
+            }
+
+            #[test]
+            fn test_previously_aborted_ids_without_bytes_or_declaration_error() {
+                check_previously_aborted_ids_without_bytes_or_declaration_error(&$storage);
+            }
+
+            #[test]
+            fn test_unknown_unprovided_transmission_errors() {
+                check_unknown_unprovided_transmission_errors(&$storage);
+            }
+        }
+    };
+}
+
+storage_service_tests!(memory, BFTMemoryService::<CurrentNetwork>::new());
+storage_service_tests!(persistent, BFTPersistentStorage::<CurrentNetwork>::open(StorageMode::new_test(None)).unwrap());

--- a/node/bft/storage-service/src/traits.rs
+++ b/node/bft/storage-service/src/traits.rs
@@ -15,7 +15,7 @@
 
 use snarkvm::{
     ledger::narwhal::{BatchHeader, Transmission, TransmissionID},
-    prelude::{Field, Network, Result},
+    prelude::{Field, Network, Result, bail},
 };
 
 use indexmap::IndexSet;
@@ -26,7 +26,17 @@ use std::{
 
 pub trait StorageService<N: Network>: Debug + Send + Sync {
     /// Returns `true` if the storage contains the specified `transmission ID`.
+    ///
+    /// Note: this is also `true` for transmission IDs only recorded as aborted, for which no
+    /// transmission is retrievable; see [`Self::contains_stored_transmission`].
     fn contains_transmission(&self, transmission_id: TransmissionID<N>) -> bool;
+
+    /// Returns `true` if the storage holds the actual transmission for the specified
+    /// `transmission ID`.
+    ///
+    /// Unlike [`Self::contains_transmission`], this is `false` for transmission IDs only recorded
+    /// as aborted, for which no transmission is retrievable.
+    fn contains_stored_transmission(&self, transmission_id: TransmissionID<N>) -> bool;
 
     /// Returns the transmission for the given `transmission ID`.
     /// If the transmission ID does not exist in storage, `None` is returned.
@@ -37,9 +47,35 @@ pub trait StorageService<N: Network>: Debug + Send + Sync {
     fn find_missing_transmissions(
         &self,
         batch_header: &BatchHeader<N>,
-        transmissions: HashMap<TransmissionID<N>, Transmission<N>>,
+        mut transmissions: HashMap<TransmissionID<N>, Transmission<N>>,
         aborted_transmissions: HashSet<TransmissionID<N>>,
-    ) -> Result<HashMap<TransmissionID<N>, Transmission<N>>>;
+    ) -> Result<HashMap<TransmissionID<N>, Transmission<N>>> {
+        // Initialize a list for the missing transmissions from storage.
+        let mut missing_transmissions = HashMap::new();
+        // Ensure the declared transmission IDs are all present in storage or the given transmissions map.
+        for transmission_id in batch_header.transmission_ids() {
+            // Check only the stored transmissions, not the aborted transmission IDs: if the caller
+            // provided a transmission for a previously-aborted ID, it must still be collected here
+            // so it is persisted and remains retrievable at commit time.
+            // If the transmission ID does not exist, ensure it was provided by the caller or aborted.
+            if !self.contains_stored_transmission(*transmission_id) {
+                // Retrieve the transmission.
+                match transmissions.remove(transmission_id) {
+                    // Append the transmission if it exists.
+                    Some(transmission) => {
+                        missing_transmissions.insert(*transmission_id, transmission);
+                    }
+                    // If the transmission does not exist, check if it was aborted.
+                    None => {
+                        if !aborted_transmissions.contains(transmission_id) {
+                            bail!("Failed to provide a transmission");
+                        }
+                    }
+                }
+            }
+        }
+        Ok(missing_transmissions)
+    }
 
     /// Inserts the given certificate ID for each of the transmission IDs, using the missing transmissions map, into storage.
     fn insert_transmissions(


### PR DESCRIPTION
## Motivation

BFT could certify and store a batch that references a transmission ID for which persistent BFT storage holds only an aborted entry and no retrievable bytes. Later, BFT commit cannot materialize those bytes and bails before producing the candidate block, temporarily stalling block production on the affected validator.

The root cause is that `StorageService::contains_transmission(id)` returns `true` for both concrete transmissions **and** aborted transmission IDs, while `get_transmission(id)` returns `None` for aborted IDs. Two paths turned this mismatch into a potential liveness issue:

- **Propose** (`Primary::propose_batch`): the storage-duplicate skip was bypassed for the *first* transmission in a proposal, so an already-aborted transmission sitting at the front of a worker's ready queue could be proposed as a normal transmission. The ledger check does not catch it, because the ledger does not store aborted transmissions.
- **Store** (`BFTPersistentStorage::find_missing_transmissions`): it used `contains_transmission` (true for aborted IDs), so caller-provided bytes for an already-aborted ID were dropped rather than persisted - leaving the certificate uncommittable. Note this also diverged from `BFTMemoryService`, which checks only the concrete map and persists the bytes.

This PR fixes both:

1. `propose_batch` now skips any transmission already recorded in storage (concrete or aborted), with no first-item exception. Proposing an empty batch is already valid and tested, so this is safe.
2. `BFTPersistentStorage::find_missing_transmissions` now checks only the concrete transmissions map, so caller-provided bytes for a previously-aborted ID are collected and persisted (matching `BFTMemoryService`).

## Test Plan

A unit test (`test_propose_batch_skips_aborted_first_transmission`) was added: it queues a worker with only aborted transmissions and asserts propose_batch skips all of them - including the first item, which previously bypassed the storage check and could be proposed.

## Documentation

N/A

## Backwards compatibility

No `ConsensusVersion` guard required. Neither change alters consensus messages, batch/certificate hashes, wire formats, or validation rules - it only affects local proposal selection.