### PR TITLE
[Cleanup] Remove Config::fatal_io_errors

### DIFF
--- a/node/tcp/src/helpers/config.rs
+++ b/node/tcp/src/helpers/config.rs
@@ -13,10 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{
-    io::{self, ErrorKind::*},
-    net::{IpAddr, Ipv4Addr, SocketAddr},
-};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 #[cfg(doc)]
 use crate::protocols::{self, Handshake, Reading, Writing};
@@ -44,10 +41,6 @@ pub struct Config {
     ///
     /// note: [`Config::listener_ip`] must not be `None` in order for it to have any effect.
     pub allow_random_port: bool,
-    /// The list of IO errors considered fatal and causing the connection to be dropped.
-    ///
-    /// note: Tcp needs to implement the [`Reading`] and/or [`Writing`] protocol in order for it to have any effect.
-    pub fatal_io_errors: Vec<io::ErrorKind>,
     /// The maximum number of active connections Tcp can maintain at any given time.
     ///
     /// note: This number can very briefly be breached by 1 in case of inbound connection attempts. It can never be
@@ -82,7 +75,6 @@ impl Default for Config {
             listener_ip: default_ip(),
             desired_listening_port: None,
             allow_random_port: true,
-            fatal_io_errors: vec![ConnectionReset, ConnectionAborted, BrokenPipe, InvalidData, UnexpectedEof],
             max_connections: 100,
             connection_timeout_ms: 3_000,
         }

--- a/node/tcp/src/protocols/reading.rs
+++ b/node/tcp/src/protocols/reading.rs
@@ -47,8 +47,8 @@ use tracing::*;
 ///
 /// Each inbound message is isolated by the user-supplied [`Reading::Codec`], creating a [`Reading::Message`],
 /// which is immediately queued (with a [`Reading::MESSAGE_QUEUE_DEPTH`] limit) to be processed by
-/// [`Reading::process_message`]. The configured fatal IO errors result in an immediate disconnect
-/// (in order to e.g. avoid accidentally reading "borked" messages).
+/// [`Reading::process_message`]. Errors result in an immediate disconnect (in order to e.g. avoid
+/// accidentally reading "borked" messages).
 #[async_trait]
 pub trait Reading: P2P
 where
@@ -226,9 +226,7 @@ impl<R: Reading> ReadingInternal for R {
                     }
                     Some(Err(e)) => {
                         error!(parent: &conn_span, "can't read: {e}");
-                        if node.config().fatal_io_errors.contains(&e.kind()) {
-                            break;
-                        }
+                        break;
                     }
                     None => break, // end of stream
                 }

--- a/node/tcp/src/protocols/writing.rs
+++ b/node/tcp/src/protocols/writing.rs
@@ -245,11 +245,8 @@ impl<W: Writing> WritingInternal for W {
                     }
                     Err(e) => {
                         error!(parent: &conn_span, "couldn't send a message: {e}");
-                        let is_fatal = node.config().fatal_io_errors.contains(&e.kind());
                         let _ = wrapped_msg.delivery_notification.send(Err(e));
-                        if is_fatal {
-                            break;
-                        }
+                        break;
                     }
                 }
             }


### PR DESCRIPTION
`Config::fatal_io_errors` no longer does what it was introduced for. Since `0.7.19`, `tokio_util` fuses a `FramedRead` once its decoder or the underlying read errors, so the connection ends regardless of whether the error kind was on the list.

On the write side, this is a change in behavior, but a desirable one, and in the same direction as https://github.com/ProvableHQ/snarkOS/pull/4381; it essentially achieves the same as if `TimedOut` was included in `fatal_io_errors`.