### PR TITLE
Fix/outbound rate limits

### DIFF
--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -22,7 +22,7 @@ use crate::{
     MEMORY_POOL_PORT,
     Worker,
     events::{DisconnectReason, EventCodec, PrimaryPing},
-    helpers::{Cache, PrimarySender, Storage, SyncSender, WorkerSender, assign_to_worker},
+    helpers::{Cache, PrimarySender, RateLimit, Storage, SyncSender, WorkerSender, assign_to_worker},
     spawn_blocking,
 };
 use smol_str::SmolStr;
@@ -112,6 +112,7 @@ use tokio::{
     net::TcpStream,
     sync::{OnceCell, oneshot},
     task::{self, JoinHandle},
+    time::Instant,
 };
 use tokio_stream::StreamExt;
 use tokio_util::codec::Framed;
@@ -120,6 +121,13 @@ use tokio_util::codec::Framed;
 const CACHE_EVENTS_INTERVAL: i64 = (MAX_BATCH_DELAY.as_secs()) as i64; // seconds
 /// The maximum interval of requests to cache.
 const CACHE_REQUESTS_INTERVAL: i64 = (MAX_BATCH_DELAY.as_secs()) as i64; // seconds
+
+/// The shortest delay between two attempts to claim outbound rate limit capacity.
+///
+/// The caches bucket by whole seconds, so a throttled sender normally sleeps until the moment its
+/// oldest recorded event ages out. This floor only applies when that moment has already passed, and
+/// exists so that a retry can never become a busy loop.
+const THROTTLE_RETRY_MIN_DELAY: Duration = Duration::from_millis(10);
 
 /// The number of consensus rounds of traffic that a per-connection message queue must absorb.
 ///
@@ -595,53 +603,89 @@ impl<N: Network> Gateway<N> {
         }
     }
 
-    /// Sends the given event to specified peer.
-    ///
-    /// This function returns as soon as the event is queued to be sent,
-    /// without waiting for the actual delivery; instead, the caller is provided with a [`oneshot::Receiver`]
-    /// which can be used to determine when and whether the event has been delivered.
     /// Waits until this peer is within the outbound rate limits for the given event, recording the
-    /// event in the outbound caches as it does so.
+    /// event in the outbound caches once it is. Returns `false` if the event should be dropped.
     ///
     /// This is the admission control for [`Transport::send`], and it deliberately runs *before* the
     /// payload is serialized. Serializing first would mean doing the expensive work for an event
     /// that is about to be throttled -- or dropped outright, if the connection's outbound queue is
     /// full by the time it is enqueued -- which lets a peer that requests large responses pile up
     /// work in the blocking pool no matter how far behind its own queue is.
