### PR TITLE
test(bft): cover the in-memory storage service, and fix a deadlock in it

### DIFF
--- a/node/bft/storage-service/src/memory.rs
+++ b/node/bft/storage-service/src/memory.rs
@@ -204,3 +204,307 @@ impl<N: Network> StorageService<N> for BFTMemoryService<N> {
         self.transmissions.read().clone().into_iter().collect()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use snarkvm::{
+        console::network::MainnetV0,
+        ledger::narwhal::Data,
+        prelude::{PrivateKey, Rng, TestRng, Uniform},
+    };
+
+    use bytes::Bytes;
+    use std::{sync::mpsc, time::Duration};
+
+    type CurrentNetwork = MainnetV0;
+
+    fn sample_transmission_id(rng: &mut TestRng) -> TransmissionID<CurrentNetwork> {
+        TransmissionID::Transaction(
+            <CurrentNetwork as Network>::TransactionID::from(Field::rand(rng)),
+            <CurrentNetwork as Network>::TransmissionChecksum::from(rng.random::<u128>()),
+        )
+    }
+
+    fn sample_transmission(payload: &[u8]) -> Transmission<CurrentNetwork> {
+        Transmission::Transaction(Data::Buffer(Bytes::from(payload.to_vec())))
+    }
+
+    /// Builds a batch header declaring the given transmission IDs.
+    fn sample_batch_header(
+        transmission_ids: &[TransmissionID<CurrentNetwork>],
+        rng: &mut TestRng,
+    ) -> BatchHeader<CurrentNetwork> {
+        let private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
+        // Round 1 is the only round that may carry no previous certificate IDs.
+        BatchHeader::new(
+            &private_key,
+            1,
+            0,
+            Field::rand(rng),
+            transmission_ids.iter().copied().collect(),
+            Default::default(),
+            rng,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn a_new_service_holds_nothing() {
+        let rng = &mut TestRng::default();
+        let service = BFTMemoryService::<CurrentNetwork>::new();
+        let transmission_id = sample_transmission_id(rng);
+
+        assert!(!service.contains_transmission(transmission_id));
+        assert!(service.get_transmission(transmission_id).is_none());
+        assert!(service.as_hashmap().is_empty());
+    }
+
+    #[test]
+    fn an_inserted_transmission_is_retrievable() {
+        let rng = &mut TestRng::default();
+        let service = BFTMemoryService::<CurrentNetwork>::new();
+        let transmission_id = sample_transmission_id(rng);
+        let transmission = sample_transmission(b"payload");
+        let certificate_id = Field::rand(rng);
+
+        service.insert_transmissions(
+            certificate_id,
+            indexset![transmission_id],
+            Default::default(),
+            [(transmission_id, transmission.clone())].into(),
+        );
+
+        assert!(service.contains_transmission(transmission_id));
+        assert_eq!(service.get_transmission(transmission_id), Some(transmission));
+    }
+
+    #[test]
+    fn a_transmission_survives_until_its_last_certificate_is_removed() {
+        let rng = &mut TestRng::default();
+        let service = BFTMemoryService::<CurrentNetwork>::new();
+        let transmission_id = sample_transmission_id(rng);
+        let transmission = sample_transmission(b"payload");
+        let (first, second) = (Field::rand(rng), Field::rand(rng));
+
+        // Two certificates referencing one transmission, as happens when the primary processes
+        // batches from several peers that all include the same transaction.
+        service.insert_transmissions(
+            first,
+            indexset![transmission_id],
+            Default::default(),
+            [(transmission_id, transmission.clone())].into(),
+        );
+        service.insert_transmissions(second, indexset![transmission_id], Default::default(), Default::default());
+
+        let (_, certificate_ids) = service.as_hashmap().remove(&transmission_id).unwrap();
+        assert_eq!(certificate_ids.len(), 2);
+
+        // Dropping one reference must not drop the transmission...
+        service.remove_transmissions(&first, &indexset![transmission_id]);
+        assert!(service.contains_transmission(transmission_id));
+
+        // ...but dropping the last one must.
+        service.remove_transmissions(&second, &indexset![transmission_id]);
+        assert!(!service.contains_transmission(transmission_id));
+        assert!(service.get_transmission(transmission_id).is_none());
+    }
+
+    #[test]
+    fn a_stored_transmission_is_not_overwritten_by_a_later_insert() {
+        let rng = &mut TestRng::default();
+        let service = BFTMemoryService::<CurrentNetwork>::new();
+        let transmission_id = sample_transmission_id(rng);
+        let original = sample_transmission(b"original");
+        let (first, second) = (Field::rand(rng), Field::rand(rng));
+
+        service.insert_transmissions(
+            first,
+            indexset![transmission_id],
+            Default::default(),
+            [(transmission_id, original.clone())].into(),
+        );
+        // A second certificate arrives carrying a different payload under the same ID. The stored
+        // transmission wins: the occupied branch only records the new certificate ID.
+        service.insert_transmissions(
+            second,
+            indexset![transmission_id],
+            Default::default(),
+            [(transmission_id, sample_transmission(b"replacement"))].into(),
+        );
+
+        assert_eq!(service.get_transmission(transmission_id), Some(original));
+    }
+
+    #[test]
+    fn an_aborted_transmission_id_is_contained_but_has_no_payload() {
+        let rng = &mut TestRng::default();
+        let service = BFTMemoryService::<CurrentNetwork>::new();
+        let transmission_id = sample_transmission_id(rng);
+
+        service.insert_transmissions(
+            Field::rand(rng),
+            Default::default(),
+            [transmission_id].into(),
+            Default::default(),
+        );
+
+        // The asymmetry is deliberate: an aborted ID is known to storage, but there is no
+        // transmission to hand back for it.
+        assert!(service.contains_transmission(transmission_id));
+        assert!(service.get_transmission(transmission_id).is_none());
+        assert!(service.as_hashmap().is_empty());
+    }
+
+    #[test]
+    fn aborted_transmission_ids_are_reference_counted_too() {
+        let rng = &mut TestRng::default();
+        let service = BFTMemoryService::<CurrentNetwork>::new();
+        let transmission_id = sample_transmission_id(rng);
+        let (first, second) = (Field::rand(rng), Field::rand(rng));
+
+        for certificate_id in [first, second] {
+            service.insert_transmissions(
+                certificate_id,
+                Default::default(),
+                [transmission_id].into(),
+                Default::default(),
+            );
+        }
+
+        service.remove_transmissions(&first, &indexset![transmission_id]);
+        assert!(service.contains_transmission(transmission_id));
+
+        service.remove_transmissions(&second, &indexset![transmission_id]);
+        assert!(!service.contains_transmission(transmission_id));
+    }
+
+    #[test]
+    fn removing_an_unrelated_certificate_leaves_the_transmission_in_place() {
+        let rng = &mut TestRng::default();
+        let service = BFTMemoryService::<CurrentNetwork>::new();
+        let transmission_id = sample_transmission_id(rng);
+        let certificate_id = Field::rand(rng);
+
+        service.insert_transmissions(
+            certificate_id,
+            indexset![transmission_id],
+            Default::default(),
+            [(transmission_id, sample_transmission(b"payload"))].into(),
+        );
+
+        // Removing a certificate that never referenced this transmission must not evict it.
+        service.remove_transmissions(&Field::rand(rng), &indexset![transmission_id]);
+
+        assert!(service.contains_transmission(transmission_id));
+    }
+
+    #[test]
+    fn removing_from_an_empty_service_is_a_no_op() {
+        let rng = &mut TestRng::default();
+        let service = BFTMemoryService::<CurrentNetwork>::new();
+
+        service.remove_transmissions(&Field::rand(rng), &indexset![sample_transmission_id(rng)]);
+
+        assert!(service.as_hashmap().is_empty());
+    }
+
+    #[test]
+    fn find_missing_transmissions_returns_only_what_storage_lacks() {
+        let rng = &mut TestRng::default();
+        let service = BFTMemoryService::<CurrentNetwork>::new();
+        let (stored_id, missing_id) = (sample_transmission_id(rng), sample_transmission_id(rng));
+        let missing = sample_transmission(b"missing");
+
+        service.insert_transmissions(
+            Field::rand(rng),
+            indexset![stored_id],
+            Default::default(),
+            [(stored_id, sample_transmission(b"stored"))].into(),
+        );
+
+        let batch_header = sample_batch_header(&[stored_id, missing_id], rng);
+        let result = service
+            .find_missing_transmissions(
+                &batch_header,
+                [(stored_id, sample_transmission(b"stored")), (missing_id, missing.clone())].into(),
+                Default::default(),
+            )
+            .unwrap();
+
+        // The already-stored one is dropped even though the caller offered it, so the primary does
+        // not re-insert a payload it already holds.
+        assert_eq!(result.len(), 1);
+        assert_eq!(result.get(&missing_id), Some(&missing));
+    }
+
+    #[test]
+    fn find_missing_transmissions_accepts_an_aborted_declaration_without_returning_it() {
+        let rng = &mut TestRng::default();
+        let service = BFTMemoryService::<CurrentNetwork>::new();
+        let aborted_id = sample_transmission_id(rng);
+
+        let batch_header = sample_batch_header(&[aborted_id], rng);
+        let result =
+            service.find_missing_transmissions(&batch_header, Default::default(), [aborted_id].into()).unwrap();
+
+        // An aborted declaration is satisfied without a payload, and contributes nothing to fetch.
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn find_missing_transmissions_rejects_a_declaration_that_is_neither_provided_nor_aborted() {
+        let rng = &mut TestRng::default();
+        let service = BFTMemoryService::<CurrentNetwork>::new();
+        let undeclared_id = sample_transmission_id(rng);
+
+        let batch_header = sample_batch_header(&[undeclared_id], rng);
+
+        // This is the check that stops a peer from having its certificate accepted while
+        // withholding the transmissions the certificate commits to.
+        assert!(service.find_missing_transmissions(&batch_header, Default::default(), Default::default()).is_err());
+    }
+
+    /// Documents a live deadlock rather than asserting correct behavior; ignored so it cannot hang
+    /// CI. Run it explicitly with `--ignored` to reproduce.
+    ///
+    /// When `insert_transmissions` reaches a vacant entry for a transmission ID that was neither
+    /// provided in `missing_transmissions` nor aborted, it calls `self.contains_transmission(..)`
+    /// while already holding the write guard on `self.transmissions`. That method takes a read
+    /// guard on the same lock, which `parking_lot::RwLock` does not grant re-entrantly, so the
+    /// thread parks forever.
+    ///
+    /// The production path reaches this branch through the gap between `find_missing_transmissions`
+    /// and `insert_transmissions`: the two take separate locks, so a concurrent
+    /// `remove_transmissions` can evict an entry that the first call saw and therefore skipped.
+    /// Only `BFTMemoryService` is affected. `BFTPersistentStorage` has the same shape but its
+    /// `contains_transmission` reads RocksDB rather than the lock it is holding.
+    #[test]
+    #[ignore = "reproduces a deadlock in insert_transmissions; see the PR description"]
+    fn insert_transmissions_deadlocks_on_an_unprovided_transmission() {
+        let (sender, receiver) = mpsc::channel();
+
+        // Run the call on its own thread so a hang is reported as a failure, not as a hung test
+        // binary. The thread is leaked if it parks, which is the behavior under test.
+        std::thread::spawn(move || {
+            let rng = &mut TestRng::default();
+            let service = BFTMemoryService::<CurrentNetwork>::new();
+            let transmission_id = sample_transmission_id(rng);
+
+            service.insert_transmissions(
+                Field::rand(rng),
+                indexset![transmission_id],
+                Default::default(),
+                Default::default(),
+            );
+
+            let _ = sender.send(());
+        });
+
+        assert!(
+            receiver.recv_timeout(Duration::from_secs(10)).is_ok(),
+            "insert_transmissions did not return: it re-entered its own lock",
+        );
+    }
+}

--- a/node/bft/storage-service/src/memory.rs
+++ b/node/bft/storage-service/src/memory.rs
@@ -124,8 +124,10 @@ impl<N: Network> StorageService<N> for BFTMemoryService<N> {
                 Entry::Vacant(vacant_entry) => {
                     // Retrieve the missing transmission.
                     let Some(transmission) = missing_transmissions.remove(&transmission_id) else {
+                        // note: `self.contains_transmission` would deadlock here; it read-locks
+                        // `self.transmissions`, which is write-locked above.
                         if !aborted_transmission_ids.contains(&transmission_id)
-                            && !self.contains_transmission(transmission_id)
+                            && !aborted_transmission_ids_lock.contains_key(&transmission_id)
                         {
                             error!("Failed to provide a missing transmission {transmission_id}");
                         }
@@ -466,32 +468,25 @@ mod tests {
         assert!(service.find_missing_transmissions(&batch_header, Default::default(), Default::default()).is_err());
     }
 
-    /// Documents a live deadlock rather than asserting correct behavior; ignored so it cannot hang
-    /// CI. Run it explicitly with `--ignored` to reproduce.
+    /// `insert_transmissions` must return when a declared transmission is neither provided nor
+    /// aborted, rather than deadlock on a re-entrant lock acquisition.
     ///
-    /// When `insert_transmissions` reaches a vacant entry for a transmission ID that was neither
-    /// provided in `missing_transmissions` nor aborted, it calls `self.contains_transmission(..)`
-    /// while already holding the write guard on `self.transmissions`. That method takes a read
-    /// guard on the same lock, which `parking_lot::RwLock` does not grant re-entrantly, so the
-    /// thread parks forever.
+    /// That branch is reached through the gap between `find_missing_transmissions` and
+    /// `insert_transmissions`, which take separate locks: a concurrent `remove_transmissions` can
+    /// evict an entry the first call saw and therefore left out of `missing_transmissions`.
     ///
-    /// The production path reaches this branch through the gap between `find_missing_transmissions`
-    /// and `insert_transmissions`: the two take separate locks, so a concurrent
-    /// `remove_transmissions` can evict an entry that the first call saw and therefore skipped.
-    /// Only `BFTMemoryService` is affected. `BFTPersistentStorage` has the same shape but its
-    /// `contains_transmission` reads RocksDB rather than the lock it is holding.
+    /// The call runs on its own thread so a regression fails on the timeout rather than hanging
+    /// the test binary.
     #[test]
-    #[ignore = "reproduces a deadlock in insert_transmissions; see the PR description"]
-    fn insert_transmissions_deadlocks_on_an_unprovided_transmission() {
+    fn insert_transmissions_returns_when_a_transmission_is_neither_provided_nor_aborted() {
         let (sender, receiver) = mpsc::channel();
 
-        // Run the call on its own thread so a hang is reported as a failure, not as a hung test
-        // binary. The thread is leaked if it parks, which is the behavior under test.
         std::thread::spawn(move || {
             let rng = &mut TestRng::default();
             let service = BFTMemoryService::<CurrentNetwork>::new();
             let transmission_id = sample_transmission_id(rng);
 
+            // Declare a transmission that is neither provided nor aborted.
             service.insert_transmissions(
                 Field::rand(rng),
                 indexset![transmission_id],
@@ -499,12 +494,14 @@ mod tests {
                 Default::default(),
             );
 
-            let _ = sender.send(());
+            let _ = sender.send(service.contains_transmission(transmission_id));
         });
 
-        assert!(
-            receiver.recv_timeout(Duration::from_secs(10)).is_ok(),
-            "insert_transmissions did not return: it re-entered its own lock",
-        );
+        let contains = receiver
+            .recv_timeout(Duration::from_secs(10))
+            .expect("insert_transmissions did not return: it re-entered its own lock");
+
+        // The undeliverable transmission is skipped, not recorded as a phantom entry.
+        assert!(!contains);
     }
 }


### PR DESCRIPTION
## Motivation

Part of a sweep over the workspace's least-tested crates. `BFTMemoryService` (206 lines) had no tests of its own, despite being the storage service every BFT test constructs — `worker.rs`, `bft.rs`, `sync/mod.rs`, and `helpers/storage.rs` all build their `Storage` on top of it.

That made it load-bearing test infrastructure whose own semantics were asserted nowhere. In particular its reference counting — a transmission is evicted only once the last certificate referencing it is removed — was never checked, so a regression there would surface as confusing failures in unrelated BFT tests rather than as a failure here.

Writing the tests surfaced a deadlock, which the second commit fixes.

## Commit 1 — the tests

- **The reference-counting lifecycle.** Two certificates referencing one transmission (as happens when the primary processes batches from several peers carrying the same transaction); dropping one reference keeps it, dropping the last evicts it.
- **The same lifecycle for aborted transmission IDs**, which are tracked in a separate map with the same semantics.
- **The aborted/stored asymmetry** — an aborted ID reports `contains_transmission == true` but `get_transmission == None`.
- **First writer wins.** When a second certificate arrives carrying a different payload under an ID already in storage, the stored transmission is kept and only the certificate ID is recorded.
- **Removal of an unrelated certificate** does not evict the transmission, and removal against an empty service is a no-op.
- **All three outcomes of `find_missing_transmissions`**: it returns only what storage lacks (dropping ids the caller offered but storage already holds), accepts an aborted declaration without returning it, and rejects a declaration that is neither provided nor aborted — the check that stops a peer from having a certificate accepted while withholding the transmissions it commits to.

## Commit 2 — the deadlock fix

**The bug.** In the vacant-entry arm of `insert_transmissions`, when a declared transmission ID was neither provided in `missing_transmissions` nor aborted, the code called `self.contains_transmission(transmission_id)` while already holding the write guard on `self.transmissions`. That method takes a read guard on the same lock. `parking_lot::RwLock` is not reentrant, so the thread parked forever.

**How it is reached.** `find_missing_transmissions` and `insert_transmissions` take separate locks, with no barrier between them. `Storage::insert_certificate` calls the first (via `check_certificate`) and then the second. An ID that the first call saw in storage — and therefore correctly omitted from `missing_transmissions` — can be evicted by a concurrent `remove_transmissions` before the second call runs. The second call then finds a vacant entry for an ID that is neither provided nor aborted, and parks.

The `contains_transmission` call appears to have been there to handle exactly this race benignly, by re-checking whether the entry was known after all. As written it deadlocked instead.

**The fix.** Answer the question from the guards already in scope. Reaching the vacant arm establishes that `self.transmissions` does not contain the ID, so `contains_transmission` reduces to a lookup in the aborted map — whose write guard is already held a few lines above. The check becomes:

```rust
if !aborted_transmission_ids.contains(&transmission_id)
    && !aborted_transmission_ids_lock.contains_key(&transmission_id)
```

This is an exact equivalence, not a weakening: `contains_transmission(id)` is `transmissions.contains_key(id) || aborted.contains_key(id)`, and the first disjunct is known to be `false` in this arm. Observable behavior is unchanged — an undeliverable transmission is logged and skipped — it just no longer deadlocks.

**Scope.** Only `BFTMemoryService` was affected, so the impact was on test infrastructure rather than on running nodes: production wires `BFTPersistentStorage` (`node/consensus/src/lib.rs:150`). The persistent backend has the same-shaped code at `persistent.rs:183`, but its `contains_transmission` reads RocksDB rather than the `cache_transmissions` mutex it is holding, so it does not deadlock and is left alone.

The repro from commit 1 is no longer `#[ignore]`d. It now asserts that the call returns and that no phantom entry is left behind, and it runs on its own thread with a 10s watchdog so that a regression fails on the timeout rather than hanging the test binary.

## Test Plan

```
cargo test -p snarkos-node-bft-storage-service --features memory,persistent
```

14 passing, 0 ignored. The feature set matches what CI already runs for this member.

I confirmed the regression test actually guards the fix by reverting the one-line change and re-running it — it fails on the watchdog timeout, then passes again with the fix restored.

Also verified:

- `cargo clippy -p snarkos-node-bft-storage-service --features memory,persistent --all-targets`
- `cargo check -p snarkos-node-bft-storage-service --features memory,persistent,locktick --all-targets`, since the lock type is feature-swapped
- `cargo test -p snarkos-node-bft --lib helpers::storage` — the 8 tests that exercise this service through `Storage`, all passing

## Documentation

None needed.

## Backwards compatibility

No behavior change; nothing to guard by `ConsensusVersion`.
