### PR TITLE
ci: pin the nightly check-fmt formats with, via an enum

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,30 @@ parameters:
   twoxlarge:
     type: string
     default: 2xlarge
+  # The toolchain `check-fmt` formats with.
+  #
+  # `.rustfmt.toml` uses options that only exist on nightly -- imports_layout,
+  # imports_granularity, overflow_delimited_expr, reorder_impl_items and
+  # style_edition -- so the formatter cannot be the 1.88.0 this project builds
+  # with, and `cargo fmt` without a toolchain silently drops all five rather
+  # than refusing. The formatter is therefore a second toolchain, and pinning
+  # it is the same act as pinning the first.
+  #
+  # Resolves to rustfmt 1.9.0-nightly (7e46c5f6fb 2026-04-01); rustup's dated
+  # nightlies are built from the previous day's commit. Bumping it may reformat
+  # the tree, so it should be a deliberate change with the reformatting in the
+  # same commit.
+  #
+  # `enum` rather than `string`: this value is interpolated unquoted into the
+  # `rustup toolchain install` and `cargo fmt` commands below, so a `string`
+  # parameter would let anyone able to trigger a pipeline with custom
+  # parameters inject arbitrary shell commands into the job. `enum` rejects
+  # any pipeline-trigger value that isn't in the list below before the config
+  # is compiled, closing that off. Add the new pin to the list when bumping.
+  fmt_nightly:
+    type: enum
+    enum: [nightly-2026-04-02]
+    default: nightly-2026-04-02
 
 orbs:
   windows: circleci/windows@5.0
@@ -413,6 +437,11 @@ commands:
     steps:
       - run: rustup toolchain install nightly-x86_64-unknown-linux-gnu
 
+  install_fmt_nightly:
+    description: "Install the pinned Rust nightly toolchain used for formatting"
+    steps:
+      - run: rustup toolchain install << pipeline.parameters.fmt_nightly >>-x86_64-unknown-linux-gnu --profile minimal --component rustfmt
+
   install_rust:
     description: "Install Rust using rustup.rs"
     steps:
@@ -689,13 +718,13 @@ jobs:
     resource_class: << pipeline.parameters.medium >>
     steps:
       - checkout
-      - install_rust_nightly
+      - install_fmt_nightly
       - setup_environment:
           cache_key: v4.2.0-rust-1.88.0-fmt-cache
       - run:
           name: Check style
           no_output_timeout: 35m
-          command: cargo +nightly fmt --all -- --check
+          command: cargo +<< pipeline.parameters.fmt_nightly >> fmt --all -- --check
       - clear_environment:
           cache_key: v4.2.0-rust-1.88.0-fmt-cache
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,9 +5,13 @@
 Always run the following after any code modification:
 
 ```bash
-cargo +nightly fmt
+cargo +nightly-2026-04-02 fmt
 cargo clippy --workspace --all-targets --all-features -- -D warnings
 ```
+
+Formatting requires the nightly `.circleci/config.yml` pins as `fmt_nightly` --
+`.rustfmt.toml` uses nightly-only options, and plain `cargo fmt` drops them
+silently rather than refusing.
 
 ## Modifying BFT Code
 


### PR DESCRIPTION
## Motivation

Port of snarkVM#3390 to snarkOS as requested. Includes the fast follow on https://github.com/ProvableHQ/snarkVM/pull/3392

Verified cargo +nightly-2026-04-02 fmt --all -- --check reports zero diff against the current tree.