### PR TITLE
CC additional maintainers on benchmark regression alerts

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -120,7 +120,7 @@ jobs:
           # but for all, except the sync variance, bigger is indeed better.
           tool: 'customBiggerIsBetter'
           output-file-path: results.json
-          alert-comment-cc-users: '@kaimast'
+          alert-comment-cc-users: '@kaimast,@snarkworld,@cbeck88'
           # Only push the results on staging (see below)
           auto-push: false
           # Enable Job Summary for PRs

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -120,7 +120,7 @@ jobs:
           # but for all, except the sync variance, bigger is indeed better.
           tool: 'customBiggerIsBetter'
           output-file-path: results.json
-          alert-comment-cc-users: '@kaimast,@snarkworld,@cbeck88'
+          alert-comment-cc-users: '@vicsn,@snarkworld,@cbeck88'
           # Only push the results on staging (see below)
           auto-push: false
           # Enable Job Summary for PRs


### PR DESCRIPTION
## Summary
- Add `@snarkworld` and `@cbeck88` to `alert-comment-cc-users` in the snarkOS benchmark workflow so they are notified on regression alerts, alongside `@kaimast`.
