### PR TITLE
refactor: fold the telemetry feature into metrics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -276,11 +276,13 @@ name = "snarkos"
 path = "snarkos/main.rs"
 
 [features]
-default = [ "snarkos-cli/metrics", "snarkos-node-metrics", "snarkos-node/metrics", "snarkos-node-cdn/metrics", "telemetry" ]
+default = [ "snarkos-cli/metrics", "snarkos-node-metrics", "snarkos-node/metrics", "snarkos-node-cdn/metrics" ]
 history = [ "snarkos-node/history" ]
 history-staking-rewards = [ "snarkos-node/history-staking-rewards" ]
 slipstream-plugins = [ "snarkos-node/slipstream-plugins", "snarkos-cli/slipstream-plugins" ]
-telemetry = [ "snarkos-node/telemetry" ]
+# Deprecated alias for the metrics feature, which now carries the validator telemetry.
+# Retained so that build commands naming this feature keep resolving.
+telemetry = [ "snarkos-node/metrics" ]
 cuda = [
   "snarkos-account/cuda",
   "snarkos-cli/cuda",

--- a/README.md
+++ b/README.md
@@ -202,7 +202,8 @@ Once enabled, telemetry metrics are available through:
     // GET /{network}/validators/participation?metadata={true}
     ```
 
-Telemetry is enabled by default, and you can still explicitly specify the `telemetry` feature flag:
+Telemetry is part of the `metrics` feature, which is enabled by default. The `telemetry` feature flag
+is kept as an alias for `metrics`, so commands that name it explicitly still work:
 
 #### 1. [Installation](#2.3-installation)
 
@@ -586,12 +587,14 @@ cargo run --release -- clean --dev <NODE_ID>
 
 ## 6.4 Feature Flags
 
-By default, the metrics and telemetry features are turned on for some internal crates.
+By default, the metrics feature is turned on for some internal crates. It carries the validator
+telemetry described in [Validator Telemetry Metrics](#321-validator-telemetry-metrics).
 
 * **history** -
   Enables a /history REST endpoint.
 * **telemetry** -
-  Allows the node to upload telemetry data.
+  Deprecated alias for **metrics**, kept so that existing build commands keep working.
+  Validator telemetry is part of **metrics**.
 * **cuda** -
   Allows some operations to run on the (NVidia) GPU, instead of on the CPU. See [CUDA acceleration for provers](#optional-cuda-acceleration-for-provers) for install tips and current puzzle status.
 * **locktick** -

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -36,6 +36,7 @@ metrics = [
   "dep:snarkos-node-metrics",
   "snarkos-node-bft/metrics",
   "snarkos-node-consensus/metrics",
+  "snarkos-node-rest/metrics",
   "snarkos-node-router/metrics",
   "snarkos-node-tcp/metrics",
   "snarkvm/metrics",
@@ -44,7 +45,6 @@ metrics = [
 history = [ "snarkos-node-rest/history", "snarkvm/history" ]
 history-staking-rewards = [ "snarkos-node-rest/history-staking-rewards", "snarkvm/history-staking-rewards" ]
 slipstream-plugins = [ "snarkos-node-rest/slipstream-plugins", "snarkvm/slipstream-plugins" ]
-telemetry = [ "snarkos-node-bft/telemetry", "snarkos-node-consensus/telemetry", "snarkos-node-rest/telemetry" ]
 cuda = [
   "snarkvm/cuda",
   "snarkos-account/cuda",

--- a/node/bft/Cargo.toml
+++ b/node/bft/Cargo.toml
@@ -18,7 +18,6 @@ edition = "2024"
 
 [features]
 default = [ ]
-telemetry = [ ]
 locktick = [
   "dep:locktick",
   "snarkos-node-bft-ledger-service/locktick",

--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -800,7 +800,7 @@ impl<N: Network> BFT<N> {
             }
 
             // Update the validator telemetry.
-            #[cfg(feature = "telemetry")]
+            #[cfg(feature = "metrics")]
             self.primary().gateway().validator_telemetry().insert_subdag(&Subdag::from(commit_subdag)?);
         }
 

--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(feature = "telemetry")]
+#[cfg(feature = "metrics")]
 use crate::helpers::{Telemetry, TelemetryWorker};
 use crate::{
     CONTEXT,
@@ -229,13 +229,13 @@ pub struct InnerGateway<N: Network> {
     /// The collection of both candidate and connected peers.
     peer_pool: RwLock<HashMap<SocketAddr, Peer<N>>>,
     /// The handle to the validator telemetry tracker.
-    #[cfg(feature = "telemetry")]
+    #[cfg(feature = "metrics")]
     validator_telemetry: Telemetry<N>,
     /// The telemetry worker, taken and spawned by `run`.
     ///
     /// This is a one-shot handoff from `new` to `run`, not a hot-path lock: the telemetry
     /// state itself lives in the worker task, and is never shared.
-    #[cfg(feature = "telemetry")]
+    #[cfg(feature = "metrics")]
     telemetry_worker: Mutex<Option<TelemetryWorker<N>>>,
     /// The primary sender.
     primary_sender: OnceCell<PrimarySender<N>>,
@@ -331,7 +331,7 @@ impl<N: Network> Gateway<N> {
         initial_peers.extend(trusted_validators.iter().copied().map(|addr| (addr, Peer::new_candidate(addr, true))));
 
         // Initialize the validator telemetry. The worker is spawned later, by `run`.
-        #[cfg(feature = "telemetry")]
+        #[cfg(feature = "metrics")]
         let (validator_telemetry, telemetry_worker) = Telemetry::new();
 
         // Return the gateway.
@@ -343,9 +343,9 @@ impl<N: Network> Gateway<N> {
             cache: Default::default(),
             resolver: Default::default(),
             peer_pool: RwLock::new(initial_peers),
-            #[cfg(feature = "telemetry")]
+            #[cfg(feature = "metrics")]
             validator_telemetry,
-            #[cfg(feature = "telemetry")]
+            #[cfg(feature = "metrics")]
             telemetry_worker: Mutex::new(Some(telemetry_worker)),
             primary_sender: Default::default(),
             worker_senders: Default::default(),
@@ -382,7 +382,7 @@ impl<N: Network> Gateway<N> {
 
         // Spawn the validator telemetry worker, which owns all telemetry state.
         // It is registered in `handles`, so `shut_down` aborts it along with everything else.
-        #[cfg(feature = "telemetry")]
+        #[cfg(feature = "metrics")]
         if let Some(telemetry_worker) = self.telemetry_worker.lock().take() {
             self.spawn(telemetry_worker.run());
         }
@@ -495,7 +495,7 @@ impl<N: Network> Gateway<N> {
     }
 
     /// Returns the validator telemetry.
-    #[cfg(feature = "telemetry")]
+    #[cfg(feature = "metrics")]
     pub fn validator_telemetry(&self) -> &Telemetry<N> {
         &self.validator_telemetry
     }
@@ -1019,7 +1019,7 @@ impl<N: Network> Gateway<N> {
         // Log the connected validators.
         self.log_connected_validators();
         // Log the validator participation scores.
-        #[cfg(feature = "telemetry")]
+        #[cfg(feature = "metrics")]
         self.log_participation_scores();
         // Keep the trusted validators connected.
         self.handle_trusted_validators();
@@ -1149,7 +1149,7 @@ impl<N: Network> Gateway<N> {
     }
 
     // Logs the validator participation scores.
-    #[cfg(feature = "telemetry")]
+    #[cfg(feature = "metrics")]
     fn log_participation_scores(&self) {
         if let Ok(committee_lookback) = self.ledger.get_committee_lookback_for_round(self.storage.current_round()) {
             // Retrieve the participation scores.

--- a/node/bft/src/helpers/mod.rs
+++ b/node/bft/src/helpers/mod.rs
@@ -43,9 +43,9 @@ pub use signed_proposals::*;
 pub mod storage;
 pub use storage::*;
 
-#[cfg(feature = "telemetry")]
+#[cfg(feature = "metrics")]
 pub mod telemetry;
-#[cfg(feature = "telemetry")]
+#[cfg(feature = "metrics")]
 pub use telemetry::*;
 
 pub mod timestamp;

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -445,7 +445,7 @@ impl<N: Network> Sync<N> {
                 }
 
                 // Update the validator telemetry.
-                #[cfg(feature = "telemetry")]
+                #[cfg(feature = "metrics")]
                 self.gateway.validator_telemetry().insert_subdag(subdag);
             }
         }

--- a/node/consensus/Cargo.toml
+++ b/node/consensus/Cargo.toml
@@ -26,8 +26,7 @@ locktick = [
   "snarkos-node-metrics/locktick",
   "snarkvm/locktick"
 ]
-metrics = [ "dep:snarkos-node-metrics" ]
-telemetry = [ "snarkos-node-bft/telemetry" ]
+metrics = [ "dep:snarkos-node-metrics", "snarkos-node-bft/metrics" ]
 cuda = [ "snarkvm/cuda", "snarkos-account/cuda", "snarkos-node-bft-ledger-service/cuda" ]
 serial = [ 
   "snarkos-node-bft/serial",

--- a/node/consensus/src/lib.rs
+++ b/node/consensus/src/lib.rs
@@ -662,7 +662,7 @@ impl<N: Network> Consensus<N> {
         #[cfg(feature = "metrics")]
         metrics::histogram(metrics::consensus::ADVANCE_TO_NEXT_BLOCK_SECS, advance_elapsed.as_secs_f64());
 
-        #[cfg(feature = "telemetry")]
+        #[cfg(feature = "metrics")]
         // Fetch the committee lookback for the latest round.
         // Note: Do not abort here if this returns an error, because the committee is only needed for telemetry,
         // not for block advancement itself.
@@ -716,7 +716,7 @@ impl<N: Network> Consensus<N> {
             metrics::gauge(metrics::blocks::CUMULATIVE_PROOF_TARGET, cumulative_proof_target as f64);
 
             // If telemetry is enabled, update participation scores.
-            #[cfg(feature = "telemetry")]
+            #[cfg(feature = "metrics")]
             {
                 let telemetry = self.bft().primary().gateway().validator_telemetry();
 

--- a/node/rest/Cargo.toml
+++ b/node/rest/Cargo.toml
@@ -21,7 +21,7 @@ default = [ ]
 history = [ "snarkvm/history" ]
 history-staking-rewards = [ "snarkvm/history-staking-rewards" ]
 slipstream-plugins = [ "snarkvm/slipstream-plugins" ]
-telemetry = [ "snarkos-node-consensus/telemetry" ]
+metrics = [ "snarkos-node-consensus/metrics" ]
 cuda = [ "snarkvm/cuda", "snarkos-node-consensus/cuda", "snarkos-node-router/cuda" ]
 locktick = [
   "dep:locktick",

--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -277,7 +277,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         };
 
         // If the node is a validator and `telemetry` features is enabled, enable the additional endpoint.
-        #[cfg(feature = "telemetry")]
+        #[cfg(feature = "metrics")]
         let routes = match self.consensus {
             Some(_) => routes.route("/validators/participation", get(Self::get_validator_participation_scores)),
             None => routes,

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -1367,7 +1367,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
 
     /// GET /{network}/validators/participation
     /// GET /{network}/validators/participation?metadata={true}
-    #[cfg(feature = "telemetry")]
+    #[cfg(feature = "metrics")]
     pub(crate) async fn get_validator_participation_scores(
         State(rest): State<Self>,
         metadata: Query<Metadata>,


### PR DESCRIPTION
## Motivation

> **Depends on #4391 — do not merge before it.**
>
> This branch is built on `refactor/telemetry-actor` rather than `staging`, because both touch the same files and rebasing this onto `staging` would conflict throughout. GitHub cannot use a fork branch as a base, so the diff below currently also contains #4391's three commits. Once #4391 merges, this diff collapses to the single commit described here. The one commit to review is `refactor: fold the telemetry feature into metrics`.

From the review of #4391:

> TODO: I think we should remove feature `telemetry` and just make it part of `metrics`, since it doesn't appear that we test those features independently so it will likely bit rot

> Indeed there was no good reason to have it separate. May want to keep a stub around at the top level to not break people's builds. — @vicsn

Validator telemetry *is* metrics data, and nothing built the `telemetry`-only configuration, so it was free to rot.

## What changed

The 18 `#[cfg(feature = "telemetry")]` sites become `#[cfg(feature = "metrics")]`, and the `telemetry` feature is removed from `snarkos-node-bft`, `snarkos-node-consensus`, `snarkos-node-rest` and `snarkos-node`.

The fold is not purely mechanical — `metrics` did not previously reach everywhere `telemetry` did, so two edges are added:

- `snarkos-node-consensus/metrics` now enables `snarkos-node-bft/metrics`. Consensus reads the BFT telemetry, which is now gated on the latter.
- `snarkos-node/metrics` now enables `snarkos-node-rest/metrics`. That gates the `/validators/participation` endpoint. `snarkos-node-rest` had **no** `metrics` feature at all, so it gains one (`metrics = ["snarkos-node-consensus/metrics"]`).

At the top level, `telemetry` remains as an alias for the metrics features, per @vicsn's request, so existing build commands naming it keep resolving. It drops out of `default`, which already enables metrics throughout.

## No change to what a default build contains

This is the property worth checking, since the whole point is that nothing should disappear.

`telemetry` was in the root `default`, so the participation endpoint and the consensus gauges were on by default. They still are — `default` carries `snarkos-node/metrics`, which now reaches both.

I verified that rather than assuming it. `cargo tree -e features` does not render the root package's own feature edges, so it cannot answer this; instead I temporarily put a `compile_error!` behind `#[cfg(feature = "metrics")]` in `snarkos-node-rest` and ran `cargo check -p snarkos` with default features. It fired, which means the endpoint is compiled into a default build. The probe was then removed.

## Test Plan

Every combination that the feature graph makes reachable:

```
cargo check -p snarkos-node-bft                          # telemetry compiled out
cargo check -p snarkos-node-bft        --features metrics
cargo check -p snarkos-node-consensus
cargo check -p snarkos-node-consensus  --features metrics
cargo check -p snarkos-node-rest
cargo check -p snarkos-node-rest       --features metrics
cargo check -p snarkos-node            --features metrics
cargo check -p snarkos                                   # default
cargo check -p snarkos                 --features telemetry   # the alias still resolves
cargo check -p snarkos                 --no-default-features
```

All pass. The telemetry unit tests now run under `metrics`:

```
cargo test -p snarkos-node-bft --features metrics --lib helpers::telemetry
```

6 tests, all passing.

## Documentation

`README.md` updated in both places that described the flag — §3.2.1 and the §6.4 feature list — to say that telemetry rides on `metrics` and that `telemetry` is a retained alias.

## Backwards compatibility

No runtime behavior change, and no consensus-visible change. `--features telemetry` still resolves. The only way to notice this is to build an internal crate with `--features telemetry` directly rather than through the root, which now needs `--features metrics`.
