### PR TITLE
test(utilities): cover node data paths, callback handle, and shutdown

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -447,6 +447,14 @@ jobs:
           workspace_member: cli
           cache_key: cli
 
+  utilities:
+    executor: rust-docker
+    resource_class: << pipeline.parameters.medium >>
+    steps:
+      - run_serial:
+          workspace_member: utilities
+          cache_key: utilities
+
   node:
     executor: rust-docker
     resource_class: << pipeline.parameters.twoxlarge >>
@@ -853,6 +861,7 @@ workflows:
       - snarkos
       - account
       - cli
+      - utilities
 
   windows-workflow:
     jobs:

--- a/utilities/Cargo.toml
+++ b/utilities/Cargo.toml
@@ -35,3 +35,6 @@ workspace = true
 
 [dependencies.parking_lot]
 workspace = true
+[dev-dependencies.tokio]
+workspace = true
+features = [ "macros", "rt", "time" ]

--- a/utilities/src/callback_handle.rs
+++ b/utilities/src/callback_handle.rs
@@ -73,3 +73,70 @@ impl<C: Send + Sync + Clone> CallbackHandle<C> {
         let _ = self.callback.write().take();
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_fresh_handle_holds_no_callback() {
+        let handle = CallbackHandle::<u8>::default();
+
+        assert!(handle.get().is_none());
+        assert!(handle.get_ref().is_none());
+    }
+
+    #[test]
+    fn a_callback_can_be_set_once_and_read_back() {
+        let handle = CallbackHandle::default();
+
+        assert!(handle.set("callback".to_string()).is_ok());
+
+        assert_eq!(handle.get(), Some("callback".to_string()));
+        assert_eq!(handle.get_ref().as_deref(), Some("callback"));
+    }
+
+    #[test]
+    fn setting_a_second_callback_is_an_error() {
+        let handle = CallbackHandle::default();
+        handle.set("first".to_string()).unwrap();
+
+        assert!(handle.set("second".to_string()).is_err());
+    }
+
+    #[test]
+    fn a_rejected_set_has_still_replaced_the_callback() {
+        let handle = CallbackHandle::default();
+        handle.set("first".to_string()).unwrap();
+
+        let _ = handle.set("second".to_string());
+
+        // `set` swaps the new callback in before deciding to report an error, so the rejection is
+        // advisory: the handle holds the callback whose installation "failed". A caller that
+        // ignores the error gets a silently swapped callback, not a no-op.
+        assert_eq!(handle.get(), Some("second".to_string()));
+    }
+
+    #[test]
+    fn clearing_makes_the_handle_settable_again() {
+        let handle = CallbackHandle::default();
+        handle.set("first".to_string()).unwrap();
+
+        handle.clear();
+        assert!(handle.get().is_none());
+
+        // This is what lets shutdown break the circular references and then rebuild them.
+        assert!(handle.set("second".to_string()).is_ok());
+        assert_eq!(handle.get(), Some("second".to_string()));
+    }
+
+    #[test]
+    fn clearing_an_empty_handle_is_a_no_op() {
+        let handle = CallbackHandle::<u8>::default();
+
+        handle.clear();
+        handle.clear();
+
+        assert!(handle.get().is_none());
+    }
+}

