### PR TITLE
Fix macOS release build (libclang)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,15 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
+      # clang-sys links libclang with @rpath. dyld does not search the Xcode
+      # toolchain, but it does search $HOME/lib (DYLD_FALLBACK_LIBRARY_PATH).
+      - name: Make libclang discoverable
+        run: |
+          LIBCLANG="$(xcode-select -p)/Toolchains/XcodeDefault.xctoolchain/usr/lib/libclang.dylib"
+          test -f "$LIBCLANG"
+          mkdir -p "$HOME/lib"
+          ln -sf "$LIBCLANG" "$HOME/lib/libclang.dylib"
+
       - name: Build snarkOS
         run: |
           cargo build --all --release && strip target/release/snarkos


### PR DESCRIPTION
## Summary
- The macOS release job aborts in `librocksdb-sys` because dyld cannot resolve `@rpath/libclang.dylib` on current GitHub `macos-latest` runners.
- Symlink Xcode's `libclang.dylib` into `$HOME/lib`, which is on dyld's default fallback search path.

## Test plan
- [x] Confirm the macOS job in the next tagged release (or a dry-run of `.github/workflows/release.yml`) compiles `librocksdb-sys` instead of SIGABRT.
- [x] Confirm Ubuntu and Windows release jobs are unchanged.