### PR TITLE
test(network): pin the NodeType wire encoding

### DIFF
--- a/node/network/src/node_type.rs
+++ b/node/network/src/node_type.rs
@@ -86,3 +86,89 @@ impl FromBytes for NodeType {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every variant, so that adding one to the enum without extending this list is a compile
+    /// error rather than a silently untested case.
+    const ALL: [NodeType; 4] = [NodeType::Client, NodeType::Prover, NodeType::Validator, NodeType::BootstrapClient];
+
+    #[test]
+    fn every_variant_round_trips_through_bytes() {
+        for node_type in ALL {
+            let bytes = node_type.to_bytes_le().unwrap();
+            assert_eq!(NodeType::read_le(&*bytes).unwrap(), node_type);
+        }
+    }
+
+    #[test]
+    fn the_wire_discriminants_are_pinned() {
+        // These bytes go out on the wire in every `ChallengeRequest` and `Ping`, so they are a
+        // compatibility surface: reordering the variants silently repurposes them.
+        assert_eq!(NodeType::Client.to_bytes_le().unwrap(), [0]);
+        assert_eq!(NodeType::Prover.to_bytes_le().unwrap(), [1]);
+        assert_eq!(NodeType::Validator.to_bytes_le().unwrap(), [2]);
+        assert_eq!(NodeType::BootstrapClient.to_bytes_le().unwrap(), [3]);
+    }
+
+    #[test]
+    fn each_discriminant_decodes_to_its_own_variant() {
+        for (discriminant, expected) in ALL.iter().enumerate() {
+            let decoded = NodeType::read_le(&[discriminant as u8][..]).unwrap();
+            assert_eq!(decoded, *expected);
+        }
+    }
+
+    #[test]
+    fn an_unknown_discriminant_is_rejected() {
+        // A peer is free to send anything here, so the first byte past the valid range and the
+        // top of the byte space both have to be refused rather than mapped onto a variant.
+        for discriminant in [ALL.len() as u8, 100, u8::MAX] {
+            assert!(NodeType::read_le(&[discriminant][..]).is_err());
+        }
+    }
+
+    #[test]
+    fn a_truncated_encoding_is_rejected() {
+        assert!(NodeType::read_le(&[][..]).is_err());
+    }
+
+    #[test]
+    fn the_predicates_agree_with_the_variant() {
+        assert!(NodeType::Client.is_client());
+        assert!(NodeType::Prover.is_prover());
+        assert!(NodeType::Validator.is_validator());
+
+        // Each predicate matches exactly one variant.
+        for node_type in ALL {
+            let matches =
+                [node_type.is_client(), node_type.is_prover(), node_type.is_validator()].iter().filter(|m| **m).count();
+            assert!(matches <= 1, "{node_type} matched more than one predicate");
+        }
+    }
+
+    #[test]
+    fn a_bootstrap_client_is_not_a_client_by_the_predicates() {
+        // Despite the name, `BootstrapClient` satisfies none of the predicates, and there is no
+        // predicate of its own. Call sites that mean "any client" have to say so explicitly, as
+        // `Client::on_connect` does by comparing the variant directly.
+        assert!(!NodeType::BootstrapClient.is_client());
+        assert!(!NodeType::BootstrapClient.is_prover());
+        assert!(!NodeType::BootstrapClient.is_validator());
+    }
+
+    #[test]
+    fn every_variant_has_a_distinct_description_and_display_form() {
+        let descriptions: Vec<String> = ALL.iter().map(|node_type| node_type.description().to_string()).collect();
+        let displays: Vec<String> = ALL.iter().map(|node_type| node_type.to_string()).collect();
+
+        for list in [&descriptions, &displays] {
+            for (i, entry) in list.iter().enumerate() {
+                assert!(!entry.is_empty());
+                assert!(!list[i + 1..].contains(entry), "duplicate label: {entry}");
+            }
+        }
+    }
+}

--- a/node/router/messages/src/challenge_request.rs
+++ b/node/router/messages/src/challenge_request.rs
@@ -115,11 +115,14 @@ pub mod prop_tests {
     }
 
     pub fn any_node_type() -> BoxedStrategy<NodeType> {
-        (0..=2)
+        // Must cover every variant: this strategy is what round-trips `NodeType` through a real
+        // `ChallengeRequest` and `Ping`, and a variant missing here is a variant never encoded.
+        (0..=3)
             .prop_map(|id| match id {
                 0 => NodeType::Client,
                 1 => NodeType::Prover,
                 2 => NodeType::Validator,
+                3 => NodeType::BootstrapClient,
                 _ => unreachable!(),
             })
             .boxed()


### PR DESCRIPTION
## Motivation

Part of a sweep over the workspace's least-tested crates. `NodeType` is a wire-format discriminant — it is encoded into every `ChallengeRequest` and every `Ping` — but nothing tested it directly.

It was round-tripped only indirectly, via the `challenge_request_roundtrip` and `ping_roundtrip` proptests. Those share a strategy, `any_node_type`, which generated `0..=2`. `NodeType::BootstrapClient` was therefore never encoded by any test in the repo.

This is a test-only PR. No behavior changes.

## What is covered

In `node/network/src/node_type.rs`:

- **Every variant round-trips**, driven off a single `ALL` array so that adding a variant without extending the list is a compile error rather than a silently untested case.
- **The discriminant bytes are pinned explicitly** — `Client` is `0`, `Prover` is `1`, `Validator` is `2`, `BootstrapClient` is `3`. This is the assertion a round-trip test cannot make: reordering the variants moves the reader and the writer together, so a round-trip still passes while the bytes on the wire now mean something else. These bytes are a compatibility surface with every peer on the network.
- **Each discriminant decodes to its own variant**, so the `read_le` match arms cannot be transposed.
- **Unknown discriminants are rejected** — the first byte past the valid range, plus `u8::MAX`. A peer can send anything here.
- **A truncated encoding is rejected.**
- **The predicates match exactly one variant each**, and none of them match `BootstrapClient` (see below).

In `node/router/messages/src/challenge_request.rs`:

- `any_node_type` widened from `0..=2` to `0..=3`, so `BootstrapClient` now round-trips through the real message encodings too. One line plus a comment; it is here rather than in its own PR because it is the other half of the same gap.

## A sharp edge worth recording

`a_bootstrap_client_is_not_a_client_by_the_predicates` pins something a reader might reasonably assume otherwise: despite the name, `NodeType::BootstrapClient` satisfies neither `is_client()` nor any other predicate, and has no predicate of its own.

Call sites that mean "any client" have to compare the variant directly, as `Client::on_connect` does (`node/src/client/router.rs:76`). Worth being aware of at `node/router/src/inbound.rs:195`, which gates on `is_client() || is_validator()`.

I have not changed any of that here — just pinned it, so a future change to the predicates is a deliberate one.

## Test Plan

```
cargo test -p snarkos-node-network --lib node_type
cargo test -p snarkos-node-router-messages --lib
```

8 new tests in `node/network`, all passing; the 15 existing `node/router/messages` tests still pass with the widened strategy. Also verified with `cargo clippy -p snarkos-node-network -p snarkos-node-router-messages --all-targets`.

## Documentation

None needed.

## Backwards compatibility

No functional changes. The pinned discriminants match what is already on the wire; this PR asserts the existing encoding rather than altering it.
