### PR TITLE
ci: check the display crate, and fix the serial wiring that hid behind it

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -671,7 +671,7 @@ jobs:
       - run:
           name: Check snarkos-display crate
           no_output_timeout: 10m
-          command: cargo check --package=snarkos-node-metrics --all-features
+          command: cargo check --package=snarkos-display --all-features
 
       - clear_environment:
           cache_key: v4.2.0-rust-1.88.0-check-other-crates-cache

--- a/display/Cargo.toml
+++ b/display/Cargo.toml
@@ -19,7 +19,7 @@ edition = "2024"
 [features]
 default = [ ]
 locktick = [ "snarkos-node/locktick", "snarkos-utilities/locktick" ]
-serial = [ "snarkvm/serial" ]
+serial = [ "snarkvm/serial", "snarkos-node/serial" ]
 
 [dependencies.anyhow]
 workspace = true

--- a/node/cdn/Cargo.toml
+++ b/node/cdn/Cargo.toml
@@ -19,7 +19,7 @@ edition = "2024"
 [features]
 default = [ ]
 serial = [ 
-  "snarkos-node-metrics/locktick",
+  "snarkos-node-metrics/serial",
   "snarkvm/serial",
 ]
 locktick = [

--- a/node/consensus/Cargo.toml
+++ b/node/consensus/Cargo.toml
@@ -30,6 +30,7 @@ metrics = [ "dep:snarkos-node-metrics" ]
 telemetry = [ "snarkos-node-bft/telemetry" ]
 cuda = [ "snarkvm/cuda", "snarkos-account/cuda", "snarkos-node-bft-ledger-service/cuda" ]
 serial = [ 
+  "snarkos-node-bft/serial",
   "snarkos-node-bft-ledger-service/serial",
   "snarkos-node-metrics/serial",
   "snarkvm/serial"


### PR DESCRIPTION
## Motivation

While auditing which workspace members CI actually runs tests for, the `check-other-crates` job turned out to contain a copy-paste bug:

```yaml
      - run:
          name: Check snarkos-node-metrics crate
          command: cargo check --package=snarkos-node-metrics --all-features
      - run:
          name: Check snarkos-display crate
          command: cargo check --package=snarkos-node-metrics --all-features   # <- same package
```

`snarkos-display` is not in the test matrix either, so nothing in CI built it at all.

Pointing the step at the right package does not compile. Chasing that down turned up the same defect in two more crates, and the audit that found it is below.

## The defect

Every crate in the workspace that exposes a `serial` feature is expected to pass `serial` down its own dependency tree — the root `snarkos` crate does this exhaustively, and so do `snarkos-cli`, `snarkos-node`, `snarkos-node-bft` and others.

When a crate enables `snarkvm/serial` but *doesn't* propagate `serial` to a snarkOS dependency that uses `cfg_iter!`, that dependency keeps the rayon branch of the macro while snarkvm's types have stopped implementing the rayon traits. The result is a hard compile error:

```
error[E0599]: the method `par_iter` exists for reference `&Transactions<N>`,
              but its trait bounds were not satisfied
```

Three crates had it. In each case the feature was unusable, not merely mis-wired:

| Crate | Wiring | Effect |
|---|---|---|
| `snarkos-display` | `serial = ["snarkvm/serial"]`, no `snarkos-node/serial` | breaks in `snarkos-node-metrics` |
| `snarkos-node-cdn` | listed `snarkos-node-metrics/`**`locktick`**, copied from the `locktick` block below it | breaks in `snarkos-node-metrics`, and dragged the locktick instrumentation into a `serial` build |
| `snarkos-node-consensus` | no `snarkos-node-bft/serial` | breaks in `snarkos-node-bft`; also broke `snarkos-node-rest` transitively via `snarkos-node-consensus/serial` |

None of these were caught because no job builds these combinations.

## Commits

1. **`ci: actually check the snarkos-display crate`** — points the step at `snarkos-display`, and propagates `snarkos-node/serial` from `snarkos-display` so that the step passes.
2. **`fix: propagate the serial feature to every snarkOS dependency`** — the `snarkos-node-cdn` and `snarkos-node-consensus` wiring.

## Test Plan

The command the fixed job runs:

```
cargo check --package=snarkos-display --all-features
```

And the sweep that found the rest — every workspace crate exposing a `serial` feature, all twelve passing after this change (`snarkos`, `snarkos-cli`, `snarkos-display`, `snarkos-node`, `snarkos-node-bft`, `snarkos-node-bft-ledger-service`, `snarkos-node-cdn`, `snarkos-node-consensus`, `snarkos-node-metrics`, `snarkos-node-rest`, `snarkos-node-router`, `snarkos-node-sync`):

```
for p in <the twelve>; do cargo check -p $p --features serial; done
```

Before this change, `snarkos-display --all-features`, `snarkos-node-cdn --features serial`, `snarkos-node-consensus --features serial` and `snarkos-node-rest --features serial` all fail to compile.

## The rest of the coverage audit

Mapping every workspace member to a CI job, and every job to a workflow that references it, four members had no tests run:

- **`node/network`** — job defined at `config.yml:507` but listed in no workflow, so its 17 tests never ran. Deliberately **not** fixed here; it is covered by a separate branch.
- **`utilities`** — no job at all. Covered by #4402.
- **`display`** and **`node/metrics`** — no test job; they are `cargo check`-only by way of `check-other-crates`, which is what this PR repairs. Both currently have zero tests, so I have not added `run_serial` jobs for them — happy to if you would rather have the coverage wired up in advance.

Every other member is covered.

## Documentation

None needed.

## Backwards compatibility

No runtime behavior change on default features. `snarkos-node-cdn` built with `serial` no longer enables locktick instrumentation, which is the stated intent of that feature. Nothing to guard by `ConsensusVersion`.