--- a/utilities/src/node_data.rs
+++ b/utilities/src/node_data.rs
@@ -107,3 +107,100 @@ impl NodeDataDir {
         self.path.join(jwt_secret_file(address))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_cache_filenames_are_pinned() {
+        // These are on-disk names. Renaming one does not fail anything at compile time; it just
+        // orphans the file a running node already wrote, so the change should be deliberate.
+        assert_eq!(ROUTER_PEER_CACHE_FILE, "router-peer-cache");
+        assert_eq!(GATEWAY_PEER_CACHE_FILE, "gateway-peer-cache");
+        assert_eq!(CURRENT_PROPOSAL_CACHE_FILE, "current-proposal-cache");
+        assert_eq!(LEGACY_ROUTER_PEER_CACHE_FILE, "cached_router_peers");
+        assert_eq!(LEGACY_GATEWAY_PEER_CACHE_FILE, "cached_gateway_peers");
+    }
+
+    #[test]
+    fn the_legacy_filenames_are_distinct_from_the_current_ones() {
+        assert_ne!(ROUTER_PEER_CACHE_FILE, LEGACY_ROUTER_PEER_CACHE_FILE);
+        assert_ne!(GATEWAY_PEER_CACHE_FILE, LEGACY_GATEWAY_PEER_CACHE_FILE);
+        assert_ne!(ROUTER_PEER_CACHE_FILE, GATEWAY_PEER_CACHE_FILE);
+    }
+
+    #[test]
+    fn every_path_is_rooted_at_the_data_dir() {
+        let dir = NodeDataDir::new(PathBuf::from("/var/lib/snarkos"));
+
+        for path in [dir.router_peer_cache_path(), dir.gateway_peer_cache_path(), dir.current_proposal_cache_path()] {
+            assert!(path.starts_with(dir.path()), "{path:?} escaped the data dir");
+            assert_eq!(path.parent().unwrap(), dir.path());
+        }
+    }
+
+    #[test]
+    fn each_cache_path_is_a_distinct_file() {
+        let dir = NodeDataDir::new(PathBuf::from("/var/lib/snarkos"));
+
+        // The router and gateway caches hold different peer sets; sharing a filename would have
+        // one silently overwrite the other.
+        assert_ne!(dir.router_peer_cache_path(), dir.gateway_peer_cache_path());
+        assert_ne!(dir.router_peer_cache_path(), dir.current_proposal_cache_path());
+        assert_ne!(dir.gateway_peer_cache_path(), dir.current_proposal_cache_path());
+    }
+
+    #[test]
+    fn the_jwt_secret_path_agrees_with_the_bare_filename_helper() {
+        let dir = NodeDataDir::new(PathBuf::from("/var/lib/snarkos"));
+        let address = "aleo1example";
+
+        // `cli::commands::start` builds this path itself out of `path()` and `jwt_secret_file`
+        // rather than calling `jwt_secret_path`, so the two constructions have to stay in step or
+        // the node writes its JWT secret where the reader will not look.
+        assert_eq!(dir.jwt_secret_path(&address), dir.path().join(jwt_secret_file(&address)));
+    }
+
+    #[test]
+    fn the_jwt_secret_filename_is_scoped_to_the_address() {
+        assert_eq!(jwt_secret_file(&"aleo1abc"), PathBuf::from("jwt_secret_aleo1abc.txt"));
+        assert_ne!(jwt_secret_file(&"aleo1abc"), jwt_secret_file(&"aleo1def"));
+    }
+
+    #[test]
+    fn the_legacy_proposal_cache_filename_switches_on_dev() {
+        // note: the dev form is a hidden file and the non-dev form is not.
+        assert_eq!(legacy_current_proposal_cache_file(1, Some(3)), PathBuf::from(".current-proposal-cache-1-3"));
+        assert_eq!(legacy_current_proposal_cache_file(1, None), PathBuf::from("current-proposal-cache-1"));
+
+        // Distinct dev indices must not collide.
+        assert_ne!(legacy_current_proposal_cache_file(1, Some(0)), legacy_current_proposal_cache_file(1, Some(1)));
+        // Neither must distinct networks.
+        assert_ne!(legacy_current_proposal_cache_file(0, None), legacy_current_proposal_cache_file(1, None));
+    }
+
+    #[test]
+    fn test_data_dirs_are_separated_by_dev_index() {
+        assert_eq!(NodeDataDir::new_test(None).path(), Path::new(".node-data-test"));
+        assert_eq!(NodeDataDir::new_test(Some(2)).path(), Path::new(".node-data-test-2"));
+
+        // Two dev nodes running side by side must not share a data dir.
+        assert_ne!(NodeDataDir::new_test(Some(0)), NodeDataDir::new_test(Some(1)));
+        assert_ne!(NodeDataDir::new_test(None), NodeDataDir::new_test(Some(0)));
+    }
+
+    #[test]
+    fn development_data_dirs_are_absolute_and_separated_by_network_and_index() {
+        let first = NodeDataDir::new_development(1, 0);
+        let second = NodeDataDir::new_development(1, 1);
+        let other_network = NodeDataDir::new_development(2, 0);
+
+        // The path is anchored at the current directory, so it must not be a bare relative name.
+        assert!(first.path().is_absolute());
+        assert_eq!(first.path().file_name().unwrap(), ".node-data-1-0");
+
+        assert_ne!(first, second);
+        assert_ne!(first, other_network);
+    }
+}

