### PR TITLE
fix(bft): enforce worker capacity limit at transmission insertion

### DIFF
--- a/node/bft/src/worker.rs
+++ b/node/bft/src/worker.rs
@@ -298,7 +298,7 @@ impl<N: Network> Worker<N> {
                         // Insert the transmission into the ready queue.
                         // Note: This method checks `contains_transmission` again, because by the time the transmission is fetched,
                         // it could have already been inserted into the ready queue.
-                        self_.process_transmission_from_peer(peer_ip, transmission_id, transmission);
+                        self_.process_transmission_from_ping(peer_ip, transmission_id, transmission);
                     }
                 }
                 // If the transmission was not fetched, then attempt to fetch it again.
@@ -313,12 +313,56 @@ impl<N: Network> Worker<N> {
         });
     }
 
+    /// Handles a transmission fetched in response to a worker ping event.
+    ///
+    /// Unlike [`Worker::process_transmission_from_peer`], this enforces the ready-queue capacity
+    /// limit (atomically with the insertion), dropping the transmission if the queue is full.
+    ///
+    /// This is required to close a time-of-check-to-time-of-use race: the capacity check in
+    /// `process_transmission_id_from_ping` runs before the transmission is fetched asynchronously,
+    /// so without a re-check at insertion time, many concurrent fetches could each observe a
+    /// non-full ready queue and then collectively exceed `MAX_TRANSMISSIONS_PER_WORKER`.
+    ///
+    /// Note: We must prioritize the unconfirmed solutions and unconfirmed transactions, not
+    /// transmissions fetched from peer pings, which is why the limit is enforced on this path.
+    fn process_transmission_from_ping(
+        &self,
+        peer_ip: SocketAddr,
+        transmission_id: TransmissionID<N>,
+        transmission: Transmission<N>,
+    ) {
+        self.insert_transmission_from_peer(peer_ip, transmission_id, transmission, true);
+    }
+
     /// Handles the incoming transmission from a peer.