-    async fn throttle_outbound(&self, peer_ip: SocketAddr, event: &Event<N>) {
-        /// Waits until the given per-peer counter is back under its limit.
-        macro_rules! wait_until_under_limit {
-            ($cache_map:ident, $interval:expr, $limit:ident) => {{
-                while self.cache.$cache_map(peer_ip, $interval) > self.$limit() {
-                    // Sleep for a short period of time to allow the cache to clear.
-                    tokio::time::sleep(Duration::from_millis(10)).await;
+    ///
+    /// Capacity is claimed atomically, and an attempt that is refused records nothing; see
+    /// [`Cache::retain_and_insert_within`] for why both halves of that matter.
+    ///
+    /// The wait is bounded by [`MAX_FETCH_TIMEOUT`]. An event that cannot be admitted inside that
+    /// window is already useless to the peer -- a requester has given up on it by then, and any
+    /// consensus event it carried is stale -- so it is dropped rather than sent late. This is the
+    /// same reasoning that sizes the queues it feeds; see [`per_connection_queue_depth`].
+    async fn throttle_outbound(&self, peer_ip: SocketAddr, event: &Event<N>) -> bool {
+        /// Attempts to claim capacity against the given per-peer counter, retrying until it is
+        /// granted or the deadline leaves no time for another attempt.
+        macro_rules! claim {
+            ($try_insert:ident, $interval:expr, $limit:ident) => {{
+                let deadline = Instant::now() + MAX_FETCH_TIMEOUT;
+                loop {
+                    let retry_after = match self.cache.$try_insert(peer_ip, $interval, self.$limit()) {
+                        RateLimit::Allowed => break true,
+                        RateLimit::Throttled { retry_after } => retry_after,
+                    };
+                    // Wait for the oldest recorded event to age out. Nothing else returns capacity:
+                    // these counters record admissions, not messages in flight, so a slot stays
+                    // taken for the whole interval rather than until the event reaches the wire.
+                    // The floor only guards against spinning if that moment has already passed.
+                    let next_attempt = Instant::now() + retry_after.max(THROTTLE_RETRY_MIN_DELAY);
+                    // Give up rather than sleep past the deadline: no attempt after it can be in
+                    // time, and the earliest useful attempt is already too late. Strictly, the
+                    // limits are dynamic (they scale with the committee), so a growing committee
+                    // could admit this event sooner than `retry_after` suggests -- but not by
+                    // enough, within one fetch timeout, to be worth waiting on.
+                    if next_attempt >= deadline {
+                        warn!("{CONTEXT} Dropping '{}' to '{peer_ip}' (outbound rate limit)", event.name());
+                        break false;
+                    }
+                    tokio::time::sleep_until(next_attempt).await;
                 }
             }};
         }
 
-        // Increment the cache for certificate, transmission and block events.
+        // Claim capacity for certificate, transmission and block events, and record the event only
+        // once it is cleared to be sent -- an event dropped above must not leave a hit behind for
+        // an event that could otherwise have been sent.
         match event {
             Event::CertificateRequest(_) | Event::CertificateResponse(_) => {
-                // Update the outbound event cache. This is necessary to ensure we don't under count the outbound events.
+                if !claim!(try_insert_outbound_certificate, CACHE_REQUESTS_INTERVAL, max_cache_certificates) {
+                    return false;
+                }
+                // Also record it against the general event cache, so events are not under counted.
                 self.cache.insert_outbound_event(peer_ip, CACHE_EVENTS_INTERVAL);
-                wait_until_under_limit!(insert_outbound_certificate, CACHE_REQUESTS_INTERVAL, max_cache_certificates)
             }
             Event::TransmissionRequest(_) | Event::TransmissionResponse(_) => {
-                // Update the outbound event cache. This is necessary to ensure we don't under count the outbound events.
+                if !claim!(try_insert_outbound_transmission, CACHE_REQUESTS_INTERVAL, max_cache_transmissions) {
+                    return false;
+                }
+                // Also record it against the general event cache, so events are not under counted.
                 self.cache.insert_outbound_event(peer_ip, CACHE_EVENTS_INTERVAL);
-                wait_until_under_limit!(insert_outbound_transmission, CACHE_REQUESTS_INTERVAL, max_cache_transmissions)
             }
             Event::BlockRequest(request) => {
+                // Use the general rate limit.
+                if !claim!(try_insert_outbound_event, CACHE_EVENTS_INTERVAL, max_cache_events) {
+                    return false;
+                }
                 // Insert the outbound request so we can match it to responses.
                 self.cache.insert_outbound_block_request(peer_ip, *request);
-                // Use the general rate limit.
-                wait_until_under_limit!(insert_outbound_event, CACHE_EVENTS_INTERVAL, max_cache_events)
             }
             // Everything else uses the general rate limit.
-            _ => wait_until_under_limit!(insert_outbound_event, CACHE_EVENTS_INTERVAL, max_cache_events),
+            _ => return claim!(try_insert_outbound_event, CACHE_EVENTS_INTERVAL, max_cache_events),
         }
+        true
     }
 
+    /// Sends the given event to specified peer.
+    ///
+    /// This function returns as soon as the event is queued to be sent,
+    /// without waiting for the actual delivery; instead, the caller is provided with a [`oneshot::Receiver`]
+    /// which can be used to determine when and whether the event has been delivered.
     fn send_inner(&self, peer_ip: SocketAddr, event: Event<N>) -> Option<oneshot::Receiver<io::Result<()>>> {
         // Resolve the listener IP to the (ambiguous) peer address.
         let Some(peer_addr) = self.resolve_to_ambiguous(peer_ip) else {
@@ -1383,7 +1427,9 @@ impl<N: Network> Gateway<N> {
 impl<N: Network> Transport<N> for Gateway<N> {
     /// Sends the given event to specified peer.
     ///
-    /// This method is rate limited to prevent spamming the peer.
+    /// This method is rate limited to prevent spamming the peer. An event that stays throttled for
+    /// longer than [`MAX_FETCH_TIMEOUT`] is already too stale to be worth sending, so it is dropped
+    /// and `None` is returned.
     ///
     /// This function returns as soon as the event is queued to be sent,
     /// without waiting for the actual delivery; instead, the caller is provided with a [`oneshot::Receiver`]
@@ -1391,7 +1437,9 @@ impl<N: Network> Transport<N> for Gateway<N> {
     async fn send(&self, peer_ip: SocketAddr, mut event: Event<N>) -> Option<oneshot::Receiver<io::Result<()>>> {
         // Apply the outbound rate limits first, so that the serialization below is only performed
         // for events this peer is actually allowed to be sent right now.
-        self.throttle_outbound(peer_ip, &event).await;
+        if !self.throttle_outbound(peer_ip, &event).await {
+            return None;
+        }
 
         // Serialize the payload here, rather than leaving it for the connection's writer task.
         //

--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -600,6 +600,48 @@ impl<N: Network> Gateway<N> {
     /// This function returns as soon as the event is queued to be sent,
     /// without waiting for the actual delivery; instead, the caller is provided with a [`oneshot::Receiver`]
     /// which can be used to determine when and whether the event has been delivered.
+    /// Waits until this peer is within the outbound rate limits for the given event, recording the
+    /// event in the outbound caches as it does so.
+    ///
+    /// This is the admission control for [`Transport::send`], and it deliberately runs *before* the
+    /// payload is serialized. Serializing first would mean doing the expensive work for an event
+    /// that is about to be throttled -- or dropped outright, if the connection's outbound queue is
+    /// full by the time it is enqueued -- which lets a peer that requests large responses pile up
+    /// work in the blocking pool no matter how far behind its own queue is.
+    async fn throttle_outbound(&self, peer_ip: SocketAddr, event: &Event<N>) {
+        /// Waits until the given per-peer counter is back under its limit.
+        macro_rules! wait_until_under_limit {
+            ($cache_map:ident, $interval:expr, $limit:ident) => {{
+                while self.cache.$cache_map(peer_ip, $interval) > self.$limit() {
+                    // Sleep for a short period of time to allow the cache to clear.
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                }
+            }};
+        }
+
+        // Increment the cache for certificate, transmission and block events.
+        match event {
+            Event::CertificateRequest(_) | Event::CertificateResponse(_) => {
+                // Update the outbound event cache. This is necessary to ensure we don't under count the outbound events.
+                self.cache.insert_outbound_event(peer_ip, CACHE_EVENTS_INTERVAL);
+                wait_until_under_limit!(insert_outbound_certificate, CACHE_REQUESTS_INTERVAL, max_cache_certificates)
+            }
+            Event::TransmissionRequest(_) | Event::TransmissionResponse(_) => {
+                // Update the outbound event cache. This is necessary to ensure we don't under count the outbound events.
+                self.cache.insert_outbound_event(peer_ip, CACHE_EVENTS_INTERVAL);
+                wait_until_under_limit!(insert_outbound_transmission, CACHE_REQUESTS_INTERVAL, max_cache_transmissions)
+            }
+            Event::BlockRequest(request) => {
+                // Insert the outbound request so we can match it to responses.
+                self.cache.insert_outbound_block_request(peer_ip, *request);
+                // Use the general rate limit.
+                wait_until_under_limit!(insert_outbound_event, CACHE_EVENTS_INTERVAL, max_cache_events)
+            }
+            // Everything else uses the general rate limit.
+            _ => wait_until_under_limit!(insert_outbound_event, CACHE_EVENTS_INTERVAL, max_cache_events),
+        }
+    }
+
     fn send_inner(&self, peer_ip: SocketAddr, event: Event<N>) -> Option<oneshot::Receiver<io::Result<()>>> {
         // Resolve the listener IP to the (ambiguous) peer address.
         let Some(peer_addr) = self.resolve_to_ambiguous(peer_ip) else {
@@ -1347,6 +1389,10 @@ impl<N: Network> Transport<N> for Gateway<N> {
     /// without waiting for the actual delivery; instead, the caller is provided with a [`oneshot::Receiver`]
     /// which can be used to determine when and whether the event has been delivered.
     async fn send(&self, peer_ip: SocketAddr, mut event: Event<N>) -> Option<oneshot::Receiver<io::Result<()>>> {
+        // Apply the outbound rate limits first, so that the serialization below is only performed
+        // for events this peer is actually allowed to be sent right now.
+        self.throttle_outbound(peer_ip, &event).await;
+
         // Serialize the payload here, rather than leaving it for the connection's writer task.
         //
         // `Data` defers serialization until the event is written to the stream, which puts it on
@@ -1372,43 +1418,8 @@ impl<N: Network> Transport<N> for Gateway<N> {
             };
         }
 
-        macro_rules! send {
-            ($self:ident, $cache_map:ident, $interval:expr, $freq:ident) => {{
-                // Rate limit the number of certificate requests sent to the peer.
-                while $self.cache.$cache_map(peer_ip, $interval) > $self.$freq() {
-                    // Sleep for a short period of time to allow the cache to clear.
-                    tokio::time::sleep(Duration::from_millis(10)).await;
-                }
-                // Send the event to the peer.
-                $self.send_inner(peer_ip, event)
-            }};
-        }
-
-        // Increment the cache for certificate, transmission and block events.
-        match event {
-            Event::CertificateRequest(_) | Event::CertificateResponse(_) => {
-                // Update the outbound event cache. This is necessary to ensure we don't under count the outbound events.
-                self.cache.insert_outbound_event(peer_ip, CACHE_EVENTS_INTERVAL);
-                // Send the event to the peer.
-                send!(self, insert_outbound_certificate, CACHE_REQUESTS_INTERVAL, max_cache_certificates)
-            }
-            Event::TransmissionRequest(_) | Event::TransmissionResponse(_) => {
-                // Update the outbound event cache. This is necessary to ensure we don't under count the outbound events.
-                self.cache.insert_outbound_event(peer_ip, CACHE_EVENTS_INTERVAL);
-                // Send the event to the peer.
-                send!(self, insert_outbound_transmission, CACHE_REQUESTS_INTERVAL, max_cache_transmissions)
-            }
-            Event::BlockRequest(request) => {
-                // Insert the outbound request so we can match it to responses.
-                self.cache.insert_outbound_block_request(peer_ip, request);
-                // Send the event to the peer and update the outbound event cache, use the general rate limit.
-                send!(self, insert_outbound_event, CACHE_EVENTS_INTERVAL, max_cache_events)
-            }
-            _ => {
-                // Send the event to the peer, use the general rate limit.
-                send!(self, insert_outbound_event, CACHE_EVENTS_INTERVAL, max_cache_events)
-            }
-        }
+        // Hand the event to the connection's outbound queue.
+        self.send_inner(peer_ip, event)
     }
 
     /// Broadcasts the given event to all connected peers.

--- a/node/bft/src/helpers/cache.rs
+++ b/node/bft/src/helpers/cache.rs
@@ -24,8 +24,24 @@ use parking_lot::RwLock;
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     net::{IpAddr, SocketAddr},
+    time::Duration,
 };
 use time::OffsetDateTime;
+
+/// The outcome of attempting to record an event against a rate-limited counter.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum RateLimit {
+    /// The event was recorded; the counter is within its limit.
+    Allowed,
+    /// The counter is at its limit, and *nothing was recorded*.
+    ///
+    /// `retry_after` is the time until the oldest recent hit ages out of the counter's interval.
+    /// Hits are never removed by any other means -- in particular, recording one reserves it for
+    /// the whole interval rather than until whatever it stands for completes -- so against an
+    /// unchanged `limit` this is how long the caller must wait. It is a lower bound: if the counter
+    /// is above its limit rather than exactly at it, more than one hit has to age out first.
+    Throttled { retry_after: Duration },
+}
 
 #[derive(Debug)]
 pub struct Cache<N: Network> {
@@ -118,6 +134,31 @@ impl<N: Network> Cache<N> {
     pub fn insert_outbound_transmission(&self, peer_ip: SocketAddr, interval_in_secs: i64) -> usize {
         Self::retain_and_insert(&self.seen_outbound_transmissions, peer_ip, interval_in_secs)
     }
+
+    /// Records a new timestamp for the given peer, unless doing so would exceed `limit`.
+    pub fn try_insert_outbound_event(&self, peer_ip: SocketAddr, interval_in_secs: i64, limit: usize) -> RateLimit {
+        Self::retain_and_insert_within(&self.seen_outbound_events, peer_ip, interval_in_secs, limit)
+    }
+
+    /// Records a new timestamp for the given peer, unless doing so would exceed `limit`.
+    pub fn try_insert_outbound_certificate(
+        &self,
+        peer_ip: SocketAddr,
+        interval_in_secs: i64,
+        limit: usize,
+    ) -> RateLimit {
+        Self::retain_and_insert_within(&self.seen_outbound_certificates, peer_ip, interval_in_secs, limit)
+    }
+
+    /// Records a new timestamp for the given peer, unless doing so would exceed `limit`.
+    pub fn try_insert_outbound_transmission(
+        &self,
+        peer_ip: SocketAddr,
+        interval_in_secs: i64,
+        limit: usize,
+    ) -> RateLimit {
+        Self::retain_and_insert_within(&self.seen_outbound_transmissions, peer_ip, interval_in_secs, limit)
+    }
 }
 
 impl<N: Network> Cache<N> {
@@ -168,37 +209,88 @@ impl<N: Network> Cache<N> {
         key: K,
         interval_in_secs: i64,
     ) -> usize {
+        // An unlimited insert is always granted, so the throttled arm is unreachable here.
+        match Self::retain_and_insert_up_to(map, key, interval_in_secs, None) {
+            Ok(cache_hits) => cache_hits,
+            Err(_) => unreachable!("an unlimited insert cannot be throttled"),
+        }
+    }
+
+    /// Insert a new timestamp for the given key, unless the key already has `limit` recent entries.
+    ///
+    /// The count and the insert happen under a *single* acquisition of the write lock, so capacity
+    /// is claimed atomically: two callers can never both observe the same free slot and take it.
+    /// That is what stops a burst of concurrent senders from collectively overshooting the limit
+    /// after they are all released by the same expiry.
+    ///
+    /// A throttled call records nothing. This matters because callers retry in a loop: an attempt
+    /// that recorded a hit would sustain the very count it is waiting to see fall, and once enough
+    /// callers were retrying, the counter could never drain again.
+    fn retain_and_insert_within<K: Copy + Clone + PartialEq + Eq + Hash>(
+        map: &RwLock<BTreeMap<i64, HashMap<K, u32>>>,
+        key: K,
+        interval_in_secs: i64,
+        limit: usize,
+    ) -> RateLimit {
+        match Self::retain_and_insert_up_to(map, key, interval_in_secs, Some(limit)) {
+            Ok(_) => RateLimit::Allowed,
+            Err(retry_after) => RateLimit::Throttled { retry_after },
+        }
+    }
+
+    /// Prunes the expired entries, then records a hit for `key` if `limit` allows it.
+    ///
+    /// Returns the number of recent entries for `key`, including the one just recorded. If `limit`
+    /// is `Some` and is already met, nothing is recorded and the time until `key`'s oldest recent
+    /// entry ages out of the interval is returned instead. Expiry is the only thing that removes an
+    /// entry, so for an unchanging `limit` no earlier retry could have been granted.
+    fn retain_and_insert_up_to<K: Copy + Clone + PartialEq + Eq + Hash>(
+        map: &RwLock<BTreeMap<i64, HashMap<K, u32>>>,
+        key: K,
+        interval_in_secs: i64,
+        limit: Option<usize>,
+    ) -> Result<usize, Duration> {
         // Fetch the current timestamp.
         let now = OffsetDateTime::now_utc().unix_timestamp();
-
-        // Get the write lock.
-        let mut map_write = map.write();
-        // Insert the new timestamp and increment the frequency for the key.
-        *map_write.entry(now).or_default().entry(key).or_default() += 1;
         // Calculate the cutoff time for the entries to retain.
         let cutoff = now.saturating_sub(interval_in_secs);
-        // Obtain the oldest timestamp from the map; it's guaranteed to exist at this point.
-        let (oldest, _) = map_write.first_key_value().unwrap();
-        // Track the number of cache hits of the key.
-        let mut cache_hits = 0;
-        // If the oldest timestamp is above the cutoff value, all the entries can be retained.
-        if cutoff <= *oldest {
-            for cache_keys in map_write.values() {
-                cache_hits += *cache_keys.get(&key).unwrap_or(&0);
-            }
-        } else {
-            // Extract the subtree after interval (i.e. non-expired entries)
+
+        // Get the write lock. Everything below happens under it, so that a count cannot go stale
+        // between being checked against the limit and being acted on.
+        let mut map_write = map.write();
+
+        // Drop the expired entries, unless every entry is still within the interval.
+        if map_write.first_key_value().is_some_and(|(oldest, _)| *oldest < cutoff) {
+            // Extract the subtree from the cutoff (i.e. the non-expired entries), discarding the rest.
             let retained = map_write.split_off(&cutoff);
-            // Clear all the expired entries.
-            map_write.clear();
-            // Reinsert the entries into map and sum the frequency of recent requests for `key` while looping.
-            for (time, cache_keys) in retained {
-                cache_hits += *cache_keys.get(&key).unwrap_or(&0);
-                map_write.insert(time, cache_keys);
+            *map_write = retained;
+        }
+
+        // Sum the frequency of the key over the retained entries, noting the oldest one holding a hit.
+        let mut cache_hits = 0;
+        let mut oldest_hit = None;
+        for (time, cache_keys) in map_write.iter() {
+            if let Some(hits) = cache_keys.get(&key) {
+                cache_hits += *hits;
+                oldest_hit.get_or_insert(*time);
             }
         }
-        // Return the frequency.
-        cache_hits as usize
+
+        // Refuse to record the hit if the key is already at its limit.
+        if let Some(limit) = limit
+            && cache_hits as usize >= limit
+        {
+            // An entry recorded at `t` remains within the interval while `t >= now - interval`, so
+            // the oldest one ages out at `t + interval + 1`. Fall back to `now` if the limit is
+            // zero, in which case there is no hit to age out and any wait is as good as another.
+            let ages_out_at = oldest_hit.unwrap_or(now).saturating_add(interval_in_secs).saturating_add(1);
+            return Err(Duration::from_secs(ages_out_at.saturating_sub(now).max(0) as u64));
+        }
+
+        // Insert the new timestamp and increment the frequency for the key.
+        *map_write.entry(now).or_default().entry(key).or_default() += 1;
+        // Return the frequency, including the hit just recorded.
+        Ok(cache_hits as usize + 1)
     }
 
     /// Increments the key's counter in the map, returning the updated counter.
@@ -233,7 +325,12 @@ mod tests {
     use super::*;
     use snarkvm::prelude::MainnetV0;
 
-    use std::{net::Ipv4Addr, thread, time::Duration};
+    use std::{
+        net::Ipv4Addr,
+        sync::{Arc, Barrier},
+        thread,
+        time::Duration,
+    };
 
     type CurrentNetwork = MainnetV0;
 
@@ -355,5 +452,79 @@ mod tests {
         // Clear all requests.
         cache.clear_outbound_validators_requests(input);
         assert!(!cache.contains_outbound_validators_request(input));
+    }
+
+    /// A throttled attempt must record nothing.
+    ///
+    /// `Gateway::throttle_outbound` retries in a loop while waiting for a peer to fall back under a
+    /// rate limit. If a refused attempt still recorded a hit, waiters would sustain the very count
+    /// they are waiting on, and past some number of them the counter could never drain again.
+    #[test]
+    fn test_throttled_outbound_does_not_record() {
+        let cache = Cache::<CurrentNetwork>::default();
+        let input: SocketAddr = Input::input();
+        const INTERVAL: i64 = 10;
+        const LIMIT: usize = 2;
+
+        // Fill the counter up to its limit.
+        for _ in 0..LIMIT {
+            assert_eq!(cache.try_insert_outbound_event(input, INTERVAL, LIMIT), RateLimit::Allowed);
+            assert_eq!(cache.try_insert_outbound_certificate(input, INTERVAL, LIMIT), RateLimit::Allowed);
+            assert_eq!(cache.try_insert_outbound_transmission(input, INTERVAL, LIMIT), RateLimit::Allowed);
+        }
+
+        // Retrying, as the wait loop does, must be refused and must leave the counts untouched.
+        for _ in 0..100 {
+            for outcome in [
+                cache.try_insert_outbound_event(input, INTERVAL, LIMIT),
+                cache.try_insert_outbound_certificate(input, INTERVAL, LIMIT),
+                cache.try_insert_outbound_transmission(input, INTERVAL, LIMIT),
+            ] {
+                // The wait must be bounded by the interval, and must be long enough to be worth
+                // making: a zero-length wait would turn the caller's retry into a busy loop.
+                let RateLimit::Throttled { retry_after } = outcome else {
+                    panic!("a counter at its limit must throttle")
+                };
+                assert!(retry_after > Duration::ZERO);
+                assert!(retry_after <= Duration::from_secs(INTERVAL as u64 + 1));
+            }
+        }
+
+        // Had any of those attempts recorded a hit, the count would have grown past the limit.
+        assert_eq!(cache.insert_outbound_event(input, INTERVAL), LIMIT + 1);
+    }
+
+    /// Only `limit` of the callers competing for the same free slot may claim it.
+    #[test]
+    fn test_concurrent_outbound_claims_do_not_overshoot() {
+        const INTERVAL: i64 = 10;
+        const LIMIT: usize = 8;
+        const CLAIMANTS: usize = 64;
+
+        let cache = Arc::new(Cache::<CurrentNetwork>::default());
+        let input: SocketAddr = Input::input();
+        // Release every thread at once, so that they contend for the same empty counter.
+        let barrier = Arc::new(Barrier::new(CLAIMANTS));
+
+        let claimants: Vec<_> = (0..CLAIMANTS)
+            .map(|_| {
+                let (cache, barrier) = (cache.clone(), barrier.clone());
+                thread::spawn(move || {
+                    barrier.wait();
+                    cache.try_insert_outbound_transmission(input, INTERVAL, LIMIT)
+                })
+            })
+            .collect();
+
+        let allowed = claimants
+            .into_iter()
+            .map(|c| c.join().expect("claimant panicked"))
+            .filter(|outcome| *outcome == RateLimit::Allowed)
+            .count();
+
+        // Exactly `LIMIT` may pass. More would mean two claimants saw the same free slot; fewer
+        // would mean a refusal consumed one.
+        assert_eq!(allowed, LIMIT);
+        assert_eq!(cache.insert_outbound_transmission(input, INTERVAL), LIMIT + 1);
     }
 }


### PR DESCRIPTION
## Motivation

This is follow on to #4382 

1. Fix an ordering issue introduced in that PR (spotted by AI review of that PR): We want to apply outbound rate limits before serializing the payload, so that we don't waste work if the message won't actually be sent.
2. Fix a pre-existing live lock condition, also spotted by AI. If we hit the outbound rate limit to a given peer, then we sleep for 10 ms and retry sending again. However, when this retry occurs, we increment the counter even though we then choose to back off, which means that once we enter the retry path, we may never be able to recover -- the fact that we retried many times recently prevents the counter from ever falling back to zero.

## Test Plan

There is a regression test for this livelock behavior

## Backwards compatibility

This should be backwards compatible because we aren't changing the messages being sent. (1) is an optimization that skips work that we don't need to do. (2) fixes a bug in the rate limiting logic, and whenever it would have mattered, we would have experienced live lock, so we aren't changing any behavior there on the normal code paths.