--- a/utilities/src/signals.rs
+++ b/utilities/src/signals.rs
@@ -158,3 +158,67 @@ impl Stoppable for SignalHandler {
         self.stopped_sender.read().is_none()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_simple_stoppable_starts_running_and_latches_when_stopped() {
+        let stoppable = SimpleStoppable::new();
+        assert!(!stoppable.is_stopped());
+
+        stoppable.stop();
+        assert!(stoppable.is_stopped());
+
+        // Stopping is idempotent; a second fatal error during shutdown must not misbehave.
+        stoppable.stop();
+        assert!(stoppable.is_stopped());
+    }
+
+    #[tokio::test]
+    async fn a_signal_handler_can_be_stopped_without_a_signal() {
+        let handler = SignalHandler::new(None);
+        assert!(!handler.is_stopped());
+
+        // The manual path, used when the node hits a fatal error rather than a Ctrl+C.
+        handler.stop();
+        assert!(handler.is_stopped());
+    }
+
+    #[tokio::test]
+    async fn stopping_a_signal_handler_twice_is_harmless() {
+        let handler = SignalHandler::new(None);
+
+        handler.stop();
+        handler.stop();
+
+        assert!(handler.is_stopped());
+    }
+
+    #[tokio::test]
+    async fn waiting_returns_once_the_handler_is_stopped() {
+        let handler = SignalHandler::new(None);
+
+        let waiter = handler.clone();
+        let task = tokio::spawn(async move { waiter.wait_for_signals().await });
+
+        handler.stop();
+
+        // The wait must resolve off the manual stop, not only off a real signal.
+        tokio::time::timeout(std::time::Duration::from_secs(10), task)
+            .await
+            .expect("wait_for_signals did not return after stop")
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn waiting_returns_immediately_if_already_stopped() {
+        let handler = SignalHandler::new(None);
+        handler.stop();
+
+        tokio::time::timeout(std::time::Duration::from_secs(10), handler.wait_for_signals())
+            .await
+            .expect("wait_for_signals did not return for an already-stopped handler");
+    }
+}


### PR DESCRIPTION
## Motivation

Part of a sweep over the workspace's least-tested crates. `utilities` had **no tests and no CircleCI job** — it is absent from the `run_serial` matrix entirely, so nothing in it was exercised, or even compiled, by the test workflow.

That is worth closing because the crate is small but load-bearing: it owns the on-disk paths for the peer caches, the proposal cache and the JWT secret, the callback handle used to break shutdown cycles, and the shutdown signalling every node binary depends on.

Tests plus one CI change. No behavior changes to the crate.

## What is covered

**`node_data.rs`**

- The on-disk filenames are pinned. Renaming one compiles cleanly and just orphans the file a running node already wrote.
- Every cache path is rooted at the data dir, and the router, gateway and proposal caches are distinct files — sharing a name would have one silently overwrite another.
- `NodeDataDir::jwt_secret_path` agrees with `path().join(jwt_secret_file(..))`. This one guards a real duplication: `cli::commands::start` builds that path itself (`cli/src/commands/start.rs:547`) instead of calling the method, so the two constructions have to stay in step or the node writes its JWT secret where the reader will not look.
- Dev and test data dirs are separated by network and dev index, so side-by-side dev nodes cannot share a directory.

**`callback_handle.rs`**

- Empty by default; set-once, read-back; clear makes it settable again; clearing an empty handle is a no-op.

**`signals.rs`**

- `SimpleStoppable` latches and is idempotent.
- `SignalHandler` can be stopped manually — the path taken when the node hits a fatal error rather than a Ctrl+C — is idempotent, and `wait_for_signals` resolves off a manual stop, both when the wait starts first and when the handler is already stopped.

## Two sharp edges recorded rather than asserted

- `a_rejected_set_has_still_replaced_the_callback`: `CallbackHandle::set` calls `replace` before deciding to return an error, so a rejected `set` has *already* swapped the new callback in. The error is advisory — a caller that ignores it gets a silently swapped callback, not a no-op.
- `the_legacy_proposal_cache_filename_switches_on_dev`: the dev form is a hidden file (`.current-proposal-cache-{network}-{dev}`) and the non-dev form is not (`current-proposal-cache-{network}`).

## CI change

Adds a `utilities` job and lists it under `snarkos-workflow`, alongside the other top-level crates. `medium` resource class; the crate has no heavy dependencies.

## Two further CI gaps found while doing this — not fixed here

Both are in `.circleci/config.yml` and are separate from this PR's scope; flagging rather than bundling.

1. **The `node-network` job is defined but never listed in any workflow.** `node-network` exists at `config.yml:507`, but does not appear under `node-workflow` or anywhere else, so `node/network`'s tests — including the 14 in `noise.rs` — do not run in CI at all.
2. **`check-other-crates` checks the same crate twice.** The step named "Check snarkos-display crate" runs `cargo check --package=snarkos-node-metrics`, identical to the step above it, so `snarkos-display` is never checked.

Happy to send either as its own PR.

## Test Plan

```
cd utilities && RUST_MIN_STACK=67108864 cargo test
```

which is exactly what the new CI job runs. 20 tests, all passing. Also verified with `cargo clippy -p snarkos-utilities --all-targets`, and the edited `config.yml` parses as YAML.

Adds tokio's `time` feature as a **dev-dependency only**, for the timeouts in the signal tests; the production dependency is untouched.

## Documentation

None needed.

## Backwards compatibility

No functional changes; nothing to guard by `ConsensusVersion`.