+    ///
+    /// Note: This does *not* enforce the ready-queue capacity limit, because this path also
+    /// materializes the transmissions of a peer's batch proposal prior to signing it (see
+    /// `Primary::insert_missing_transmissions_into_workers`); dropping a transmission there would
+    /// cause the node to sign a batch whose transmissions it does not hold. The capacity limit is
+    /// enforced only on the worker-ping path, via [`Worker::process_transmission_from_ping`].
     pub(crate) fn process_transmission_from_peer(
         &self,
         peer_ip: SocketAddr,
         transmission_id: TransmissionID<N>,
         transmission: Transmission<N>,
+    ) {
+        self.insert_transmission_from_peer(peer_ip, transmission_id, transmission, false);
+    }
+
+    /// Inserts a peer-provided transmission into the ready queue.
+    ///
+    /// If `enforce_capacity_limit` is `true`, the transmission is dropped when the ready queue is
+    /// already full. This must only be set for the worker-ping fetch path; callers that must retain
+    /// the transmission (e.g. materializing a peer's batch proposal before signing it) must leave it
+    /// `false`. See [`Worker::process_transmission_from_ping`] and
+    /// [`Worker::process_transmission_from_peer`].
+    fn insert_transmission_from_peer(
+        &self,
+        peer_ip: SocketAddr,
+        transmission_id: TransmissionID<N>,
+        transmission: Transmission<N>,
+        enforce_capacity_limit: bool,
     ) {
         // If the transmission ID already exists, then do not store it.
         if self.contains_transmission(transmission_id) {
@@ -347,22 +391,13 @@ impl<N: Network> Worker<N> {
             }
             _ => None,
         };
-        // Insert the transmission into the ready queue, re-checking the capacity limit atomically
-        // with the insertion (i.e. under a single write lock).
-        //
-        // This check is required in addition to the one in `process_transmission_id_from_ping`,
-        // because the transmission is fetched asynchronously: without it, many concurrent fetches
-        // can each observe a non-full ready queue before any of them insert, and then collectively
-        // exceed `MAX_TRANSMISSIONS_PER_WORKER` (a time-of-check-to-time-of-use race). Performing the
-        // check while holding the write lock guarantees the peer-fetch path never grows the ready
-        // queue beyond the limit.
-        //
-        // Note: We must prioritize the unconfirmed solutions and unconfirmed transactions, not
-        // transmissions fetched from peers, which is why this limit is only enforced here.
+        // Insert the transmission into the ready queue. When the capacity limit is enforced, the
+        // check is performed atomically with the insertion (i.e. under a single write lock), so that
+        // concurrent inserts cannot collectively exceed `MAX_TRANSMISSIONS_PER_WORKER`.
         let inserted = {
             let mut ready = self.ready.write();
             // If the ready queue is full, then skip this transmission.
-            if ready.num_transmissions() > Self::MAX_TRANSMISSIONS_PER_WORKER {
+            if enforce_capacity_limit && ready.num_transmissions() > Self::MAX_TRANSMISSIONS_PER_WORKER {
                 return;
             }
             ready.insert(transmission_id, transmission)
@@ -763,7 +798,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_process_transmission_from_peer_respects_capacity() {
+    async fn test_process_transmission_from_ping_respects_capacity() {
         let rng = &mut TestRng::default();
         // Sample a committee.
         let committee = snarkvm::ledger::committee::test_helpers::sample_committee(rng);
@@ -785,7 +820,7 @@ mod tests {
         let peer_ip = SocketAddr::from(([127, 0, 0, 1], 1234));
 
         // Emulate the asynchronous worker-ping fetch path inserting far more transmissions than the
-        // per-worker limit. Each fetched transmission is inserted via `process_transmission_from_peer`,
+        // per-worker limit. Each fetched transmission is inserted via `process_transmission_from_ping`,
         // exactly as it would be when a `send_transmission_request` future resolves. Without an insertion
         // time capacity check, the TOCTOU in `process_transmission_id_from_ping` lets these accumulate
         // without bound.
@@ -796,10 +831,10 @@ mod tests {
                 rng.random::<<CurrentNetwork as Network>::TransmissionChecksum>(),
             );
             let transmission = Transmission::Solution(data(rng));
-            worker.process_transmission_from_peer(peer_ip, transmission_id, transmission);
+            worker.process_transmission_from_ping(peer_ip, transmission_id, transmission);
         }
 
-        // The peer-fetch path must not grow the ready queue beyond the per-worker limit.
+        // The worker-ping path must not grow the ready queue beyond the per-worker limit.
         // At most one extra transmission is tolerated (the insertion that crosses the boundary).
         assert!(
             worker.num_transmissions() <= Worker::<CurrentNetwork>::MAX_TRANSMISSIONS_PER_WORKER + 1,
@@ -807,6 +842,45 @@ mod tests {
             worker.num_transmissions(),
             Worker::<CurrentNetwork>::MAX_TRANSMISSIONS_PER_WORKER + 1,
         );
+    }
+
+    #[tokio::test]
+    async fn test_process_transmission_from_peer_ignores_capacity() {
+        let rng = &mut TestRng::default();
+        // Sample a committee.
+        let committee = snarkvm::ledger::committee::test_helpers::sample_committee(rng);
+        let committee_clone = committee.clone();
+        // Setup the mock gateway and ledger.
+        let gateway = MockGateway::default();
+        let mut mock_ledger = MockLedger::default();
+        mock_ledger.expect_current_committee().returning(move || Ok(committee.clone()));
+        mock_ledger.expect_get_committee_lookback_for_round().returning(move |_| Ok(committee_clone.clone()));
+        mock_ledger.expect_contains_transmission().returning(|_| Ok(false));
+        let ledger: Arc<dyn LedgerService<CurrentNetwork>> = Arc::new(mock_ledger);
+        // Initialize the storage.
+        let storage = Storage::<CurrentNetwork>::new(ledger.clone(), Arc::new(BFTMemoryService::new()), 1).unwrap();
+
+        // Create the Worker.
+        let worker = Worker::new(0, Arc::new(gateway), storage, ledger, Default::default()).unwrap();
+        let data =
+            |rng: &mut TestRng| Data::Buffer(Bytes::from((0..512).map(|_| rng.random::<u8>()).collect::<Vec<_>>()));
+        let peer_ip = SocketAddr::from(([127, 0, 0, 1], 1234));
+
+        // The batch-materialization path (`process_transmission_from_peer`) must retain every
+        // transmission, even beyond the per-worker limit, so the node never signs a peer's batch
+        // whose transmissions it does not hold.
+        let num_to_insert = Worker::<CurrentNetwork>::MAX_TRANSMISSIONS_PER_WORKER * 4;
+        for _ in 0..num_to_insert {
+            let transmission_id = TransmissionID::Solution(
+                rng.random::<u64>().into(),
+                rng.random::<<CurrentNetwork as Network>::TransmissionChecksum>(),
+            );
+            let transmission = Transmission::Solution(data(rng));
+            worker.process_transmission_from_peer(peer_ip, transmission_id, transmission);
+        }
+
+        // Every transmission was retained.
+        assert_eq!(worker.num_transmissions(), num_to_insert);
     }
 
     #[tokio::test]

--- a/node/bft/src/worker.rs
+++ b/node/bft/src/worker.rs
@@ -334,20 +334,48 @@ impl<N: Network> Worker<N> {
             // All other combinations are clearly invalid.
             _ => false,
         };
-        // If the transmission is a deserialized execution, verify it immediately.
-        // This takes heavy transaction verification out of the hot path during block generation.
-        if let (TransmissionID::Transaction(tx_id, _), Transmission::Transaction(Data::Object(tx))) =
-            (transmission_id, &transmission)
-            && tx.is_execute()
-        {
-            let self_ = self.clone();
-            let tx_ = tx.clone();
-            tokio::spawn(async move {
-                let _ = self_.ledger.check_transaction_basic(tx_id, tx_).await;
-            });
+        // If the transmission type does not match the transmission ID, then do not store it.
+        if !is_well_formed {
+            return;
         }
-        // If the transmission ID and transmission type matches, then insert the transmission into the ready queue.
-        if is_well_formed && self.ready.write().insert(transmission_id, transmission) {
+        // If the transmission is a deserialized execution, capture it so it can be verified
+        // immediately below (only if it is actually inserted). This takes heavy transaction
+        // verification out of the hot path during block generation.
+        let execution_to_verify = match (transmission_id, &transmission) {
+            (TransmissionID::Transaction(tx_id, _), Transmission::Transaction(Data::Object(tx))) if tx.is_execute() => {
+                Some((tx_id, tx.clone()))
+            }
+            _ => None,
+        };
+        // Insert the transmission into the ready queue, re-checking the capacity limit atomically
+        // with the insertion (i.e. under a single write lock).
+        //
+        // This check is required in addition to the one in `process_transmission_id_from_ping`,
+        // because the transmission is fetched asynchronously: without it, many concurrent fetches
+        // can each observe a non-full ready queue before any of them insert, and then collectively
+        // exceed `MAX_TRANSMISSIONS_PER_WORKER` (a time-of-check-to-time-of-use race). Performing the
+        // check while holding the write lock guarantees the peer-fetch path never grows the ready
+        // queue beyond the limit.
+        //
+        // Note: We must prioritize the unconfirmed solutions and unconfirmed transactions, not
+        // transmissions fetched from peers, which is why this limit is only enforced here.
+        let inserted = {
+            let mut ready = self.ready.write();
+            // If the ready queue is full, then skip this transmission.
+            if ready.num_transmissions() > Self::MAX_TRANSMISSIONS_PER_WORKER {
+                return;
+            }
+            ready.insert(transmission_id, transmission)
+        };
+        // If the transmission was newly inserted, then process it further.
+        if inserted {
+            // Eagerly verify a newly-inserted execution to warm the verification cache.
+            if let Some((tx_id, tx)) = execution_to_verify {
+                let self_ = self.clone();
+                tokio::spawn(async move {
+                    let _ = self_.ledger.check_transaction_basic(tx_id, tx).await;
+                });
+            }
             trace!(
                 "Worker {} - Added transmission '{}' from '{peer_ip}'",
                 self.id,
@@ -732,6 +760,53 @@ mod tests {
         // Take the transmission from the ready set.
         assert!(worker.ready.write().remove_front().is_some());
         assert!(!worker.ready.read().contains(transmission_id));
+    }
+
+    #[tokio::test]
+    async fn test_process_transmission_from_peer_respects_capacity() {
+        let rng = &mut TestRng::default();
+        // Sample a committee.
+        let committee = snarkvm::ledger::committee::test_helpers::sample_committee(rng);
+        let committee_clone = committee.clone();
+        // Setup the mock gateway and ledger.
+        let gateway = MockGateway::default();
+        let mut mock_ledger = MockLedger::default();
+        mock_ledger.expect_current_committee().returning(move || Ok(committee.clone()));
+        mock_ledger.expect_get_committee_lookback_for_round().returning(move |_| Ok(committee_clone.clone()));
+        mock_ledger.expect_contains_transmission().returning(|_| Ok(false));
+        let ledger: Arc<dyn LedgerService<CurrentNetwork>> = Arc::new(mock_ledger);
+        // Initialize the storage.
+        let storage = Storage::<CurrentNetwork>::new(ledger.clone(), Arc::new(BFTMemoryService::new()), 1).unwrap();
+
+        // Create the Worker.
+        let worker = Worker::new(0, Arc::new(gateway), storage, ledger, Default::default()).unwrap();
+        let data =
+            |rng: &mut TestRng| Data::Buffer(Bytes::from((0..512).map(|_| rng.random::<u8>()).collect::<Vec<_>>()));
+        let peer_ip = SocketAddr::from(([127, 0, 0, 1], 1234));
+
+        // Emulate the asynchronous worker-ping fetch path inserting far more transmissions than the
+        // per-worker limit. Each fetched transmission is inserted via `process_transmission_from_peer`,
+        // exactly as it would be when a `send_transmission_request` future resolves. Without an insertion
+        // time capacity check, the TOCTOU in `process_transmission_id_from_ping` lets these accumulate
+        // without bound.
+        let num_to_insert = Worker::<CurrentNetwork>::MAX_TRANSMISSIONS_PER_WORKER * 4;
+        for _ in 0..num_to_insert {
+            let transmission_id = TransmissionID::Solution(
+                rng.random::<u64>().into(),
+                rng.random::<<CurrentNetwork as Network>::TransmissionChecksum>(),
+            );
+            let transmission = Transmission::Solution(data(rng));
+            worker.process_transmission_from_peer(peer_ip, transmission_id, transmission);
+        }
+
+        // The peer-fetch path must not grow the ready queue beyond the per-worker limit.
+        // At most one extra transmission is tolerated (the insertion that crosses the boundary).
+        assert!(
+            worker.num_transmissions() <= Worker::<CurrentNetwork>::MAX_TRANSMISSIONS_PER_WORKER + 1,
+            "ready queue exceeded the per-worker limit: {} > {}",
+            worker.num_transmissions(),
+            Worker::<CurrentNetwork>::MAX_TRANSMISSIONS_PER_WORKER + 1,
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Motivation

`process_transmission_id_from_ping` checks the ready-queue capacity (`num_transmissions() > MAX_TRANSMISSIONS_PER_WORKER`) before spawning an asynchronous fetch, but the insertion that follows did not re-check. Because the fetch is asynchronous, many concurrent pings can each observe a non-full ready queue before any of them insert, then collectively exceed the limit (a time-of-check-to-time-of-use race). A malicious validator can exploit this to inflate a peer's ready queue past `MAX_TRANSMISSIONS_PER_WORKER`, which in turn pushes `num_unconfirmed_transmissions` past `MAX_TRANSMISSIONS_TOLERANCE` and stalls admission of honest unconfirmed transactions/solutions into the BFT layer.

## The fix

Re-check the capacity limit atomically with the insertion (under a single write lock), but **only on the worker-ping fetch path**. The insertion logic is factored into a shared `insert_transmission_from_peer` helper with an `enforce_capacity_limit` flag:

- `process_transmission_from_ping` — the worker-ping path — enforces the limit, closing the TOCTOU.
- `process_transmission_from_peer` — batch-proposal materialization and all other callers — is left uncapped.

The limit is enforced only on the ping path because `process_unconfirmed_{solution,transaction}` and `insert_front`/`reinsert` must stay uncapped so real user submissions and primary re-queueing keep priority.

## Test Plan

- `test_process_transmission_from_ping_respects_capacity`: floods the worker-ping path and asserts the ready queue never grows beyond the per-worker limit.
- `test_process_transmission_from_peer_ignores_capacity`: asserts the batch-materialization path retains every transmission, even beyond the limit.

## Alternatives

The first commit took the simpler route of enforcing the cap directly inside `process_transmission_from_peer`, which was the only function performing the insertion. On review this turned out to be unsafe, because that function is shared by two callers, not just the ping path:

1. the async worker-ping fetch (the intended target), and
2. `Primary::insert_missing_transmissions_into_workers`, which materializes the transmissions of a peer's batch proposal **immediately before the node signs that batch**.

On path 2, an early return under capacity pressure silently dropped the transmission while `insert_missing_transmissions_into_workers` still returned `Ok(())`, so the node would sign and broadcast a `BatchSignature` for a batch whose transmissions it does not hold — the "certified batch referencing unmaterializable transmissions" failure this work is meant to avoid. It was also reachable without a Byzantine peer: since the unconfirmed solution/transaction paths are intentionally uncapped, `ready` can legitimately sit above `MAX_TRANSMISSIONS_PER_WORKER` under load, and while it does, every honest peer's proposal would have its transmissions dropped and get signed anyway.

Rather than propagate the drop as an error and have the node decline to sign (safer, but changes proposal-handling behaviour under load), we scoped the cap to the ping path via the split above. This matches the original intent — the batch path keeps priority and never drops ahead of signing — and is the smaller behavioural change.

## Backwards compatibility

I think this is backwards compatible, it just prevents us from exceeding the limit via the TOCTOU race.
