### PR TITLE
[Fix] Don't certify batches that reference aborted transactions

### DIFF
--- a/node/bft/ledger-service/src/mock.rs
+++ b/node/bft/ledger-service/src/mock.rs
@@ -31,20 +31,26 @@ use snarkvm::{
 use locktick::parking_lot::Mutex;
 #[cfg(not(feature = "locktick"))]
 use parking_lot::Mutex;
-use std::{collections::BTreeMap, ops::Range};
+use std::{
+    collections::{BTreeMap, HashSet},
+    ops::Range,
+};
 use tracing::*;
 
-/// A mock ledger service that always returns `false`.
+/// A mock ledger service that always returns `false`, unless configured otherwise.
 #[derive(Debug)]
 pub struct MockLedgerService<N: Network> {
     committee: Committee<N>,
     height_to_round_and_hash: Mutex<BTreeMap<u32, (u64, N::BlockHash)>>,
+    /// The transmission IDs the ledger knows without being able to produce a transmission for them,
+    /// as is the case for the ones it recorded as aborted.
+    known_transmission_ids: HashSet<TransmissionID<N>>,
 }
 
 impl<N: Network> MockLedgerService<N> {
     /// Initializes a new mock ledger service.
     pub fn new(committee: Committee<N>) -> Self {
-        Self { committee, height_to_round_and_hash: Default::default() }
+        Self { committee, height_to_round_and_hash: Default::default(), known_transmission_ids: Default::default() }
     }
 
     /// Initializes a new mock ledger service at the specified height.
@@ -53,7 +59,22 @@ impl<N: Network> MockLedgerService<N> {
         for i in 0..=height {
             height_to_hash.insert(i, (i as u64 * 2, Field::<N>::from_u32(i).into()));
         }
-        Self { committee, height_to_round_and_hash: Mutex::new(height_to_hash) }
+        Self {
+            committee,
+            height_to_round_and_hash: Mutex::new(height_to_hash),
+            known_transmission_ids: Default::default(),
+        }
+    }
+
+    /// Initializes a new mock ledger service that knows the given transmission IDs.
+    ///
+    /// The real ledger reports an aborted transmission ID as contained while holding no transmission
+    /// for it; this models that, which the default mock cannot do.
+    pub fn new_with_known_transmission_ids(
+        committee: Committee<N>,
+        known_transmission_ids: HashSet<TransmissionID<N>>,
+    ) -> Self {
+        Self { committee, height_to_round_and_hash: Default::default(), known_transmission_ids }
     }
 }
 
@@ -144,7 +165,10 @@ impl<N: Network> LedgerService<N> for MockLedgerService<N> {
 
     /// Returns the unconfirmed transaction for the given transaction ID.
     fn get_unconfirmed_transaction(&self, _transaction_id: N::TransactionID) -> Result<Option<Transaction<N>>> {
-        unreachable!("MockLedgerService does not support get_unconfirmed_transaction")
+        // Note: this deliberately does not panic, unlike the other getters. A caller that finds a
+        // transmission ID contained but unretrievable reaches this on its way to establishing that
+        // the ID was aborted, and the mock holds no transactions to hand back.
+        Ok(None)
     }
 
     /// Returns the batch certificate for the given batch certificate ID.
@@ -173,14 +197,15 @@ impl<N: Network> LedgerService<N> for MockLedgerService<N> {
         Ok(false)
     }
 
-    /// Returns `false` for all queries.
+    /// Returns `false`, unless the mock was configured to know the transmission ID.
     fn contains_transmission(&self, transmission_id: &TransmissionID<N>) -> Result<bool> {
+        let contains = self.known_transmission_ids.contains(transmission_id);
         trace!(
-            "[MockLedgerService] Contains transmission ID {}.{} - false",
+            "[MockLedgerService] Contains transmission ID {}.{} - {contains}",
             fmt_id(transmission_id),
             fmt_id(transmission_id.checksum().unwrap_or_default())
         );
-        Ok(false)
+        Ok(contains)
     }
 
     /// Ensures that the given transmission is not a fee and matches the given transmission ID.

--- a/node/bft/src/helpers/storage.rs
+++ b/node/bft/src/helpers/storage.rs
@@ -882,8 +882,13 @@ impl<N: Network> Storage<N> {
             if missing_transmissions.contains_key(transmission_id) {
                 continue;
             }
-            // If the transmission ID exists in storage, skip it.
-            if self.contains_transmission(*transmission_id) {
+            // If the transmission can be retrieved from storage, skip it.
+            //
+            // Note that an ID recorded as aborted by an earlier certificate is deliberately not
+            // skipped here: storage holds no transmission for it, so it has to go through the
+            // classification below - which either recovers the transmission from the block, or
+            // declares the ID as aborted for this certificate as well.
+            if self.contains_retrievable_transmission(*transmission_id) {
                 continue;
             }
             // Retrieve the transmission.
@@ -896,12 +901,17 @@ impl<N: Network> Storage<N> {
                     //
                     // Aborted transmissions only appear in the aborted set of the first block that contains them,
                     // for subsequent blocks, we can check that `contains_transmission` is true to determine if the transmission was aborted.
+                    //
+                    // Note that the ledger only answers for the blocks it already holds: the block that
+                    // aborted the ID may still be awaiting its availability check in `Sync::pending_blocks`,
+                    // so storage is consulted as well - it recorded the abort when that block was processed.
                     if let Some(solution) = block.get_solution(solution_id) {
                         missing_transmissions.insert(*transmission_id, (*solution).into());
                     } else if let Ok(Some(solution)) = self.ledger.get_solution(solution_id) {
                         missing_transmissions.insert(*transmission_id, solution.into());
                     } else if aborted_solutions.contains(solution_id)
                         || self.ledger.contains_transmission(transmission_id).unwrap_or(false)
+                        || self.contains_aborted_transmission(*transmission_id)
                     {
                         aborted_transmissions.insert(*transmission_id);
                     } else {
@@ -915,12 +925,17 @@ impl<N: Network> Storage<N> {
                     //
                     // Aborted solutions only appear in the aborted set of the first block that contains them,
                     // for subsequent blocks, we can check that `contains_transmission` is true to determine if the transaction was aborted.
+                    //
+                    // Note that the ledger only answers for the blocks it already holds: the block that
+                    // aborted the ID may still be awaiting its availability check in `Sync::pending_blocks`,
+                    // so storage is consulted as well - it recorded the abort when that block was processed.
                     if let Some(transaction) = unconfirmed_transactions.get(transaction_id) {
                         missing_transmissions.insert(*transmission_id, transaction.clone().into());
                     } else if let Ok(Some(transaction)) = self.ledger.get_unconfirmed_transaction(*transaction_id) {
                         missing_transmissions.insert(*transmission_id, transaction.into());
                     } else if aborted_transactions.contains(transaction_id)
                         || self.ledger.contains_transmission(transmission_id).unwrap_or(false)
+                        || self.contains_aborted_transmission(*transmission_id)
                     {
                         aborted_transmissions.insert(*transmission_id);
                     } else {
@@ -1267,6 +1282,107 @@ pub(crate) mod tests {
                 "Non-aborted transmission {id:?} should have content in storage"
             );
         }
+    }
+
+    /// Builds a storage instance, plus a closure producing quorum-signed round-1 certificates that
+    /// all reference the given transmission ID, each authored by a different committee member.
+    ///
+    /// The ledger holds no transaction for the ID either way - as is the case for one it recorded as
+    /// aborted; `ledger_knows_the_id` only decides whether it reports the ID as contained.
+    fn sample_storage_and_certificates_for_transmission(
+        transmission_id: TransmissionID<CurrentNetwork>,
+        ledger_knows_the_id: bool,
+        rng: &mut TestRng,
+    ) -> (Storage<CurrentNetwork>, impl Fn(usize, &mut TestRng) -> BatchCertificate<CurrentNetwork> + use<>) {
+        let (committee, private_keys) =
+            snarkvm::ledger::committee::test_helpers::sample_committee_and_keys_for_round(0, 5, rng);
+        let known_transmission_ids =
+            if ledger_knows_the_id { [transmission_id].into_iter().collect() } else { Default::default() };
+        let ledger =
+            Arc::new(MockLedgerService::new_with_known_transmission_ids(committee.clone(), known_transmission_ids));
+        let storage = Storage::<CurrentNetwork>::new(ledger, Arc::new(BFTMemoryService::new()), 1).unwrap();
+
+        let make_certificate = move |author_index: usize, rng: &mut TestRng| {
+            let batch_header = BatchHeader::new(
+                &private_keys[author_index],
+                1,
+                crate::helpers::now(),
+                committee.id(),
+                indexset![transmission_id],
+                Default::default(),
+                rng,
+            )
+            .unwrap();
+            let signatures = private_keys
+                .iter()
+                .enumerate()
+                .filter(|(index, _)| *index != author_index)
+                .map(|(_, private_key)| private_key.sign(&[batch_header.batch_id()], rng).unwrap())
+                .collect();
+            BatchCertificate::from(batch_header, signatures).unwrap()
+        };
+
+        (storage, make_certificate)
+    }
+
+    /// A certificate referencing a transmission that an earlier certificate recorded as aborted must
+    /// still be syncable from a block.
+    ///
+    /// Storage holds no transmission for such an ID, so it cannot be skipped as already known: it
+    /// has to go through the classification, which recovers the transmission from the block if it
+    /// carries one, and otherwise records the ID as aborted for this certificate as well. Skipping
+    /// it would leave the ID out of both sets, and it would not be reference counted against the
+    /// certificate that declares it.
+    ///
+    /// `ledger_knows_the_id` separates the two ways the classification can conclude that the ID was
+    /// aborted: the block that aborted it has reached the ledger, or it has not - as while it awaits
+    /// its availability check in `Sync::pending_blocks` - and only storage remembers.
+    fn check_sync_certificate_with_a_previously_aborted_transmission(ledger_knows_the_id: bool) {
+        use snarkvm::prelude::Uniform;
+
+        let rng = &mut TestRng::default();
+
+        // A transaction transmission ID, referenced by both certificates.
+        let transmission_id = TransmissionID::Transaction(
+            <CurrentNetwork as Network>::TransactionID::from(Field::rand(rng)),
+            <CurrentNetwork as Network>::TransmissionChecksum::from(rng.random::<u128>()),
+        );
+        let (storage, make_certificate) =
+            sample_storage_and_certificates_for_transmission(transmission_id, ledger_knows_the_id, rng);
+
+        // Insert the first certificate, recording the transmission as aborted.
+        let certificate_1 = make_certificate(0, rng);
+        storage
+            .insert_certificate(certificate_1.clone(), Default::default(), [transmission_id].into_iter().collect())
+            .unwrap();
+        assert!(storage.contains_transmission(transmission_id));
+        assert!(!storage.contains_retrievable_transmission(transmission_id));
+
+        // Sync a later certificate that references the previously-aborted transmission. The block
+        // carries neither the transmission nor its ID, so only the ledger and storage know it; any
+        // block will do here, hence the sample genesis block.
+        let certificate_2 = make_certificate(1, rng);
+        let block = snarkvm::ledger::test_helpers::sample_genesis_block(rng);
+        storage
+            .sync_certificate_with_block(&block, certificate_2.clone(), &Default::default(), false)
+            .expect("syncing a certificate referencing a previously-aborted transmission must succeed");
+        assert!(storage.contains_certificate(certificate_2.id()));
+
+        // The ID must have been recorded as aborted for the second certificate too, so dropping the
+        // first one must not take the aborted entry with it.
+        assert!(storage.remove_certificate(certificate_1.id()));
+        assert!(storage.contains_transmission(transmission_id));
+        assert!(!storage.contains_retrievable_transmission(transmission_id));
+    }
+
+    #[test]
+    fn test_sync_certificate_with_a_previously_aborted_transmission() {
+        check_sync_certificate_with_a_previously_aborted_transmission(true);
+    }
+
+    #[test]
+    fn test_sync_certificate_with_a_previously_aborted_transmission_the_ledger_does_not_know() {
+        check_sync_certificate_with_a_previously_aborted_transmission(false);
     }
 
     /// Test that `check_incoming_certificate` does not reject a valid cert.

--- a/node/bft/src/helpers/storage.rs
+++ b/node/bft/src/helpers/storage.rs
@@ -710,26 +710,16 @@ impl<N: Network> Storage<N> {
         &self,
         certificate: BatchCertificate<N>,
         transmissions: HashMap<TransmissionID<N>, Transmission<N>>,
-        mut aborted_transmissions: HashSet<TransmissionID<N>>,
+        aborted_transmissions: HashSet<TransmissionID<N>>,
     ) -> Result<()> {
         // Ensure the certificate round is above the GC round.
         ensure!(certificate.round() > self.gc_round(), "Certificate round is at or below the GC round");
         // Ensure the certificate and its transmissions are valid.
         let missing_transmissions =
             self.check_certificate(&certificate, transmissions, aborted_transmissions.clone())?;
-        // Declare as aborted every referenced ID that storage only knows as aborted and that nobody
-        // provided. Callers outside the block sync always pass an empty set of aborted IDs, so
-        // without this the certificate would be reference counted against neither the transmission
-        // nor the aborted entry - and removing the certificate that first recorded the abort would
-        // drop the entry while this certificate still refers to it.
-        for transmission_id in certificate.transmission_ids() {
-            if !missing_transmissions.contains_key(transmission_id)
-                && !self.contains_retrievable_transmission(*transmission_id)
-                && self.contains_aborted_transmission(*transmission_id)
-            {
-                aborted_transmissions.insert(*transmission_id);
-            }
-        }
+        // Note: a referenced ID that storage only knows as aborted, and that nobody provided, is
+        // counted against the certificate by `insert_transmissions` itself - callers outside the
+        // block sync always pass an empty set of aborted IDs.
         // Insert the certificate into storage.
         self.insert_certificate_atomic(certificate, aborted_transmissions, missing_transmissions);
         Ok(())

--- a/node/bft/src/helpers/storage.rs
+++ b/node/bft/src/helpers/storage.rs
@@ -313,14 +313,20 @@ impl<N: Network> Storage<N> {
     /// Returns `true` if the storage holds the specified transmission, i.e. exactly when
     /// [`Self::get_transmission`] would return `Some`.
     ///
-    /// Unlike [`Self::contains_transmission`], this is `false` for a transmission ID that is only
-    /// recorded as aborted.
+    /// Unlike [`Self::contains_transmission`], this is `false` for a transmission ID that storage
+    /// knows only as aborted.
     pub fn contains_retrievable_transmission(&self, transmission_id: impl Into<TransmissionID<N>>) -> bool {
         self.transmissions.contains_retrievable_transmission(transmission_id.into())
     }
 
-    /// Returns `true` if the specified transmission ID was recorded as aborted, i.e. the storage
-    /// knows the ID but holds no transmission for it.
+    /// Returns `true` if the specified transmission ID was recorded as aborted.
+    ///
+    /// This and [`Self::contains_retrievable_transmission`] are **not** mutually exclusive: one
+    /// certificate can record an ID as aborted while another provides the bytes for it - as
+    /// `sync_certificate_with_block` does when the block carries them - in which case both
+    /// queries answer `true`. Use `contains_aborted_transmission(id) &&
+    /// !contains_retrievable_transmission(id)` to ask whether an ID is aborted *and* has nothing to
+    /// hand back.
     pub fn contains_aborted_transmission(&self, transmission_id: impl Into<TransmissionID<N>>) -> bool {
         self.transmissions.contains_aborted_transmission(transmission_id.into())
     }

--- a/node/bft/src/helpers/storage.rs
+++ b/node/bft/src/helpers/storage.rs
@@ -301,20 +301,13 @@ impl<N: Network> Storage<N> {
         self.batch_ids.read().contains_key(&batch_id)
     }
 
-    /// Returns `true` if the storage contains the specified transmission, or it was recorded as aborted.
-    ///
-    /// This is the union of [`Self::contains_retrievable_transmission`] and
-    /// [`Self::contains_aborted_transmission`]; prefer one of those whenever the distinction
-    /// matters.
-    pub fn contains_transmission(&self, transmission_id: impl Into<TransmissionID<N>>) -> bool {
-        self.transmissions.contains_transmission(transmission_id.into())
-    }
-
     /// Returns `true` if the storage holds the specified transmission, i.e. exactly when
     /// [`Self::get_transmission`] would return `Some`.
     ///
-    /// Unlike [`Self::contains_transmission`], this is `false` for a transmission ID that storage
-    /// knows only as aborted.
+    /// This is `false` for a transmission ID that storage knows only as aborted, which holds no
+    /// transmission; see [`Self::contains_aborted_transmission`]. There is deliberately no single
+    /// query for "known either way": conflating the two is what let a batch be certified while
+    /// committing to a transmission that nobody can produce.
     pub fn contains_retrievable_transmission(&self, transmission_id: impl Into<TransmissionID<N>>) -> bool {
         self.transmissions.contains_retrievable_transmission(transmission_id.into())
     }
@@ -1266,7 +1259,7 @@ pub(crate) mod tests {
             let (missing_transmissions, _) = sample_transmissions(&certificate, rng);
             storage.insert_certificate_atomic(certificate.clone(), HashSet::new(), missing_transmissions);
             for id in certificate.transmission_ids() {
-                assert!(storage.contains_transmission(*id));
+                assert!(storage.contains_retrievable_transmission(*id));
             }
             return;
         }
@@ -1282,11 +1275,11 @@ pub(crate) mod tests {
         assert!(storage.contains_certificate(certificate_id));
         assert_eq!(storage.get_certificates_for_round(round), indexset! { certificate.clone() });
 
-        // Every transmission ID in the certificate (including aborted) should be resolvable.
+        // Every transmission ID in the certificate must be recorded, one way or the other.
         for id in certificate.transmission_ids() {
             assert!(
-                storage.contains_transmission(*id),
-                "contains_transmission should be true for all transmission IDs including aborted {id:?}"
+                storage.contains_retrievable_transmission(*id) || storage.contains_aborted_transmission(*id),
+                "every transmission ID must be recorded as stored or aborted, including {id:?}"
             );
         }
 
@@ -1374,7 +1367,7 @@ pub(crate) mod tests {
         storage
             .insert_certificate(certificate_1.clone(), Default::default(), [transmission_id].into_iter().collect())
             .unwrap();
-        assert!(storage.contains_transmission(transmission_id));
+        assert!(storage.contains_aborted_transmission(transmission_id));
         assert!(!storage.contains_retrievable_transmission(transmission_id));
 
         // Sync a later certificate that references the previously-aborted transmission. The block
@@ -1390,7 +1383,7 @@ pub(crate) mod tests {
         // The ID must have been recorded as aborted for the second certificate too, so dropping the
         // first one must not take the aborted entry with it.
         assert!(storage.remove_certificate(certificate_1.id()));
-        assert!(storage.contains_transmission(transmission_id));
+        assert!(storage.contains_aborted_transmission(transmission_id));
         assert!(!storage.contains_retrievable_transmission(transmission_id));
     }
 
@@ -1436,12 +1429,12 @@ pub(crate) mod tests {
 
         // Dropping the first certificate must leave the aborted entry in place for the second.
         assert!(storage.remove_certificate(certificate_1.id()));
-        assert!(storage.contains_transmission(transmission_id));
+        assert!(storage.contains_aborted_transmission(transmission_id));
         assert!(!storage.contains_retrievable_transmission(transmission_id));
 
         // Dropping the second one as well must then remove it.
         assert!(storage.remove_certificate(certificate_2.id()));
-        assert!(!storage.contains_transmission(transmission_id));
+        assert!(!storage.contains_aborted_transmission(transmission_id));
     }
 
     /// Test that `check_incoming_certificate` does not reject a valid cert.

--- a/node/bft/src/helpers/storage.rs
+++ b/node/bft/src/helpers/storage.rs
@@ -302,8 +302,27 @@ impl<N: Network> Storage<N> {
     }
 
     /// Returns `true` if the storage contains the specified transmission, or it was recorded as aborted.
+    ///
+    /// This is the union of [`Self::contains_retrievable_transmission`] and
+    /// [`Self::contains_aborted_transmission`]; prefer one of those whenever the distinction
+    /// matters.
     pub fn contains_transmission(&self, transmission_id: impl Into<TransmissionID<N>>) -> bool {
         self.transmissions.contains_transmission(transmission_id.into())
+    }
+
+    /// Returns `true` if the storage holds the specified transmission, i.e. exactly when
+    /// [`Self::get_transmission`] would return `Some`.
+    ///
+    /// Unlike [`Self::contains_transmission`], this is `false` for a transmission ID that is only
+    /// recorded as aborted.
+    pub fn contains_retrievable_transmission(&self, transmission_id: impl Into<TransmissionID<N>>) -> bool {
+        self.transmissions.contains_retrievable_transmission(transmission_id.into())
+    }
+
+    /// Returns `true` if the specified transmission ID was recorded as aborted, i.e. the storage
+    /// knows the ID but holds no transmission for it.
+    pub fn contains_aborted_transmission(&self, transmission_id: impl Into<TransmissionID<N>>) -> bool {
+        self.transmissions.contains_aborted_transmission(transmission_id.into())
     }
 
     /// Returns the transmission for the given `transmission ID`.

--- a/node/bft/src/helpers/storage.rs
+++ b/node/bft/src/helpers/storage.rs
@@ -912,7 +912,7 @@ impl<N: Network> Storage<N> {
                     // was aborted before querying the ledger.
                     //
                     // Aborted transmissions only appear in the aborted set of the first block that contains them,
-                    // for subsequent blocks, we can check that `contains_transmission` is true to determine if the transmission was aborted.
+                    // for subsequent blocks, `contains_aborted_transmission` is what tells us the transmission was aborted.
                     //
                     // Note that the ledger only answers for the blocks it already holds: the block that
                     // aborted the ID may still be awaiting its availability check in `Sync::pending_blocks`,
@@ -936,7 +936,7 @@ impl<N: Network> Storage<N> {
                     // was aborted before querying the ledger.
                     //
                     // Aborted solutions only appear in the aborted set of the first block that contains them,
-                    // for subsequent blocks, we can check that `contains_transmission` is true to determine if the transaction was aborted.
+                    // for subsequent blocks, `contains_aborted_transmission` is what tells us the transaction was aborted.
                     //
                     // Note that the ledger only answers for the blocks it already holds: the block that
                     // aborted the ID may still be awaiting its availability check in `Sync::pending_blocks`,
@@ -1237,8 +1237,8 @@ pub(crate) mod tests {
     }
 
     /// Verify that when inserting a certificate with a mix of provided transmissions and aborted
-    /// transmission IDs, storage correctly records both: contains_transmission is true for all
-    /// (including aborted), and aborted IDs are stored so sync can resolve certificate references.
+    /// transmission IDs, storage correctly records both: every ID is recorded as either stored or
+    /// aborted, and aborted IDs are kept so sync can resolve certificate references.
     #[test]
     fn test_certificate_insert_with_aborted_transmissions() {
         use std::collections::HashSet;

--- a/node/bft/src/helpers/storage.rs
+++ b/node/bft/src/helpers/storage.rs
@@ -711,13 +711,26 @@ impl<N: Network> Storage<N> {
         &self,
         certificate: BatchCertificate<N>,
         transmissions: HashMap<TransmissionID<N>, Transmission<N>>,
-        aborted_transmissions: HashSet<TransmissionID<N>>,
+        mut aborted_transmissions: HashSet<TransmissionID<N>>,
     ) -> Result<()> {
         // Ensure the certificate round is above the GC round.
         ensure!(certificate.round() > self.gc_round(), "Certificate round is at or below the GC round");
         // Ensure the certificate and its transmissions are valid.
         let missing_transmissions =
             self.check_certificate(&certificate, transmissions, aborted_transmissions.clone())?;
+        // Declare as aborted every referenced ID that storage only knows as aborted and that nobody
+        // provided. Callers outside the block sync always pass an empty set of aborted IDs, so
+        // without this the certificate would be reference counted against neither the transmission
+        // nor the aborted entry - and removing the certificate that first recorded the abort would
+        // drop the entry while this certificate still refers to it.
+        for transmission_id in certificate.transmission_ids() {
+            if !missing_transmissions.contains_key(transmission_id)
+                && !self.contains_retrievable_transmission(*transmission_id)
+                && self.contains_aborted_transmission(*transmission_id)
+            {
+                aborted_transmissions.insert(*transmission_id);
+            }
+        }
         // Insert the certificate into storage.
         self.insert_certificate_atomic(certificate, aborted_transmissions, missing_transmissions);
         Ok(())
@@ -1383,6 +1396,46 @@ pub(crate) mod tests {
     #[test]
     fn test_sync_certificate_with_a_previously_aborted_transmission_the_ledger_does_not_know() {
         check_sync_certificate_with_a_previously_aborted_transmission(false);
+    }
+
+    /// A certificate inserted outside the block sync - as the primary does for a peer's batch or
+    /// certificate - arrives with an empty set of aborted transmission IDs.
+    ///
+    /// A referenced ID that storage only knows as aborted still has to be counted against such a
+    /// certificate, or removing the certificate that first recorded the abort drops the entry while
+    /// this one is still referring to it.
+    #[test]
+    fn test_insert_certificate_counts_a_previously_aborted_transmission() {
+        use snarkvm::prelude::Uniform;
+
+        let rng = &mut TestRng::default();
+
+        let transmission_id = TransmissionID::Transaction(
+            <CurrentNetwork as Network>::TransactionID::from(Field::rand(rng)),
+            <CurrentNetwork as Network>::TransmissionChecksum::from(rng.random::<u128>()),
+        );
+        let (storage, make_certificate) = sample_storage_and_certificates_for_transmission(transmission_id, false, rng);
+
+        // Insert the first certificate, recording the transmission as aborted.
+        let certificate_1 = make_certificate(0, rng);
+        storage
+            .insert_certificate(certificate_1.clone(), Default::default(), [transmission_id].into_iter().collect())
+            .unwrap();
+
+        // Insert a second certificate the way the primary does: no transmissions, and nothing
+        // declared as aborted.
+        let certificate_2 = make_certificate(1, rng);
+        storage.insert_certificate(certificate_2.clone(), Default::default(), Default::default()).unwrap();
+        assert!(storage.contains_certificate(certificate_2.id()));
+
+        // Dropping the first certificate must leave the aborted entry in place for the second.
+        assert!(storage.remove_certificate(certificate_1.id()));
+        assert!(storage.contains_transmission(transmission_id));
+        assert!(!storage.contains_retrievable_transmission(transmission_id));
+
+        // Dropping the second one as well must then remove it.
+        assert!(storage.remove_certificate(certificate_2.id()));
+        assert!(!storage.contains_transmission(transmission_id));
     }
 
     /// Test that `check_incoming_certificate` does not reject a valid cert.

--- a/node/bft/src/helpers/storage.rs
+++ b/node/bft/src/helpers/storage.rs
@@ -307,7 +307,7 @@ impl<N: Network> Storage<N> {
     /// This is `false` for a transmission ID that storage knows only as aborted, which holds no
     /// transmission; see [`Self::contains_aborted_transmission`]. There is deliberately no single
     /// query for "known either way": conflating the two is what let a batch be certified while
-    /// committing to a transmission that nobody can produce.
+    /// committing to a transmission that storage cannot hand back.
     pub fn contains_retrievable_transmission(&self, transmission_id: impl Into<TransmissionID<N>>) -> bool {
         self.transmissions.contains_retrievable_transmission(transmission_id.into())
     }

--- a/node/bft/src/helpers/telemetry.rs
+++ b/node/bft/src/helpers/telemetry.rs
@@ -182,6 +182,10 @@ enum TelemetryUpdate<N: Network> {
     /// anything about the subdag itself.
     Subdag { gc_round: u64, metadata: Vec<CertificateMetadata<N>> },
     /// Insert the metadata of a single certificate.
+    ///
+    /// Only [`Telemetry::insert_certificate`] produces this, which is itself test-only, so the
+    /// variant is gated the same way rather than sitting unconstructable in a release build.
+    #[cfg(test)]
     Certificate(Box<CertificateMetadata<N>>),
     /// Acknowledge once every previously enqueued update has been applied and published.
     Flush(oneshot::Sender<()>),
@@ -434,6 +438,7 @@ impl<N: Network> TelemetryWorker<N> {
                         self.gc_round = self.gc_round.max(gc_round);
                         recompute = true;
                     }
+                    #[cfg(test)]
                     TelemetryUpdate::Certificate(metadata) => {
                         // Deliberately leaves `recompute` alone. A lone certificate barely moves
                         // the scores, and the next subdag recomputes and republishes them, so the

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -2030,8 +2030,15 @@ impl<N: Network> Primary<N> {
         let num_workers = self.num_workers();
         // Iterate through the transmission IDs.
         for transmission_id in batch_header.transmission_ids() {
-            // If the transmission does not exist in storage, proceed to fetch the transmission.
-            if !self.storage.contains_transmission(*transmission_id) {
+            // If the transmission cannot be retrieved from storage, proceed to fetch it.
+            //
+            // Note that an ID storage knows only as aborted is deliberately fetched too: storage
+            // holds no payload for it, so treating the aborted marker as "already have it" would
+            // accept a certificate committing to a transmission this node can never materialize.
+            // A batch is an availability claim by its author, so ask for the bytes rather than
+            // excuse them - the author can serve them, and a certificate carries `2f + 1` such
+            // claims, so an honest peer holds them even if this one does not.
+            if !self.storage.contains_retrievable_transmission(*transmission_id) {
                 // Determine the worker ID.
                 let Ok(worker_id) = assign_to_worker(*transmission_id, num_workers) else {
                     bail!("Unable to assign transmission ID '{transmission_id}' to a worker")
@@ -2693,6 +2700,50 @@ mod tests {
         );
         // The primary signed the proposal.
         assert!(primary.signed_proposals.read().get(&peer_account.1.address()).is_some());
+    }
+
+    /// A transmission that storage knows only as aborted still has to be fetched from the peer:
+    /// storage holds no payload for it, so skipping the fetch is what leaves a certificate stored
+    /// with a transmission this node can never materialize.
+    #[test_log::test(tokio::test)]
+    async fn test_fetch_missing_transmissions_fetches_an_aborted_transmission() {
+        let mut rng = TestRng::default();
+        let (primary, accounts) = primary_without_handlers(&mut rng);
+        let peer_ip = accounts[1].0;
+
+        // A proposal from a peer, whose transmissions the worker holds - as the peer's would.
+        let round = 1;
+        let proposal = create_test_proposal(
+            &accounts[1].1,
+            primary.ledger.current_committee().unwrap(),
+            round,
+            Default::default(),
+            now() + MIN_BATCH_DELAY.as_secs() as i64,
+            1,
+            &mut rng,
+        );
+        for (transmission_id, transmission) in proposal.transmissions() {
+            primary.workers()[0].process_transmission_from_peer(peer_ip, *transmission_id, transmission.clone());
+        }
+
+        // Record one of the referenced IDs as aborted, as an earlier certificate would have.
+        let aborted_transmission_id = *proposal.transmissions().keys().next().unwrap();
+        let (certificate, transmissions) =
+            create_batch_certificate(accounts[2].1.address(), &accounts, round, Default::default(), &mut rng);
+        primary
+            .storage
+            .insert_certificate(certificate, transmissions, [aborted_transmission_id].into_iter().collect())
+            .unwrap();
+        assert!(primary.storage.contains_aborted_transmission(aborted_transmission_id));
+        assert!(!primary.storage.contains_retrievable_transmission(aborted_transmission_id));
+
+        // The aborted ID is fetched like any other, rather than excused by its marker.
+        let fetched = primary.fetch_missing_transmissions(peer_ip, proposal.batch_header()).await.unwrap();
+        assert_eq!(
+            fetched.get(&aborted_transmission_id),
+            proposal.transmissions().get(&aborted_transmission_id),
+            "the aborted transmission ID was skipped, so its payload will never reach storage"
+        );
     }
 
     /// A proposal referencing a transmission that storage knows only as aborted must not be signed:

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -989,24 +989,6 @@ impl<N: Network> Primary<N> {
         // Inserts the missing transmissions into the workers.
         self.insert_missing_transmissions_into_workers(peer_ip, missing_transmissions.into_iter())?;
 
-        // Do not sign a proposal referencing a transmission this node knows only as aborted: storage
-        // holds no payload for it, and none can be fetched from anyone, so the signature would help
-        // certify a batch committing to something that can never be materialized.
-        //
-        // Note: this is deliberately stricter than the certificate and block sync paths, which have
-        // to keep accepting such IDs - see `StorageService::find_missing_transmissions`. It is also a
-        // judgment made from local sync state, so an honest peer that has not seen the aborting block
-        // yet can trip it; skip the proposal rather than treat the peer as malicious.
-        if let Some(transmission_id) =
-            batch_header.transmission_ids().iter().find(|id| self.storage.contains_aborted_transmission(**id))
-        {
-            debug!(
-                "Primary is safely skipping a batch proposal from '{peer_ip}' - {}",
-                format!("it references the aborted transmission '{}'", fmt_id(transmission_id)).dimmed()
-            );
-            return Ok(());
-        }
-
         /* Proceeding to sign the batch. */
 
         // Retrieve the batch ID.
@@ -2774,9 +2756,14 @@ mod tests {
         );
     }
 
-    /// A proposal referencing a transmission that storage knows only as aborted must not be signed:
-    /// there is no payload for it, and none can be fetched, so the signature would help certify a
-    /// batch committing to something that can never be materialized.
+    /// A proposal referencing a transmission that storage knows only as aborted is signed like any
+    /// other, once the bytes have been obtained from its author.
+    ///
+    /// The aborted marker is not a reason to withhold a signature: it only means this node holds no
+    /// payload, and the author of a batch is claiming it can serve one. Refusing here would be a
+    /// unilateral judgment made from local sync state, which an honest peer that has not yet seen
+    /// the aborting block would trip. A proposal whose author cannot serve the bytes fails earlier,
+    /// at the fetch, like any other proposal with a missing transmission.
     #[test_log::test(tokio::test)]
     async fn test_batch_propose_from_peer_with_an_aborted_transmission() {
         let mut rng = TestRng::default();
@@ -2819,11 +2806,11 @@ mod tests {
             .insert_certificate(certificate, transmissions, [aborted_transmission_id].into_iter().collect())
             .unwrap();
         assert!(primary.storage.contains_aborted_transmission(aborted_transmission_id));
+        assert!(!primary.storage.contains_retrievable_transmission(aborted_transmission_id));
 
-        // The proposal is skipped rather than rejected - an honest peer that has not seen the
-        // aborting block yet can send one - and no signature is produced for it.
+        // The payload is available from the author, so the proposal is signed like any other.
         primary.process_batch_propose_from_peer(peer_ip, (*proposal.batch_header()).clone().into()).await.unwrap();
-        assert!(primary.signed_proposals.read().get(&peer_account.1.address()).is_none());
+        assert!(primary.signed_proposals.read().get(&peer_account.1.address()).is_some());
     }
 
     /// A proposal for the current round is left in place; once the round advances past it, the same

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -676,10 +676,13 @@ impl<N: Network> proposal_task::BatchPropose for Primary<N> {
                     continue;
                 }
 
-                // Check if the storage already contain the transmission.
-                // Note: We do not skip if this is the first transmission in the proposal, to ensure that
-                // the primary does not propose a batch with no transmissions.
-                if !transmissions.is_empty() && self.storage.contains_transmission(id) {
+                // Check if the storage already contains the transmission.
+                // Note: `contains_transmission` is also true for an ID that storage only recorded as
+                // aborted, which holds no transmission to hand back. Proposing one of those would
+                // commit the batch to a transmission that peers cannot materialize, so it is skipped
+                // here unconditionally - proposing an empty batch is valid, so there is no need to
+                // make an exception for the first transmission in the proposal.
+                if self.storage.contains_transmission(id) {
                     trace!("Proposing - Skipping transmission '{}' - Already in storage", fmt_id(id));
                     continue;
                 }
@@ -2454,6 +2457,37 @@ mod tests {
         // Try to propose a batch again. This time, it should succeed.
         assert!(primary.propose_batch().await.is_ok());
         assert!(primary.proposed_batch.read().is_proposed());
+    }
+
+    /// A transmission that storage only knows as aborted holds no bytes for peers to materialize, so
+    /// it must be skipped when proposing - including when it is the first item drained from the
+    /// worker, which used to bypass the storage check entirely.
+    #[test_log::test(tokio::test)]
+    async fn test_propose_batch_skips_an_aborted_first_transmission() {
+        let mut rng = TestRng::default();
+        let (primary, accounts) = primary_without_handlers(&mut rng);
+        let peer_ip = accounts[1].0;
+
+        // Queue a certificate's transmissions on the worker before recording them as aborted.
+        let (certificate, transmissions) =
+            create_batch_certificate(accounts[1].1.address(), &accounts, 1, Default::default(), &mut rng);
+        for (transmission_id, transmission) in &transmissions {
+            primary.workers()[0].process_transmission_from_peer(peer_ip, *transmission_id, transmission.clone());
+        }
+        assert_eq!(primary.workers()[0].num_transmissions(), transmissions.len());
+
+        // Record the queued transmission IDs as aborted in storage.
+        let aborted_transmissions = transmissions.keys().copied().collect::<HashSet<_>>();
+        primary.storage.insert_certificate(certificate, Default::default(), aborted_transmissions.clone()).unwrap();
+        for transmission_id in &aborted_transmissions {
+            assert!(primary.storage.contains_transmission(*transmission_id));
+            assert!(!primary.storage.contains_retrievable_transmission(*transmission_id));
+        }
+
+        // Every aborted ID is skipped, leaving an empty proposal rather than an uncommittable one.
+        assert!(primary.propose_batch().await.unwrap());
+        assert!(primary.proposed_batch.read().as_proposal().unwrap().transmissions().is_empty());
+        assert_eq!(primary.workers()[0].num_transmissions(), 0);
     }
 
     #[test_log::test(tokio::test)]

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -676,13 +676,15 @@ impl<N: Network> proposal_task::BatchPropose for Primary<N> {
                     continue;
                 }
 
-                // Check if the storage already contains the transmission.
-                // Note: `contains_transmission` is also true for an ID that storage only recorded as
-                // aborted, which holds no transmission to hand back. Proposing one of those would
-                // commit the batch to a transmission that peers cannot materialize, so it is skipped
-                // here unconditionally - proposing an empty batch is valid, so there is no need to
-                // make an exception for the first transmission in the proposal.
-                if self.storage.contains_transmission(id) {
+                // Check if storage already knows the transmission, either way.
+                //
+                // This is the one place that wants both states: a transmission already in storage is
+                // already in the DAG, and an ID storage knows only as aborted holds no transmission
+                // to hand back, so proposing it would commit the batch to something peers cannot
+                // materialize. Both are skipped unconditionally - proposing an empty batch is valid,
+                // so there is no need to make an exception for the first transmission.
+                if self.storage.contains_retrievable_transmission(id) || self.storage.contains_aborted_transmission(id)
+                {
                     trace!("Proposing - Skipping transmission '{}' - Already in storage", fmt_id(id));
                     continue;
                 }
@@ -2487,7 +2489,7 @@ mod tests {
         let aborted_transmissions = transmissions.keys().copied().collect::<HashSet<_>>();
         primary.storage.insert_certificate(certificate, Default::default(), aborted_transmissions.clone()).unwrap();
         for transmission_id in &aborted_transmissions {
-            assert!(primary.storage.contains_transmission(*transmission_id));
+            assert!(primary.storage.contains_aborted_transmission(*transmission_id));
             assert!(!primary.storage.contains_retrievable_transmission(*transmission_id));
         }
 
@@ -3553,7 +3555,7 @@ mod tests {
         assert!(primary.storage.contains_certificate(certificate_id));
         // Ensure that the aborted transmission IDs exist in storage.
         for aborted_transmission_id in aborted_transmissions {
-            assert!(primary.storage.contains_transmission(aborted_transmission_id));
+            assert!(primary.storage.contains_aborted_transmission(aborted_transmission_id));
             assert!(primary.storage.get_transmission(aborted_transmission_id).is_none());
         }
     }

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -989,6 +989,24 @@ impl<N: Network> Primary<N> {
         // Inserts the missing transmissions into the workers.
         self.insert_missing_transmissions_into_workers(peer_ip, missing_transmissions.into_iter())?;
 
+        // Do not sign a proposal referencing a transmission this node knows only as aborted: storage
+        // holds no payload for it, and none can be fetched from anyone, so the signature would help
+        // certify a batch committing to something that can never be materialized.
+        //
+        // Note: this is deliberately stricter than the certificate and block sync paths, which have
+        // to keep accepting such IDs - see `StorageService::find_missing_transmissions`. It is also a
+        // judgment made from local sync state, so an honest peer that has not seen the aborting block
+        // yet can trip it; skip the proposal rather than treat the peer as malicious.
+        if let Some(transmission_id) =
+            batch_header.transmission_ids().iter().find(|id| self.storage.contains_aborted_transmission(**id))
+        {
+            debug!(
+                "Primary is safely skipping a batch proposal from '{peer_ip}' - {}",
+                format!("it references the aborted transmission '{}'", fmt_id(transmission_id)).dimmed()
+            );
+            return Ok(());
+        }
+
         /* Proceeding to sign the batch. */
 
         // Retrieve the batch ID.
@@ -2673,6 +2691,60 @@ mod tests {
         assert!(
             primary.process_batch_propose_from_peer(peer_ip, (*proposal.batch_header()).clone().into()).await.is_ok()
         );
+        // The primary signed the proposal.
+        assert!(primary.signed_proposals.read().get(&peer_account.1.address()).is_some());
+    }
+
+    /// A proposal referencing a transmission that storage knows only as aborted must not be signed:
+    /// there is no payload for it, and none can be fetched, so the signature would help certify a
+    /// batch committing to something that can never be materialized.
+    #[test_log::test(tokio::test)]
+    async fn test_batch_propose_from_peer_with_an_aborted_transmission() {
+        let mut rng = TestRng::default();
+        let (primary, accounts) = primary_without_handlers(&mut rng);
+
+        // Create a valid proposal with an author that isn't the primary.
+        let round = 1;
+        let peer_account = &accounts[1];
+        let peer_ip = peer_account.0;
+        let timestamp = now() + MIN_BATCH_DELAY.as_secs() as i64;
+        let proposal = create_test_proposal(
+            &peer_account.1,
+            primary.ledger.current_committee().unwrap(),
+            round,
+            Default::default(),
+            timestamp,
+            1,
+            &mut rng,
+        );
+
+        // Make sure the primary is aware of the transmissions in the proposal.
+        for (transmission_id, transmission) in proposal.transmissions() {
+            primary.workers()[0].process_transmission_from_peer(peer_ip, *transmission_id, transmission.clone())
+        }
+
+        // The author must be known to resolver to pass propose checks.
+        primary.gateway.resolver().write().insert_peer(peer_ip, peer_ip, Some(peer_account.1.address()));
+
+        // The primary will only consider itself synced if we received
+        // block locators from a peer.
+        primary.sync.testing_only_update_peer_locators_testing_only(peer_ip, sample_block_locators(20)).unwrap();
+        primary.sync.testing_only_set_sync_height_testing_only(20);
+
+        // Record one of the proposed transmission IDs as aborted, as an earlier certificate would have.
+        let aborted_transmission_id = *proposal.transmissions().keys().next().unwrap();
+        let (certificate, transmissions) =
+            create_batch_certificate(accounts[2].1.address(), &accounts, round, Default::default(), &mut rng);
+        primary
+            .storage
+            .insert_certificate(certificate, transmissions, [aborted_transmission_id].into_iter().collect())
+            .unwrap();
+        assert!(primary.storage.contains_aborted_transmission(aborted_transmission_id));
+
+        // The proposal is skipped rather than rejected - an honest peer that has not seen the
+        // aborting block yet can send one - and no signature is produced for it.
+        primary.process_batch_propose_from_peer(peer_ip, (*proposal.batch_header()).clone().into()).await.unwrap();
+        assert!(primary.signed_proposals.read().get(&peer_account.1.address()).is_none());
     }
 
     /// A proposal for the current round is left in place; once the round advances past it, the same

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -2746,6 +2746,34 @@ mod tests {
         );
     }
 
+    /// The worker must accept a transmission whose ID storage knows only as aborted: the aborted
+    /// marker holds no payload, so discarding the bytes throws away what a fetch just produced and
+    /// leaves this node unable to serve them to anyone else.
+    #[test_log::test(tokio::test)]
+    async fn test_worker_retains_a_transmission_for_an_aborted_id() {
+        let mut rng = TestRng::default();
+        let (primary, accounts) = primary_without_handlers(&mut rng);
+        let peer_ip = accounts[1].0;
+
+        // Record a certificate's transmission IDs as aborted, keeping the transmissions in hand.
+        let (certificate, transmissions) =
+            create_batch_certificate(accounts[1].1.address(), &accounts, 1, Default::default(), &mut rng);
+        let aborted_transmissions = transmissions.keys().copied().collect::<HashSet<_>>();
+        primary.storage.insert_certificate(certificate, Default::default(), aborted_transmissions).unwrap();
+
+        let (transmission_id, transmission) = transmissions.iter().next().unwrap();
+        assert!(primary.storage.contains_aborted_transmission(*transmission_id));
+        assert!(!primary.storage.contains_retrievable_transmission(*transmission_id));
+
+        // The worker takes the bytes rather than treating the aborted marker as already holding them.
+        primary.workers()[0].process_transmission_from_peer(peer_ip, *transmission_id, transmission.clone());
+        assert_eq!(
+            primary.workers()[0].get_transmission(*transmission_id),
+            Some(transmission.clone()),
+            "the worker discarded the payload, so it cannot be served or reused"
+        );
+    }
+
     /// A proposal referencing a transmission that storage knows only as aborted must not be signed:
     /// there is no payload for it, and none can be fetched, so the signature would help certify a
     /// batch committing to something that can never be materialized.

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -679,10 +679,12 @@ impl<N: Network> proposal_task::BatchPropose for Primary<N> {
                 // Check if storage already knows the transmission, either way.
                 //
                 // This is the one place that wants both states: a transmission already in storage is
-                // already in the DAG, and an ID storage knows only as aborted holds no transmission
-                // to hand back, so proposing it would commit the batch to something peers cannot
-                // materialize. Both are skipped unconditionally - proposing an empty batch is valid,
-                // so there is no need to make an exception for the first transmission.
+                // already in the DAG, and an ID storage knows only as aborted was already decided by
+                // a block, so re-proposing it yields a certificate that storage cannot serve at
+                // commit time - the aborted marker answers the containment check, but
+                // `get_transmission` still has nothing to hand back. Both are skipped
+                // unconditionally - proposing an empty batch is valid, so there is no need to make
+                // an exception for the first transmission.
                 if self.storage.contains_retrievable_transmission(id) || self.storage.contains_aborted_transmission(id)
                 {
                     trace!("Proposing - Skipping transmission '{}' - Already in storage", fmt_id(id));
@@ -2020,8 +2022,8 @@ impl<N: Network> Primary<N> {
             // holds no payload for it, so treating the aborted marker as "already have it" would
             // accept a certificate committing to a transmission this node can never materialize.
             // A batch is an availability claim by its author, so ask for the bytes rather than
-            // excuse them - the author can serve them, and a certificate carries `2f + 1` such
-            // claims, so an honest peer holds them even if this one does not.
+            // excuse them; the request goes to that author, which is the peer claiming to hold
+            // them. If it cannot serve them, the fetch fails and the batch is not signed.
             if !self.storage.contains_retrievable_transmission(*transmission_id) {
                 // Determine the worker ID.
                 let Ok(worker_id) = assign_to_worker(*transmission_id, num_workers) else {
@@ -2468,9 +2470,10 @@ mod tests {
         assert!(primary.proposed_batch.read().is_proposed());
     }
 
-    /// A transmission that storage only knows as aborted holds no bytes for peers to materialize, so
-    /// it must be skipped when proposing - including when it is the first item drained from the
-    /// worker, which used to bypass the storage check entirely.
+    /// A transmission that storage only knows as aborted was already decided by a block, and storage
+    /// has nothing to hand back for it at commit time, so it must be skipped when proposing -
+    /// including when it is the first item drained from the worker, which used to bypass the storage
+    /// check entirely.
     #[test_log::test(tokio::test)]
     async fn test_propose_batch_skips_an_aborted_first_transmission() {
         let mut rng = TestRng::default();

--- a/node/bft/src/worker.rs
+++ b/node/bft/src/worker.rs
@@ -185,12 +185,17 @@ impl<N: Network> Worker<N> {
     }
 
     /// Returns `true` if the transmission ID exists in the ready queue, proposed batch, storage, or ledger.
+    ///
+    /// Note that the storage check is the retrievable one: an ID that BFT storage knows only as
+    /// aborted holds no payload, so the worker still wants the bytes - to retain what a fetch just
+    /// produced, and to serve them to peers. The ledger check is deliberately the wider one, since
+    /// an ID the ledger knows - confirmed, rejected, or aborted - must not re-enter the queue.
     pub fn contains_transmission(&self, transmission_id: impl Into<TransmissionID<N>>) -> bool {
         let transmission_id = transmission_id.into();
         // Check if the transmission ID exists in the ready queue, proposed batch, storage, or ledger.
         self.ready.read().contains(transmission_id)
             || matches!(&*self.proposed_batch.read(), ProposedBatchState::Certifying(p) if p.contains_transmission(transmission_id))
-            || self.storage.contains_transmission(transmission_id)
+            || self.storage.contains_retrievable_transmission(transmission_id)
             || self.ledger.contains_transmission(&transmission_id).unwrap_or(false)
     }
 

--- a/node/bft/storage-service/Cargo.toml
+++ b/node/bft/storage-service/Cargo.toml
@@ -20,7 +20,7 @@ edition = "2024"
 default = [ ]
 locktick = [ "dep:locktick", "snarkvm/locktick" ]
 memory = [ "parking_lot", "tracing" ]
-persistent = [ ]
+persistent = [ "parking_lot", "tracing" ]
 test = [ "memory" ]
 
 [dependencies.aleo-std]

--- a/node/bft/storage-service/src/lib.rs
+++ b/node/bft/storage-service/src/lib.rs
@@ -28,3 +28,7 @@ pub use persistent::*;
 
 pub mod traits;
 pub use traits::*;
+
+// The expectations shared by every service, which need every service to assert them against.
+#[cfg(all(test, feature = "memory", feature = "persistent"))]
+mod tests;

--- a/node/bft/storage-service/src/lib.rs
+++ b/node/bft/storage-service/src/lib.rs
@@ -30,5 +30,5 @@ pub mod traits;
 pub use traits::*;
 
 // The expectations shared by every service, which need every service to assert them against.
-#[cfg(all(test, feature = "memory", feature = "persistent"))]
+#[cfg(all(test, any(feature = "memory", feature = "persistent")))]
 mod tests;

--- a/node/bft/storage-service/src/memory.rs
+++ b/node/bft/storage-service/src/memory.rs
@@ -73,7 +73,7 @@ impl<N: Network> StorageService<N> for BFTMemoryService<N> {
         &self,
         certificate_id: Field<N>,
         transmission_ids: IndexSet<TransmissionID<N>>,
-        aborted_transmission_ids: HashSet<TransmissionID<N>>,
+        mut aborted_transmission_ids: HashSet<TransmissionID<N>>,
         mut missing_transmissions: HashMap<TransmissionID<N>, Transmission<N>>,
     ) {
         // Acquire the transmissions write lock.
@@ -96,10 +96,15 @@ impl<N: Network> StorageService<N> for BFTMemoryService<N> {
                     let Some(transmission) = missing_transmissions.remove(&transmission_id) else {
                         // note: `self.contains_retrievable_transmission` would deadlock here; it
                         // read-locks `self.transmissions`, which is write-locked above.
-                        if !aborted_transmission_ids.contains(&transmission_id)
-                            && !aborted_transmission_ids_lock.contains_key(&transmission_id)
-                        {
-                            error!("Failed to provide a missing transmission {transmission_id}");
+                        if !aborted_transmission_ids.contains(&transmission_id) {
+                            // An ID that storage already knows as aborted needs no bytes from
+                            // anyone, but this certificate still has to be counted against the
+                            // aborted entry: `remove_transmissions` decrements it either way.
+                            if aborted_transmission_ids_lock.contains_key(&transmission_id) {
+                                aborted_transmission_ids.insert(transmission_id);
+                            } else {
+                                error!("Failed to provide a missing transmission {transmission_id}");
+                            }
                         }
                         continue 'outer;
                     };

--- a/node/bft/storage-service/src/memory.rs
+++ b/node/bft/storage-service/src/memory.rs
@@ -85,10 +85,16 @@ impl<N: Network> StorageService<N> for BFTMemoryService<N> {
         // Initialize a list for the missing transmissions from storage.
         let mut missing_transmissions = HashMap::new();
         // Lock the existing transmissions.
+        // Note: both maps are read through their guards rather than through
+        // `contains_retrievable_transmission` and `contains_aborted_transmission`, which would take
+        // the very same locks again while these guards are held.
         let known_transmissions = self.transmissions.read();
+        let known_aborted_transmission_ids = self.aborted_transmission_ids.read();
         // Ensure the declared transmission IDs are all present in storage or the given transmissions map.
         for transmission_id in batch_header.transmission_ids() {
-            // If the transmission ID does not exist, ensure it was provided by the caller or aborted.
+            // If the transmission cannot be retrieved from storage, ensure it was provided by the
+            // caller. Note that an ID recorded as aborted holds no transmission, so bytes provided
+            // for it must still be collected here in order to become retrievable.
             if !known_transmissions.contains_key(transmission_id) {
                 // Retrieve the transmission.
                 match transmissions.remove(transmission_id) {
@@ -96,9 +102,13 @@ impl<N: Network> StorageService<N> for BFTMemoryService<N> {
                     Some(transmission) => {
                         missing_transmissions.insert(*transmission_id, transmission);
                     }
-                    // If the transmission does not exist, check if it was aborted.
+                    // If the transmission does not exist, it must be aborted: either the caller
+                    // declares it as such, or storage already recorded it as aborted for an earlier
+                    // certificate - in which case there are no bytes to be had from anyone.
                     None => {
-                        if !aborted_transmissions.contains(transmission_id) {
+                        if !aborted_transmissions.contains(transmission_id)
+                            && !known_aborted_transmission_ids.contains_key(transmission_id)
+                        {
                             bail!("Failed to provide a transmission");
                         }
                     }
@@ -540,6 +550,27 @@ mod tests {
             missing_transmissions,
         );
         assert_eq!(service.get_transmission(transmission_id), Some(transmission));
+    }
+
+    /// An ID that storage already recorded as aborted needs neither bytes nor a fresh declaration:
+    /// there is nothing to fetch, because no peer holds a transmission for an aborted ID either.
+    ///
+    /// Only the caller that has the block can declare the ID itself; a batch proposed or certified
+    /// by a peer arrives with an empty set of aborted IDs.
+    #[test]
+    fn find_missing_transmissions_accepts_an_already_aborted_id_without_bytes() {
+        let rng = &mut TestRng::default();
+        let service = BFTMemoryService::<CurrentNetwork>::new();
+        let aborted_id = sample_transmission_id(rng);
+
+        // An earlier certificate recorded the ID as aborted.
+        service.insert_transmissions(Field::rand(rng), Default::default(), [aborted_id].into(), Default::default());
+
+        let batch_header = sample_batch_header(&[aborted_id], rng);
+        let result = service.find_missing_transmissions(&batch_header, Default::default(), Default::default()).unwrap();
+
+        // Nothing to fetch, and nothing to reject.
+        assert!(result.is_empty());
     }
 
     #[test]

--- a/node/bft/storage-service/src/memory.rs
+++ b/node/bft/storage-service/src/memory.rs
@@ -455,6 +455,51 @@ mod tests {
         assert!(result.is_empty());
     }
 
+    /// An aborted entry records the transmission ID and nothing else, so a later certificate that
+    /// declares the same ID and provides its bytes must have them collected and stored - otherwise
+    /// that certificate references a transmission that can never be materialized.
+    ///
+    /// This service consults only its concrete map, so it does the right thing here. The persistent
+    /// service gates the same decision on `contains_transmission`, which is also true for an
+    /// aborted ID, and discards the bytes.
+    #[test]
+    fn find_missing_transmissions_keeps_provided_bytes_for_an_aborted_id() {
+        let rng = &mut TestRng::default();
+        let service = BFTMemoryService::<CurrentNetwork>::new();
+        let transmission_id = sample_transmission_id(rng);
+        let transmission = sample_transmission(b"payload");
+
+        // An earlier certificate recorded the ID as aborted, so storage contains it without bytes.
+        service.insert_transmissions(
+            Field::rand(rng),
+            Default::default(),
+            [transmission_id].into(),
+            Default::default(),
+        );
+        assert!(service.contains_transmission(transmission_id));
+        assert!(service.get_transmission(transmission_id).is_none());
+
+        // A later certificate declares the same ID and provides its bytes.
+        let batch_header = sample_batch_header(&[transmission_id], rng);
+        let missing_transmissions = service
+            .find_missing_transmissions(
+                &batch_header,
+                [(transmission_id, transmission.clone())].into(),
+                Default::default(),
+            )
+            .unwrap();
+
+        // The bytes are collected, and once inserted the transmission is retrievable.
+        assert_eq!(missing_transmissions.get(&transmission_id), Some(&transmission));
+        service.insert_transmissions(
+            Field::rand(rng),
+            indexset![transmission_id],
+            Default::default(),
+            missing_transmissions,
+        );
+        assert_eq!(service.get_transmission(transmission_id), Some(transmission));
+    }
+
     #[test]
     fn find_missing_transmissions_rejects_a_declaration_that_is_neither_provided_nor_aborted() {
         let rng = &mut TestRng::default();

--- a/node/bft/storage-service/src/memory.rs
+++ b/node/bft/storage-service/src/memory.rs
@@ -51,13 +51,6 @@ impl<N: Network> BFTMemoryService<N> {
 }
 
 impl<N: Network> StorageService<N> for BFTMemoryService<N> {
-    /// Returns `true` if the storage contains the specified `transmission ID`.
-    fn contains_transmission(&self, transmission_id: TransmissionID<N>) -> bool {
-        // Check if the transmission ID exists in storage.
-        self.transmissions.read().contains_key(&transmission_id)
-            || self.aborted_transmission_ids.read().contains_key(&transmission_id)
-    }
-
     /// Returns `true` if the storage holds the transmission for the specified `transmission ID`.
     fn contains_retrievable_transmission(&self, transmission_id: TransmissionID<N>) -> bool {
         self.transmissions.read().contains_key(&transmission_id)
@@ -101,8 +94,8 @@ impl<N: Network> StorageService<N> for BFTMemoryService<N> {
                 Entry::Vacant(vacant_entry) => {
                     // Retrieve the missing transmission.
                     let Some(transmission) = missing_transmissions.remove(&transmission_id) else {
-                        // note: `self.contains_transmission` would deadlock here; it read-locks
-                        // `self.transmissions`, which is write-locked above.
+                        // note: `self.contains_retrievable_transmission` would deadlock here; it
+                        // read-locks `self.transmissions`, which is write-locked above.
                         if !aborted_transmission_ids.contains(&transmission_id)
                             && !aborted_transmission_ids_lock.contains_key(&transmission_id)
                         {
@@ -216,7 +209,8 @@ mod tests {
         let service = BFTMemoryService::<CurrentNetwork>::new();
         let transmission_id = sample_transmission_id(rng);
 
-        assert!(!service.contains_transmission(transmission_id));
+        assert!(!service.contains_retrievable_transmission(transmission_id));
+        assert!(!service.contains_aborted_transmission(transmission_id));
         assert!(service.get_transmission(transmission_id).is_none());
         assert!(service.as_hashmap().is_empty());
     }
@@ -236,7 +230,7 @@ mod tests {
             [(transmission_id, transmission.clone())].into(),
         );
 
-        assert!(service.contains_transmission(transmission_id));
+        assert!(service.contains_retrievable_transmission(transmission_id));
         assert_eq!(service.get_transmission(transmission_id), Some(transmission));
     }
 
@@ -263,11 +257,11 @@ mod tests {
 
         // Dropping one reference must not drop the transmission...
         service.remove_transmissions(&first, &indexset![transmission_id]);
-        assert!(service.contains_transmission(transmission_id));
+        assert!(service.contains_retrievable_transmission(transmission_id));
 
         // ...but dropping the last one must.
         service.remove_transmissions(&second, &indexset![transmission_id]);
-        assert!(!service.contains_transmission(transmission_id));
+        assert!(!service.contains_retrievable_transmission(transmission_id));
         assert!(service.get_transmission(transmission_id).is_none());
     }
 
@@ -298,7 +292,7 @@ mod tests {
     }
 
     #[test]
-    fn an_aborted_transmission_id_is_contained_but_has_no_payload() {
+    fn an_aborted_transmission_id_is_recorded_but_has_no_payload() {
         let rng = &mut TestRng::default();
         let service = BFTMemoryService::<CurrentNetwork>::new();
         let transmission_id = sample_transmission_id(rng);
@@ -312,7 +306,8 @@ mod tests {
 
         // The asymmetry is deliberate: an aborted ID is known to storage, but there is no
         // transmission to hand back for it.
-        assert!(service.contains_transmission(transmission_id));
+        assert!(service.contains_aborted_transmission(transmission_id));
+        assert!(!service.contains_retrievable_transmission(transmission_id));
         assert!(service.get_transmission(transmission_id).is_none());
         assert!(service.as_hashmap().is_empty());
     }
@@ -334,10 +329,10 @@ mod tests {
         }
 
         service.remove_transmissions(&first, &indexset![transmission_id]);
-        assert!(service.contains_transmission(transmission_id));
+        assert!(service.contains_aborted_transmission(transmission_id));
 
         service.remove_transmissions(&second, &indexset![transmission_id]);
-        assert!(!service.contains_transmission(transmission_id));
+        assert!(!service.contains_aborted_transmission(transmission_id));
     }
 
     #[test]
@@ -357,7 +352,7 @@ mod tests {
         // Removing a certificate that never referenced this transmission must not evict it.
         service.remove_transmissions(&Field::rand(rng), &indexset![transmission_id]);
 
-        assert!(service.contains_transmission(transmission_id));
+        assert!(service.contains_retrievable_transmission(transmission_id));
     }
 
     #[test]
@@ -396,7 +391,7 @@ mod tests {
                 Default::default(),
             );
 
-            let _ = sender.send(service.contains_transmission(transmission_id));
+            let _ = sender.send(service.contains_retrievable_transmission(transmission_id));
         });
 
         let contains = receiver

--- a/node/bft/storage-service/src/memory.rs
+++ b/node/bft/storage-service/src/memory.rs
@@ -58,6 +58,16 @@ impl<N: Network> StorageService<N> for BFTMemoryService<N> {
             || self.aborted_transmission_ids.read().contains_key(&transmission_id)
     }
 
+    /// Returns `true` if the storage holds the transmission for the specified `transmission ID`.
+    fn contains_retrievable_transmission(&self, transmission_id: TransmissionID<N>) -> bool {
+        self.transmissions.read().contains_key(&transmission_id)
+    }
+
+    /// Returns `true` if the specified `transmission ID` is recorded as aborted.
+    fn contains_aborted_transmission(&self, transmission_id: TransmissionID<N>) -> bool {
+        self.aborted_transmission_ids.read().contains_key(&transmission_id)
+    }
+
     /// Returns the transmission for the given `transmission ID`.
     /// If the transmission does not exist in storage, `None` is returned.
     fn get_transmission(&self, transmission_id: TransmissionID<N>) -> Option<Transmission<N>> {
@@ -280,6 +290,38 @@ mod tests {
 
         assert!(service.contains_transmission(transmission_id));
         assert_eq!(service.get_transmission(transmission_id), Some(transmission));
+    }
+
+    /// The three containment queries must answer three different questions: a stored transmission
+    /// is retrievable, an aborted ID is known but has nothing to return, and both are contained.
+    #[test]
+    fn the_containment_queries_distinguish_stored_from_aborted_ids() {
+        let rng = &mut TestRng::default();
+        let service = BFTMemoryService::<CurrentNetwork>::new();
+        let (stored_id, aborted_id, unknown_id) =
+            (sample_transmission_id(rng), sample_transmission_id(rng), sample_transmission_id(rng));
+
+        service.insert_transmissions(
+            Field::rand(rng),
+            indexset![stored_id],
+            [aborted_id].into(),
+            [(stored_id, sample_transmission(b"payload"))].into(),
+        );
+
+        // The stored transmission is contained and retrievable, but not aborted.
+        assert!(service.contains_transmission(stored_id));
+        assert!(service.contains_retrievable_transmission(stored_id));
+        assert!(!service.contains_aborted_transmission(stored_id));
+
+        // The aborted ID is contained and aborted, but not retrievable.
+        assert!(service.contains_transmission(aborted_id));
+        assert!(!service.contains_retrievable_transmission(aborted_id));
+        assert!(service.contains_aborted_transmission(aborted_id));
+
+        // An unknown ID is none of the three.
+        assert!(!service.contains_transmission(unknown_id));
+        assert!(!service.contains_retrievable_transmission(unknown_id));
+        assert!(!service.contains_aborted_transmission(unknown_id));
     }
 
     #[test]

--- a/node/bft/storage-service/src/memory.rs
+++ b/node/bft/storage-service/src/memory.rs
@@ -15,8 +15,8 @@
 
 use crate::StorageService;
 use snarkvm::{
-    ledger::narwhal::{BatchHeader, Transmission, TransmissionID},
-    prelude::{Field, Network, Result, bail},
+    ledger::narwhal::{Transmission, TransmissionID},
+    prelude::{Field, Network},
 };
 
 use indexmap::{IndexMap, IndexSet, indexset, map::Entry};
@@ -73,49 +73,6 @@ impl<N: Network> StorageService<N> for BFTMemoryService<N> {
     fn get_transmission(&self, transmission_id: TransmissionID<N>) -> Option<Transmission<N>> {
         // Get the transmission.
         self.transmissions.read().get(&transmission_id).map(|(transmission, _)| transmission).cloned()
-    }
-
-    /// Returns the missing transmissions in storage from the given transmissions.
-    fn find_missing_transmissions(
-        &self,
-        batch_header: &BatchHeader<N>,
-        mut transmissions: HashMap<TransmissionID<N>, Transmission<N>>,
-        aborted_transmissions: HashSet<TransmissionID<N>>,
-    ) -> Result<HashMap<TransmissionID<N>, Transmission<N>>> {
-        // Initialize a list for the missing transmissions from storage.
-        let mut missing_transmissions = HashMap::new();
-        // Lock the existing transmissions.
-        // Note: both maps are read through their guards rather than through
-        // `contains_retrievable_transmission` and `contains_aborted_transmission`, which would take
-        // the very same locks again while these guards are held.
-        let known_transmissions = self.transmissions.read();
-        let known_aborted_transmission_ids = self.aborted_transmission_ids.read();
-        // Ensure the declared transmission IDs are all present in storage or the given transmissions map.
-        for transmission_id in batch_header.transmission_ids() {
-            // If the transmission cannot be retrieved from storage, ensure it was provided by the
-            // caller. Note that an ID recorded as aborted holds no transmission, so bytes provided
-            // for it must still be collected here in order to become retrievable.
-            if !known_transmissions.contains_key(transmission_id) {
-                // Retrieve the transmission.
-                match transmissions.remove(transmission_id) {
-                    // Append the transmission if it exists.
-                    Some(transmission) => {
-                        missing_transmissions.insert(*transmission_id, transmission);
-                    }
-                    // If the transmission does not exist, it must be aborted: either the caller
-                    // declares it as such, or storage already recorded it as aborted for an earlier
-                    // certificate - in which case there are no bytes to be had from anyone.
-                    None => {
-                        if !aborted_transmissions.contains(transmission_id)
-                            && !known_aborted_transmission_ids.contains_key(transmission_id)
-                        {
-                            bail!("Failed to provide a transmission");
-                        }
-                    }
-                }
-            }
-        }
-        Ok(missing_transmissions)
     }
 
     /// Inserts the given certificate ID for each of the transmission IDs, using the missing transmissions map, into storage.
@@ -234,7 +191,7 @@ mod tests {
     use snarkvm::{
         console::network::MainnetV0,
         ledger::narwhal::Data,
-        prelude::{PrivateKey, Rng, TestRng, Uniform},
+        prelude::{Rng, TestRng, Uniform},
     };
 
     use bytes::Bytes;
@@ -251,25 +208,6 @@ mod tests {
 
     fn sample_transmission(payload: &[u8]) -> Transmission<CurrentNetwork> {
         Transmission::Transaction(Data::Buffer(Bytes::from(payload.to_vec())))
-    }
-
-    /// Builds a batch header declaring the given transmission IDs.
-    fn sample_batch_header(
-        transmission_ids: &[TransmissionID<CurrentNetwork>],
-        rng: &mut TestRng,
-    ) -> BatchHeader<CurrentNetwork> {
-        let private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
-        // Round 1 is the only round that may carry no previous certificate IDs.
-        BatchHeader::new(
-            &private_key,
-            1,
-            0,
-            Field::rand(rng),
-            transmission_ids.iter().copied().collect(),
-            Default::default(),
-            rng,
-        )
-        .unwrap()
     }
 
     #[test]
@@ -300,38 +238,6 @@ mod tests {
 
         assert!(service.contains_transmission(transmission_id));
         assert_eq!(service.get_transmission(transmission_id), Some(transmission));
-    }
-
-    /// The three containment queries must answer three different questions: a stored transmission
-    /// is retrievable, an aborted ID is known but has nothing to return, and both are contained.
-    #[test]
-    fn the_containment_queries_distinguish_stored_from_aborted_ids() {
-        let rng = &mut TestRng::default();
-        let service = BFTMemoryService::<CurrentNetwork>::new();
-        let (stored_id, aborted_id, unknown_id) =
-            (sample_transmission_id(rng), sample_transmission_id(rng), sample_transmission_id(rng));
-
-        service.insert_transmissions(
-            Field::rand(rng),
-            indexset![stored_id],
-            [aborted_id].into(),
-            [(stored_id, sample_transmission(b"payload"))].into(),
-        );
-
-        // The stored transmission is contained and retrievable, but not aborted.
-        assert!(service.contains_transmission(stored_id));
-        assert!(service.contains_retrievable_transmission(stored_id));
-        assert!(!service.contains_aborted_transmission(stored_id));
-
-        // The aborted ID is contained and aborted, but not retrievable.
-        assert!(service.contains_transmission(aborted_id));
-        assert!(!service.contains_retrievable_transmission(aborted_id));
-        assert!(service.contains_aborted_transmission(aborted_id));
-
-        // An unknown ID is none of the three.
-        assert!(!service.contains_transmission(unknown_id));
-        assert!(!service.contains_retrievable_transmission(unknown_id));
-        assert!(!service.contains_aborted_transmission(unknown_id));
     }
 
     #[test]
@@ -462,128 +368,6 @@ mod tests {
         service.remove_transmissions(&Field::rand(rng), &indexset![sample_transmission_id(rng)]);
 
         assert!(service.as_hashmap().is_empty());
-    }
-
-    #[test]
-    fn find_missing_transmissions_returns_only_what_storage_lacks() {
-        let rng = &mut TestRng::default();
-        let service = BFTMemoryService::<CurrentNetwork>::new();
-        let (stored_id, missing_id) = (sample_transmission_id(rng), sample_transmission_id(rng));
-        let missing = sample_transmission(b"missing");
-
-        service.insert_transmissions(
-            Field::rand(rng),
-            indexset![stored_id],
-            Default::default(),
-            [(stored_id, sample_transmission(b"stored"))].into(),
-        );
-
-        let batch_header = sample_batch_header(&[stored_id, missing_id], rng);
-        let result = service
-            .find_missing_transmissions(
-                &batch_header,
-                [(stored_id, sample_transmission(b"stored")), (missing_id, missing.clone())].into(),
-                Default::default(),
-            )
-            .unwrap();
-
-        // The already-stored one is dropped even though the caller offered it, so the primary does
-        // not re-insert a payload it already holds.
-        assert_eq!(result.len(), 1);
-        assert_eq!(result.get(&missing_id), Some(&missing));
-    }
-
-    #[test]
-    fn find_missing_transmissions_accepts_an_aborted_declaration_without_returning_it() {
-        let rng = &mut TestRng::default();
-        let service = BFTMemoryService::<CurrentNetwork>::new();
-        let aborted_id = sample_transmission_id(rng);
-
-        let batch_header = sample_batch_header(&[aborted_id], rng);
-        let result =
-            service.find_missing_transmissions(&batch_header, Default::default(), [aborted_id].into()).unwrap();
-
-        // An aborted declaration is satisfied without a payload, and contributes nothing to fetch.
-        assert!(result.is_empty());
-    }
-
-    /// An aborted entry records the transmission ID and nothing else, so a later certificate that
-    /// declares the same ID and provides its bytes must have them collected and stored - otherwise
-    /// that certificate references a transmission that can never be materialized.
-    ///
-    /// This service consults only its concrete map, so it does the right thing here. The persistent
-    /// service gates the same decision on `contains_transmission`, which is also true for an
-    /// aborted ID, and discards the bytes.
-    #[test]
-    fn find_missing_transmissions_keeps_provided_bytes_for_an_aborted_id() {
-        let rng = &mut TestRng::default();
-        let service = BFTMemoryService::<CurrentNetwork>::new();
-        let transmission_id = sample_transmission_id(rng);
-        let transmission = sample_transmission(b"payload");
-
-        // An earlier certificate recorded the ID as aborted, so storage contains it without bytes.
-        service.insert_transmissions(
-            Field::rand(rng),
-            Default::default(),
-            [transmission_id].into(),
-            Default::default(),
-        );
-        assert!(service.contains_transmission(transmission_id));
-        assert!(service.get_transmission(transmission_id).is_none());
-
-        // A later certificate declares the same ID and provides its bytes.
-        let batch_header = sample_batch_header(&[transmission_id], rng);
-        let missing_transmissions = service
-            .find_missing_transmissions(
-                &batch_header,
-                [(transmission_id, transmission.clone())].into(),
-                Default::default(),
-            )
-            .unwrap();
-
-        // The bytes are collected, and once inserted the transmission is retrievable.
-        assert_eq!(missing_transmissions.get(&transmission_id), Some(&transmission));
-        service.insert_transmissions(
-            Field::rand(rng),
-            indexset![transmission_id],
-            Default::default(),
-            missing_transmissions,
-        );
-        assert_eq!(service.get_transmission(transmission_id), Some(transmission));
-    }
-
-    /// An ID that storage already recorded as aborted needs neither bytes nor a fresh declaration:
-    /// there is nothing to fetch, because no peer holds a transmission for an aborted ID either.
-    ///
-    /// Only the caller that has the block can declare the ID itself; a batch proposed or certified
-    /// by a peer arrives with an empty set of aborted IDs.
-    #[test]
-    fn find_missing_transmissions_accepts_an_already_aborted_id_without_bytes() {
-        let rng = &mut TestRng::default();
-        let service = BFTMemoryService::<CurrentNetwork>::new();
-        let aborted_id = sample_transmission_id(rng);
-
-        // An earlier certificate recorded the ID as aborted.
-        service.insert_transmissions(Field::rand(rng), Default::default(), [aborted_id].into(), Default::default());
-
-        let batch_header = sample_batch_header(&[aborted_id], rng);
-        let result = service.find_missing_transmissions(&batch_header, Default::default(), Default::default()).unwrap();
-
-        // Nothing to fetch, and nothing to reject.
-        assert!(result.is_empty());
-    }
-
-    #[test]
-    fn find_missing_transmissions_rejects_a_declaration_that_is_neither_provided_nor_aborted() {
-        let rng = &mut TestRng::default();
-        let service = BFTMemoryService::<CurrentNetwork>::new();
-        let undeclared_id = sample_transmission_id(rng);
-
-        let batch_header = sample_batch_header(&[undeclared_id], rng);
-
-        // This is the check that stops a peer from having its certificate accepted while
-        // withholding the transmissions the certificate commits to.
-        assert!(service.find_missing_transmissions(&batch_header, Default::default(), Default::default()).is_err());
     }
 
     /// `insert_transmissions` must return when a declared transmission is neither provided nor

--- a/node/bft/storage-service/src/memory.rs
+++ b/node/bft/storage-service/src/memory.rs
@@ -177,17 +177,17 @@ impl<N: Network> StorageService<N> for BFTMemoryService<N> {
     }
 }
 
+/// The expectations shared with every other service are asserted in `crate::tests`; what remains
+/// here is specific to this one's locking.
 #[cfg(test)]
 mod tests {
     use super::*;
 
     use snarkvm::{
         console::network::MainnetV0,
-        ledger::narwhal::Data,
         prelude::{Rng, TestRng, Uniform},
     };
 
-    use bytes::Bytes;
     use std::{sync::mpsc, time::Duration};
 
     type CurrentNetwork = MainnetV0;
@@ -197,172 +197,6 @@ mod tests {
             <CurrentNetwork as Network>::TransactionID::from(Field::rand(rng)),
             <CurrentNetwork as Network>::TransmissionChecksum::from(rng.random::<u128>()),
         )
-    }
-
-    fn sample_transmission(payload: &[u8]) -> Transmission<CurrentNetwork> {
-        Transmission::Transaction(Data::Buffer(Bytes::from(payload.to_vec())))
-    }
-
-    #[test]
-    fn a_new_service_holds_nothing() {
-        let rng = &mut TestRng::default();
-        let service = BFTMemoryService::<CurrentNetwork>::new();
-        let transmission_id = sample_transmission_id(rng);
-
-        assert!(!service.contains_retrievable_transmission(transmission_id));
-        assert!(!service.contains_aborted_transmission(transmission_id));
-        assert!(service.get_transmission(transmission_id).is_none());
-        assert!(service.as_hashmap().is_empty());
-    }
-
-    #[test]
-    fn an_inserted_transmission_is_retrievable() {
-        let rng = &mut TestRng::default();
-        let service = BFTMemoryService::<CurrentNetwork>::new();
-        let transmission_id = sample_transmission_id(rng);
-        let transmission = sample_transmission(b"payload");
-        let certificate_id = Field::rand(rng);
-
-        service.insert_transmissions(
-            certificate_id,
-            indexset![transmission_id],
-            Default::default(),
-            [(transmission_id, transmission.clone())].into(),
-        );
-
-        assert!(service.contains_retrievable_transmission(transmission_id));
-        assert_eq!(service.get_transmission(transmission_id), Some(transmission));
-    }
-
-    #[test]
-    fn a_transmission_survives_until_its_last_certificate_is_removed() {
-        let rng = &mut TestRng::default();
-        let service = BFTMemoryService::<CurrentNetwork>::new();
-        let transmission_id = sample_transmission_id(rng);
-        let transmission = sample_transmission(b"payload");
-        let (first, second) = (Field::rand(rng), Field::rand(rng));
-
-        // Two certificates referencing one transmission, as happens when the primary processes
-        // batches from several peers that all include the same transaction.
-        service.insert_transmissions(
-            first,
-            indexset![transmission_id],
-            Default::default(),
-            [(transmission_id, transmission.clone())].into(),
-        );
-        service.insert_transmissions(second, indexset![transmission_id], Default::default(), Default::default());
-
-        let (_, certificate_ids) = service.as_hashmap().remove(&transmission_id).unwrap();
-        assert_eq!(certificate_ids.len(), 2);
-
-        // Dropping one reference must not drop the transmission...
-        service.remove_transmissions(&first, &indexset![transmission_id]);
-        assert!(service.contains_retrievable_transmission(transmission_id));
-
-        // ...but dropping the last one must.
-        service.remove_transmissions(&second, &indexset![transmission_id]);
-        assert!(!service.contains_retrievable_transmission(transmission_id));
-        assert!(service.get_transmission(transmission_id).is_none());
-    }
-
-    #[test]
-    fn a_stored_transmission_is_not_overwritten_by_a_later_insert() {
-        let rng = &mut TestRng::default();
-        let service = BFTMemoryService::<CurrentNetwork>::new();
-        let transmission_id = sample_transmission_id(rng);
-        let original = sample_transmission(b"original");
-        let (first, second) = (Field::rand(rng), Field::rand(rng));
-
-        service.insert_transmissions(
-            first,
-            indexset![transmission_id],
-            Default::default(),
-            [(transmission_id, original.clone())].into(),
-        );
-        // A second certificate arrives carrying a different payload under the same ID. The stored
-        // transmission wins: the occupied branch only records the new certificate ID.
-        service.insert_transmissions(
-            second,
-            indexset![transmission_id],
-            Default::default(),
-            [(transmission_id, sample_transmission(b"replacement"))].into(),
-        );
-
-        assert_eq!(service.get_transmission(transmission_id), Some(original));
-    }
-
-    #[test]
-    fn an_aborted_transmission_id_is_recorded_but_has_no_payload() {
-        let rng = &mut TestRng::default();
-        let service = BFTMemoryService::<CurrentNetwork>::new();
-        let transmission_id = sample_transmission_id(rng);
-
-        service.insert_transmissions(
-            Field::rand(rng),
-            Default::default(),
-            [transmission_id].into(),
-            Default::default(),
-        );
-
-        // The asymmetry is deliberate: an aborted ID is known to storage, but there is no
-        // transmission to hand back for it.
-        assert!(service.contains_aborted_transmission(transmission_id));
-        assert!(!service.contains_retrievable_transmission(transmission_id));
-        assert!(service.get_transmission(transmission_id).is_none());
-        assert!(service.as_hashmap().is_empty());
-    }
-
-    #[test]
-    fn aborted_transmission_ids_are_reference_counted_too() {
-        let rng = &mut TestRng::default();
-        let service = BFTMemoryService::<CurrentNetwork>::new();
-        let transmission_id = sample_transmission_id(rng);
-        let (first, second) = (Field::rand(rng), Field::rand(rng));
-
-        for certificate_id in [first, second] {
-            service.insert_transmissions(
-                certificate_id,
-                Default::default(),
-                [transmission_id].into(),
-                Default::default(),
-            );
-        }
-
-        service.remove_transmissions(&first, &indexset![transmission_id]);
-        assert!(service.contains_aborted_transmission(transmission_id));
-
-        service.remove_transmissions(&second, &indexset![transmission_id]);
-        assert!(!service.contains_aborted_transmission(transmission_id));
-    }
-
-    #[test]
-    fn removing_an_unrelated_certificate_leaves_the_transmission_in_place() {
-        let rng = &mut TestRng::default();
-        let service = BFTMemoryService::<CurrentNetwork>::new();
-        let transmission_id = sample_transmission_id(rng);
-        let certificate_id = Field::rand(rng);
-
-        service.insert_transmissions(
-            certificate_id,
-            indexset![transmission_id],
-            Default::default(),
-            [(transmission_id, sample_transmission(b"payload"))].into(),
-        );
-
-        // Removing a certificate that never referenced this transmission must not evict it.
-        service.remove_transmissions(&Field::rand(rng), &indexset![transmission_id]);
-
-        assert!(service.contains_retrievable_transmission(transmission_id));
-    }
-
-    #[test]
-    fn removing_from_an_empty_service_is_a_no_op() {
-        let rng = &mut TestRng::default();
-        let service = BFTMemoryService::<CurrentNetwork>::new();
-
-        service.remove_transmissions(&Field::rand(rng), &indexset![sample_transmission_id(rng)]);
-
-        assert!(service.as_hashmap().is_empty());
     }
 
     /// `insert_transmissions` must return when a declared transmission is neither provided nor

--- a/node/bft/storage-service/src/memory.rs
+++ b/node/bft/storage-service/src/memory.rs
@@ -97,8 +97,8 @@ impl<N: Network> StorageService<N> for BFTMemoryService<N> {
                         // note: `self.contains_retrievable_transmission` would deadlock here; it
                         // read-locks `self.transmissions`, which is write-locked above.
                         if !aborted_transmission_ids.contains(&transmission_id) {
-                            // An ID that storage already knows as aborted needs no bytes from
-                            // anyone, but this certificate still has to be counted against the
+                            // An ID that storage already knows as aborted needs no bytes to be
+                            // inserted, but this certificate still has to be counted against the
                             // aborted entry: `remove_transmissions` decrements it either way.
                             if aborted_transmission_ids_lock.contains_key(&transmission_id) {
                                 aborted_transmission_ids.insert(transmission_id);

--- a/node/bft/storage-service/src/persistent.rs
+++ b/node/bft/storage-service/src/persistent.rs
@@ -82,24 +82,6 @@ impl<N: Network> BFTPersistentStorage<N> {
 }
 
 impl<N: Network> StorageService<N> for BFTPersistentStorage<N> {
-    /// Returns `true` if the storage contains the specified `transmission ID`.
-    fn contains_transmission(&self, transmission_id: TransmissionID<N>) -> bool {
-        // Check if the transmission ID exists in storage.
-        match self.transmissions.contains_key_confirmed(&transmission_id) {
-            Ok(true) => return true,
-            Ok(false) => (),
-            Err(error) => error!("Failed to check if transmission ID exists in confirmed storage - {error}"),
-        }
-        // Check if the transmission ID is in aborted storage.
-        match self.aborted_transmission_ids.contains_key_confirmed(&transmission_id) {
-            Ok(result) => result,
-            Err(error) => {
-                error!("Failed to check if aborted transmission ID exists in storage - {error}");
-                false
-            }
-        }
-    }
-
     /// Returns `true` if the storage holds the transmission for the specified `transmission ID`.
     fn contains_retrievable_transmission(&self, transmission_id: TransmissionID<N>) -> bool {
         // Check the cache first: it only ever holds transmissions that are also in persistent
@@ -446,7 +428,8 @@ mod tests {
         // The transmission must be gone from both the persistent storage and the cache.
         assert!(!storage.as_hashmap().contains_key(&transmission_id));
         assert!(storage.get_transmission(transmission_id).is_none());
-        assert!(!storage.contains_transmission(transmission_id));
+        assert!(!storage.contains_retrievable_transmission(transmission_id));
+        assert!(!storage.contains_aborted_transmission(transmission_id));
     }
 
     /// The cache `contains_retrievable_transmission` consults first must not outlive the storage

--- a/node/bft/storage-service/src/persistent.rs
+++ b/node/bft/storage-service/src/persistent.rs
@@ -160,17 +160,23 @@ impl<N: Network> StorageService<N> for BFTPersistentStorage<N> {
         let mut missing_transmissions = HashMap::new();
         // Ensure the declared transmission IDs are all present in storage or the given transmissions map.
         for transmission_id in batch_header.transmission_ids() {
-            // If the transmission ID does not exist, ensure it was provided by the caller or aborted.
-            if !self.contains_transmission(*transmission_id) {
+            // If the transmission cannot be retrieved from storage, ensure it was provided by the
+            // caller. Note that an ID recorded as aborted holds no transmission, so bytes provided
+            // for it must still be collected here in order to become retrievable.
+            if !self.contains_retrievable_transmission(*transmission_id) {
                 // Retrieve the transmission.
                 match transmissions.remove(transmission_id) {
                     // Append the transmission if it exists.
                     Some(transmission) => {
                         missing_transmissions.insert(*transmission_id, transmission);
                     }
-                    // If the transmission does not exist, check if it was aborted.
+                    // If the transmission does not exist, it must be aborted: either the caller
+                    // declares it as such, or storage already recorded it as aborted for an earlier
+                    // certificate - in which case there are no bytes to be had from anyone.
                     None => {
-                        if !aborted_transmissions.contains(transmission_id) {
+                        if !aborted_transmissions.contains(transmission_id)
+                            && !self.contains_aborted_transmission(*transmission_id)
+                        {
                             bail!("Failed to provide a transmission");
                         }
                     }
@@ -551,6 +557,27 @@ mod tests {
 
         storage.remove_transmissions(&certificate_id, &indexset![transmission_id]);
         assert!(!storage.contains_retrievable_transmission(transmission_id));
+    }
+
+    /// An ID that storage already recorded as aborted needs neither bytes nor a fresh declaration:
+    /// there is nothing to fetch, because no peer holds a transmission for an aborted ID either.
+    ///
+    /// Only the caller that has the block can declare the ID itself; a batch proposed or certified
+    /// by a peer arrives with an empty set of aborted IDs.
+    #[test]
+    fn test_find_missing_transmissions_accepts_an_already_aborted_id_without_bytes() {
+        let rng = &mut TestRng::default();
+        let storage = BFTPersistentStorage::<CurrentNetwork>::open(StorageMode::new_test(None)).unwrap();
+        let aborted_id = sample_transmission_id(rng);
+
+        // An earlier certificate recorded the ID as aborted.
+        storage.insert_transmissions(Field::rand(rng), Default::default(), [aborted_id].into(), Default::default());
+
+        let batch_header = sample_batch_header(&[aborted_id], rng);
+        let result = storage.find_missing_transmissions(&batch_header, Default::default(), Default::default()).unwrap();
+
+        // Nothing to fetch, and nothing to reject.
+        assert!(result.is_empty());
     }
 
     /// A transmission whose ID an earlier certificate recorded as aborted must still be persisted

--- a/node/bft/storage-service/src/persistent.rs
+++ b/node/bft/storage-service/src/persistent.rs
@@ -207,8 +207,12 @@ impl<N: Network> StorageService<N> for BFTPersistentStorage<N> {
                     // The transmission is missing from persistent storage.
                     // Check if it exists in the `missing_transmissions` map provided.
                     let Some(transmission) = missing_transmissions.remove(&transmission_id) else {
+                        // This is the branch where persistent storage does not hold the
+                        // transmission, so asking whether it is aborted is the same question as
+                        // asking whether storage knows the ID at all - without repeating the
+                        // lookup that just came back empty.
                         if !aborted_transmission_ids.contains(&transmission_id)
-                            && !self.contains_transmission(transmission_id)
+                            && !self.contains_aborted_transmission(transmission_id)
                         {
                             error!("Failed to provide a missing transmission {transmission_id}");
                         }

--- a/node/bft/storage-service/src/persistent.rs
+++ b/node/bft/storage-service/src/persistent.rs
@@ -135,7 +135,7 @@ impl<N: Network> StorageService<N> for BFTPersistentStorage<N> {
         &self,
         certificate_id: Field<N>,
         transmission_ids: IndexSet<TransmissionID<N>>,
-        aborted_transmission_ids: HashSet<TransmissionID<N>>,
+        mut aborted_transmission_ids: HashSet<TransmissionID<N>>,
         mut missing_transmissions: HashMap<TransmissionID<N>, Transmission<N>>,
     ) {
         // Hold the cache lock for the entire update, to serialize the read-modify-write updates
@@ -161,10 +161,15 @@ impl<N: Network> StorageService<N> for BFTPersistentStorage<N> {
                         // transmission, so asking whether it is aborted is the same question as
                         // asking whether storage knows the ID at all - without repeating the
                         // lookup that just came back empty.
-                        if !aborted_transmission_ids.contains(&transmission_id)
-                            && !self.contains_aborted_transmission(transmission_id)
-                        {
-                            error!("Failed to provide a missing transmission {transmission_id}");
+                        if !aborted_transmission_ids.contains(&transmission_id) {
+                            // An ID that storage already knows as aborted needs no bytes from
+                            // anyone, but this certificate still has to be counted against the
+                            // aborted entry: `remove_transmissions` decrements it either way.
+                            if self.contains_aborted_transmission(transmission_id) {
+                                aborted_transmission_ids.insert(transmission_id);
+                            } else {
+                                error!("Failed to provide a missing transmission {transmission_id}");
+                            }
                         }
                         continue 'outer;
                     };

--- a/node/bft/storage-service/src/persistent.rs
+++ b/node/bft/storage-service/src/persistent.rs
@@ -100,6 +100,34 @@ impl<N: Network> StorageService<N> for BFTPersistentStorage<N> {
         }
     }
 
+    /// Returns `true` if the storage holds the transmission for the specified `transmission ID`.
+    fn contains_retrievable_transmission(&self, transmission_id: TransmissionID<N>) -> bool {
+        // Check the cache first: it only ever holds transmissions that are also in persistent
+        // storage, so a hit answers this without a storage read. This also keeps the check in
+        // agreement with `get_transmission`, which probes the cache first as well.
+        if self.cache_transmissions.lock().contains(&transmission_id) {
+            return true;
+        }
+        match self.transmissions.contains_key_confirmed(&transmission_id) {
+            Ok(result) => result,
+            Err(error) => {
+                error!("Failed to check if transmission ID exists in confirmed storage - {error}");
+                false
+            }
+        }
+    }
+
+    /// Returns `true` if the specified `transmission ID` is recorded as aborted.
+    fn contains_aborted_transmission(&self, transmission_id: TransmissionID<N>) -> bool {
+        match self.aborted_transmission_ids.contains_key_confirmed(&transmission_id) {
+            Ok(result) => result,
+            Err(error) => {
+                error!("Failed to check if aborted transmission ID exists in storage - {error}");
+                false
+            }
+        }
+    }
+
     /// Returns the transmission for the given `transmission ID`.
     /// If the transmission ID does not exist in storage, `None` is returned.
     fn get_transmission(&self, transmission_id: TransmissionID<N>) -> Option<Transmission<N>> {
@@ -466,6 +494,59 @@ mod tests {
         assert!(!storage.as_hashmap().contains_key(&transmission_id));
         assert!(storage.get_transmission(transmission_id).is_none());
         assert!(!storage.contains_transmission(transmission_id));
+    }
+
+    /// The three containment queries must answer three different questions: a stored transmission
+    /// is retrievable, an aborted ID is known but has nothing to return, and both are contained.
+    #[test]
+    fn test_the_containment_queries_distinguish_stored_from_aborted_ids() {
+        let rng = &mut TestRng::default();
+        let storage = BFTPersistentStorage::<CurrentNetwork>::open(StorageMode::new_test(None)).unwrap();
+        let (stored_id, aborted_id, unknown_id) =
+            (sample_transmission_id(rng), sample_transmission_id(rng), sample_transmission_id(rng));
+
+        storage.insert_transmissions(
+            Field::rand(rng),
+            indexset![stored_id],
+            [aborted_id].into(),
+            [(stored_id, sample_transmission(b"payload"))].into(),
+        );
+
+        // The stored transmission is contained and retrievable, but not aborted.
+        assert!(storage.contains_transmission(stored_id));
+        assert!(storage.contains_retrievable_transmission(stored_id));
+        assert!(!storage.contains_aborted_transmission(stored_id));
+
+        // The aborted ID is contained and aborted, but not retrievable.
+        assert!(storage.contains_transmission(aborted_id));
+        assert!(!storage.contains_retrievable_transmission(aborted_id));
+        assert!(storage.contains_aborted_transmission(aborted_id));
+
+        // An unknown ID is none of the three.
+        assert!(!storage.contains_transmission(unknown_id));
+        assert!(!storage.contains_retrievable_transmission(unknown_id));
+        assert!(!storage.contains_aborted_transmission(unknown_id));
+    }
+
+    /// The cache `contains_retrievable_transmission` consults first must not outlive the storage
+    /// entry it stands for, or the query would report a removed transmission as retrievable.
+    #[test]
+    fn test_contains_retrievable_transmission_follows_a_removal_through_the_cache() {
+        let rng = &mut TestRng::default();
+        let storage = BFTPersistentStorage::<CurrentNetwork>::open(StorageMode::new_test(None)).unwrap();
+        let transmission_id = sample_transmission_id(rng);
+        let certificate_id = Field::rand(rng);
+
+        storage.insert_transmissions(
+            certificate_id,
+            indexset![transmission_id],
+            Default::default(),
+            [(transmission_id, sample_transmission(b"payload"))].into(),
+        );
+        assert!(storage.contains_retrievable_transmission(transmission_id));
+
+        storage.remove_transmissions(&certificate_id, &indexset![transmission_id]);
+        assert!(!storage.contains_retrievable_transmission(transmission_id));
     }
 
     /// A transmission whose ID an earlier certificate recorded as aborted must still be persisted

--- a/node/bft/storage-service/src/persistent.rs
+++ b/node/bft/storage-service/src/persistent.rs
@@ -337,13 +337,46 @@ mod tests {
     use snarkvm::{
         console::network::MainnetV0,
         ledger::narwhal::Data,
-        prelude::{Rng, TestRng, Uniform},
+        prelude::{PrivateKey, Rng, TestRng, Uniform},
     };
 
     use bytes::Bytes;
     use std::sync::{Arc, Barrier};
 
     type CurrentNetwork = MainnetV0;
+
+    // Note: these mirror the helpers in the in-memory service's tests; they are candidates for a
+    // shared harness once both services are exercised against the same expectations.
+
+    fn sample_transmission_id(rng: &mut TestRng) -> TransmissionID<CurrentNetwork> {
+        TransmissionID::Transaction(
+            <CurrentNetwork as Network>::TransactionID::from(Field::rand(rng)),
+            <CurrentNetwork as Network>::TransmissionChecksum::from(rng.random::<u128>()),
+        )
+    }
+
+    fn sample_transmission(payload: &[u8]) -> Transmission<CurrentNetwork> {
+        Transmission::Transaction(Data::Buffer(Bytes::from(payload.to_vec())))
+    }
+
+    /// Builds a batch header declaring the given transmission IDs.
+    fn sample_batch_header(
+        transmission_ids: &[TransmissionID<CurrentNetwork>],
+        rng: &mut TestRng,
+    ) -> BatchHeader<CurrentNetwork> {
+        let private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
+        // Round 1 is the only round that may carry no previous certificate IDs.
+        BatchHeader::new(
+            &private_key,
+            1,
+            0,
+            Field::rand(rng),
+            transmission_ids.iter().copied().collect(),
+            Default::default(),
+            rng,
+        )
+        .unwrap()
+    }
 
     /// Every certificate that references a transmission must contribute its certificate ID to the
     /// transmission's reference set, even when the insertions happen concurrently — as they do when
@@ -433,5 +466,61 @@ mod tests {
         assert!(!storage.as_hashmap().contains_key(&transmission_id));
         assert!(storage.get_transmission(transmission_id).is_none());
         assert!(!storage.contains_transmission(transmission_id));
+    }
+
+    /// A transmission whose ID an earlier certificate recorded as aborted must still be persisted
+    /// when a later certificate provides its bytes.
+    ///
+    /// An aborted entry records the ID and nothing else, so `get_transmission` has nothing to hand
+    /// back for it. `find_missing_transmissions` nevertheless decides whether the bytes are needed
+    /// with `contains_transmission`, which is also true for an aborted ID - so the bytes are
+    /// discarded, and the certificate that declares the ID is accepted into storage while the
+    /// transmission it commits to can never be materialized.
+    ///
+    /// Note the in-memory service does not share this behavior: it consults only its concrete map,
+    /// collects the bytes, and stores them.
+    #[test]
+    fn test_provided_bytes_are_kept_for_a_previously_aborted_id() {
+        let rng = &mut TestRng::default();
+        let storage = BFTPersistentStorage::<CurrentNetwork>::open(StorageMode::new_test(None)).unwrap();
+        let transmission_id = sample_transmission_id(rng);
+        let transmission = sample_transmission(b"payload");
+
+        // An earlier certificate recorded the ID as aborted, so storage contains it without bytes.
+        storage.insert_transmissions(
+            Field::rand(rng),
+            Default::default(),
+            [transmission_id].into(),
+            Default::default(),
+        );
+        assert!(storage.contains_transmission(transmission_id));
+        assert!(storage.get_transmission(transmission_id).is_none());
+
+        // A later certificate declares the same ID and provides its bytes.
+        let batch_header = sample_batch_header(&[transmission_id], rng);
+        let missing_transmissions = storage
+            .find_missing_transmissions(
+                &batch_header,
+                [(transmission_id, transmission.clone())].into(),
+                Default::default(),
+            )
+            .unwrap();
+
+        // The bytes have to be collected...
+        assert_eq!(
+            missing_transmissions.get(&transmission_id),
+            Some(&transmission),
+            "the provided bytes were discarded, so they will never reach storage"
+        );
+
+        // ...and, once inserted, they have to be retrievable, or the certificate that declares this
+        // transmission ID cannot be committed.
+        storage.insert_transmissions(
+            Field::rand(rng),
+            indexset![transmission_id],
+            Default::default(),
+            missing_transmissions,
+        );
+        assert_eq!(storage.get_transmission(transmission_id), Some(transmission));
     }
 }

--- a/node/bft/storage-service/src/persistent.rs
+++ b/node/bft/storage-service/src/persistent.rs
@@ -27,7 +27,7 @@ use snarkvm::{
             },
         },
     },
-    prelude::{Field, Network, Result, bail},
+    prelude::{Field, Network, Result},
 };
 
 use aleo_std::StorageMode;
@@ -146,44 +146,6 @@ impl<N: Network> StorageService<N> for BFTPersistentStorage<N> {
                 None
             }
         }
-    }
-
-    /// Takes a certificate and its transmissions, and returns the subset of transmissions that
-    /// did not yet exists in the storage.
-    fn find_missing_transmissions(
-        &self,
-        batch_header: &BatchHeader<N>,
-        mut transmissions: HashMap<TransmissionID<N>, Transmission<N>>,
-        aborted_transmissions: HashSet<TransmissionID<N>>,
-    ) -> Result<HashMap<TransmissionID<N>, Transmission<N>>> {
-        // Initialize a list for the missing transmissions from storage.
-        let mut missing_transmissions = HashMap::new();
-        // Ensure the declared transmission IDs are all present in storage or the given transmissions map.
-        for transmission_id in batch_header.transmission_ids() {
-            // If the transmission cannot be retrieved from storage, ensure it was provided by the
-            // caller. Note that an ID recorded as aborted holds no transmission, so bytes provided
-            // for it must still be collected here in order to become retrievable.
-            if !self.contains_retrievable_transmission(*transmission_id) {
-                // Retrieve the transmission.
-                match transmissions.remove(transmission_id) {
-                    // Append the transmission if it exists.
-                    Some(transmission) => {
-                        missing_transmissions.insert(*transmission_id, transmission);
-                    }
-                    // If the transmission does not exist, it must be aborted: either the caller
-                    // declares it as such, or storage already recorded it as aborted for an earlier
-                    // certificate - in which case there are no bytes to be had from anyone.
-                    None => {
-                        if !aborted_transmissions.contains(transmission_id)
-                            && !self.contains_aborted_transmission(*transmission_id)
-                        {
-                            bail!("Failed to provide a transmission");
-                        }
-                    }
-                }
-            }
-        }
-        Ok(missing_transmissions)
     }
 
     /// Inserts the given certificate ID for each of the transmission IDs, using the missing transmissions map, into storage.
@@ -375,7 +337,7 @@ mod tests {
     use snarkvm::{
         console::network::MainnetV0,
         ledger::narwhal::Data,
-        prelude::{PrivateKey, Rng, TestRng, Uniform},
+        prelude::{Rng, TestRng, Uniform},
     };
 
     use bytes::Bytes;
@@ -395,25 +357,6 @@ mod tests {
 
     fn sample_transmission(payload: &[u8]) -> Transmission<CurrentNetwork> {
         Transmission::Transaction(Data::Buffer(Bytes::from(payload.to_vec())))
-    }
-
-    /// Builds a batch header declaring the given transmission IDs.
-    fn sample_batch_header(
-        transmission_ids: &[TransmissionID<CurrentNetwork>],
-        rng: &mut TestRng,
-    ) -> BatchHeader<CurrentNetwork> {
-        let private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
-        // Round 1 is the only round that may carry no previous certificate IDs.
-        BatchHeader::new(
-            &private_key,
-            1,
-            0,
-            Field::rand(rng),
-            transmission_ids.iter().copied().collect(),
-            Default::default(),
-            rng,
-        )
-        .unwrap()
     }
 
     /// Every certificate that references a transmission must contribute its certificate ID to the
@@ -506,38 +449,6 @@ mod tests {
         assert!(!storage.contains_transmission(transmission_id));
     }
 
-    /// The three containment queries must answer three different questions: a stored transmission
-    /// is retrievable, an aborted ID is known but has nothing to return, and both are contained.
-    #[test]
-    fn test_the_containment_queries_distinguish_stored_from_aborted_ids() {
-        let rng = &mut TestRng::default();
-        let storage = BFTPersistentStorage::<CurrentNetwork>::open(StorageMode::new_test(None)).unwrap();
-        let (stored_id, aborted_id, unknown_id) =
-            (sample_transmission_id(rng), sample_transmission_id(rng), sample_transmission_id(rng));
-
-        storage.insert_transmissions(
-            Field::rand(rng),
-            indexset![stored_id],
-            [aborted_id].into(),
-            [(stored_id, sample_transmission(b"payload"))].into(),
-        );
-
-        // The stored transmission is contained and retrievable, but not aborted.
-        assert!(storage.contains_transmission(stored_id));
-        assert!(storage.contains_retrievable_transmission(stored_id));
-        assert!(!storage.contains_aborted_transmission(stored_id));
-
-        // The aborted ID is contained and aborted, but not retrievable.
-        assert!(storage.contains_transmission(aborted_id));
-        assert!(!storage.contains_retrievable_transmission(aborted_id));
-        assert!(storage.contains_aborted_transmission(aborted_id));
-
-        // An unknown ID is none of the three.
-        assert!(!storage.contains_transmission(unknown_id));
-        assert!(!storage.contains_retrievable_transmission(unknown_id));
-        assert!(!storage.contains_aborted_transmission(unknown_id));
-    }
-
     /// The cache `contains_retrievable_transmission` consults first must not outlive the storage
     /// entry it stands for, or the query would report a removed transmission as retrievable.
     #[test]
@@ -557,82 +468,5 @@ mod tests {
 
         storage.remove_transmissions(&certificate_id, &indexset![transmission_id]);
         assert!(!storage.contains_retrievable_transmission(transmission_id));
-    }
-
-    /// An ID that storage already recorded as aborted needs neither bytes nor a fresh declaration:
-    /// there is nothing to fetch, because no peer holds a transmission for an aborted ID either.
-    ///
-    /// Only the caller that has the block can declare the ID itself; a batch proposed or certified
-    /// by a peer arrives with an empty set of aborted IDs.
-    #[test]
-    fn test_find_missing_transmissions_accepts_an_already_aborted_id_without_bytes() {
-        let rng = &mut TestRng::default();
-        let storage = BFTPersistentStorage::<CurrentNetwork>::open(StorageMode::new_test(None)).unwrap();
-        let aborted_id = sample_transmission_id(rng);
-
-        // An earlier certificate recorded the ID as aborted.
-        storage.insert_transmissions(Field::rand(rng), Default::default(), [aborted_id].into(), Default::default());
-
-        let batch_header = sample_batch_header(&[aborted_id], rng);
-        let result = storage.find_missing_transmissions(&batch_header, Default::default(), Default::default()).unwrap();
-
-        // Nothing to fetch, and nothing to reject.
-        assert!(result.is_empty());
-    }
-
-    /// A transmission whose ID an earlier certificate recorded as aborted must still be persisted
-    /// when a later certificate provides its bytes.
-    ///
-    /// An aborted entry records the ID and nothing else, so `get_transmission` has nothing to hand
-    /// back for it. `find_missing_transmissions` nevertheless decides whether the bytes are needed
-    /// with `contains_transmission`, which is also true for an aborted ID - so the bytes are
-    /// discarded, and the certificate that declares the ID is accepted into storage while the
-    /// transmission it commits to can never be materialized.
-    ///
-    /// Note the in-memory service does not share this behavior: it consults only its concrete map,
-    /// collects the bytes, and stores them.
-    #[test]
-    fn test_provided_bytes_are_kept_for_a_previously_aborted_id() {
-        let rng = &mut TestRng::default();
-        let storage = BFTPersistentStorage::<CurrentNetwork>::open(StorageMode::new_test(None)).unwrap();
-        let transmission_id = sample_transmission_id(rng);
-        let transmission = sample_transmission(b"payload");
-
-        // An earlier certificate recorded the ID as aborted, so storage contains it without bytes.
-        storage.insert_transmissions(
-            Field::rand(rng),
-            Default::default(),
-            [transmission_id].into(),
-            Default::default(),
-        );
-        assert!(storage.contains_transmission(transmission_id));
-        assert!(storage.get_transmission(transmission_id).is_none());
-
-        // A later certificate declares the same ID and provides its bytes.
-        let batch_header = sample_batch_header(&[transmission_id], rng);
-        let missing_transmissions = storage
-            .find_missing_transmissions(
-                &batch_header,
-                [(transmission_id, transmission.clone())].into(),
-                Default::default(),
-            )
-            .unwrap();
-
-        // The bytes have to be collected...
-        assert_eq!(
-            missing_transmissions.get(&transmission_id),
-            Some(&transmission),
-            "the provided bytes were discarded, so they will never reach storage"
-        );
-
-        // ...and, once inserted, they have to be retrievable, or the certificate that declares this
-        // transmission ID cannot be committed.
-        storage.insert_transmissions(
-            Field::rand(rng),
-            indexset![transmission_id],
-            Default::default(),
-            missing_transmissions,
-        );
-        assert_eq!(storage.get_transmission(transmission_id), Some(transmission));
     }
 }

--- a/node/bft/storage-service/src/persistent.rs
+++ b/node/bft/storage-service/src/persistent.rs
@@ -162,8 +162,8 @@ impl<N: Network> StorageService<N> for BFTPersistentStorage<N> {
                         // asking whether storage knows the ID at all - without repeating the
                         // lookup that just came back empty.
                         if !aborted_transmission_ids.contains(&transmission_id) {
-                            // An ID that storage already knows as aborted needs no bytes from
-                            // anyone, but this certificate still has to be counted against the
+                            // An ID that storage already knows as aborted needs no bytes to be
+                            // inserted, but this certificate still has to be counted against the
                             // aborted entry: `remove_transmissions` decrements it either way.
                             if self.contains_aborted_transmission(transmission_id) {
                                 aborted_transmission_ids.insert(transmission_id);

--- a/node/bft/storage-service/src/tests.rs
+++ b/node/bft/storage-service/src/tests.rs
@@ -1,0 +1,256 @@
+// Copyright (c) 2019-2026 Provable Inc.
+// This file is part of the snarkOS library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The expectations that every [`StorageService`] implementation has to meet.
+//!
+//! These are the queries whose answers the rest of the BFT reasons about, and
+//! `find_missing_transmissions` is now shared by every implementation, so they are asserted here
+//! once and instantiated per service rather than restated in each one. Behavior specific to a single
+//! service - the persistent one's cache, the in-memory one's locking - stays in its own module.
+
+use crate::{StorageService, memory::BFTMemoryService, persistent::BFTPersistentStorage};
+use snarkvm::{
+    console::network::MainnetV0,
+    ledger::narwhal::{BatchHeader, Data, Transmission, TransmissionID},
+    prelude::{Field, Network, PrivateKey, Rng, TestRng, Uniform},
+};
+
+use aleo_std::StorageMode;
+use bytes::Bytes;
+use indexmap::indexset;
+
+type CurrentNetwork = MainnetV0;
+
+fn sample_transmission_id(rng: &mut TestRng) -> TransmissionID<CurrentNetwork> {
+    TransmissionID::Transaction(
+        <CurrentNetwork as Network>::TransactionID::from(Field::rand(rng)),
+        <CurrentNetwork as Network>::TransmissionChecksum::from(rng.random::<u128>()),
+    )
+}
+
+fn sample_transmission(payload: &[u8]) -> Transmission<CurrentNetwork> {
+    Transmission::Transaction(Data::Buffer(Bytes::from(payload.to_vec())))
+}
+
+/// Builds a batch header declaring the given transmission IDs.
+fn sample_batch_header(
+    transmission_ids: &[TransmissionID<CurrentNetwork>],
+    rng: &mut TestRng,
+) -> BatchHeader<CurrentNetwork> {
+    let private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
+    // Round 1 is the only round that may carry no previous certificate IDs.
+    BatchHeader::new(
+        &private_key,
+        1,
+        0,
+        Field::rand(rng),
+        transmission_ids.iter().copied().collect(),
+        Default::default(),
+        rng,
+    )
+    .unwrap()
+}
+
+/// Records the given transmission ID as aborted, as an earlier certificate would have.
+fn record_as_aborted(
+    service: &impl StorageService<CurrentNetwork>,
+    transmission_id: TransmissionID<CurrentNetwork>,
+    rng: &mut TestRng,
+) {
+    service.insert_transmissions(Field::rand(rng), Default::default(), [transmission_id].into(), Default::default());
+}
+
+/// The three containment queries must answer three different questions: a stored transmission is
+/// retrievable, an aborted ID is known but has nothing to return, and both are contained.
+fn check_containment_queries_distinguish_stored_from_aborted_ids(service: &impl StorageService<CurrentNetwork>) {
+    let rng = &mut TestRng::default();
+    let (stored_id, aborted_id, unknown_id) =
+        (sample_transmission_id(rng), sample_transmission_id(rng), sample_transmission_id(rng));
+
+    service.insert_transmissions(
+        Field::rand(rng),
+        indexset![stored_id],
+        [aborted_id].into(),
+        [(stored_id, sample_transmission(b"payload"))].into(),
+    );
+
+    // The stored transmission is contained and retrievable, but not aborted.
+    assert!(service.contains_transmission(stored_id));
+    assert!(service.contains_retrievable_transmission(stored_id));
+    assert!(!service.contains_aborted_transmission(stored_id));
+
+    // The aborted ID is contained and aborted, but not retrievable.
+    assert!(service.contains_transmission(aborted_id));
+    assert!(!service.contains_retrievable_transmission(aborted_id));
+    assert!(service.contains_aborted_transmission(aborted_id));
+
+    // An unknown ID is none of the three.
+    assert!(!service.contains_transmission(unknown_id));
+    assert!(!service.contains_retrievable_transmission(unknown_id));
+    assert!(!service.contains_aborted_transmission(unknown_id));
+}
+
+/// Only the transmissions that storage lacks are returned, so the primary does not re-insert a
+/// payload it already holds.
+fn check_find_missing_transmissions_returns_only_what_storage_lacks(service: &impl StorageService<CurrentNetwork>) {
+    let rng = &mut TestRng::default();
+    let (stored_id, missing_id) = (sample_transmission_id(rng), sample_transmission_id(rng));
+    let missing = sample_transmission(b"missing");
+
+    service.insert_transmissions(
+        Field::rand(rng),
+        indexset![stored_id],
+        Default::default(),
+        [(stored_id, sample_transmission(b"stored"))].into(),
+    );
+
+    let batch_header = sample_batch_header(&[stored_id, missing_id], rng);
+    let result = service
+        .find_missing_transmissions(
+            &batch_header,
+            [(stored_id, sample_transmission(b"stored")), (missing_id, missing.clone())].into(),
+            Default::default(),
+        )
+        .unwrap();
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(result.get(&missing_id), Some(&missing));
+}
+
+/// An ID the caller declares as aborted is satisfied without a payload, and contributes nothing to
+/// fetch.
+fn check_find_missing_transmissions_accepts_a_declared_aborted_id(service: &impl StorageService<CurrentNetwork>) {
+    let rng = &mut TestRng::default();
+    let aborted_id = sample_transmission_id(rng);
+
+    let batch_header = sample_batch_header(&[aborted_id], rng);
+    let result = service.find_missing_transmissions(&batch_header, Default::default(), [aborted_id].into()).unwrap();
+
+    assert!(result.is_empty());
+}
+
+/// An ID that storage already recorded as aborted needs neither bytes nor a fresh declaration:
+/// there is nothing to fetch, because no peer holds a transmission for an aborted ID either.
+///
+/// Only the caller that has the block can declare the ID itself; a batch proposed or certified by a
+/// peer arrives with an empty set of aborted IDs.
+fn check_find_missing_transmissions_accepts_an_already_aborted_id_without_bytes(
+    service: &impl StorageService<CurrentNetwork>,
+) {
+    let rng = &mut TestRng::default();
+    let aborted_id = sample_transmission_id(rng);
+
+    record_as_aborted(service, aborted_id, rng);
+
+    let batch_header = sample_batch_header(&[aborted_id], rng);
+    let result = service.find_missing_transmissions(&batch_header, Default::default(), Default::default()).unwrap();
+
+    assert!(result.is_empty());
+}
+
+/// A transmission whose ID an earlier certificate recorded as aborted must still be persisted when a
+/// later certificate provides its bytes.
+///
+/// An aborted entry records the ID and nothing else, so `get_transmission` has nothing to hand back
+/// for it. Discarding the bytes would accept the certificate that declares the ID into storage while
+/// the transmission it commits to could never be materialized.
+fn check_find_missing_transmissions_keeps_provided_bytes_for_an_aborted_id(
+    service: &impl StorageService<CurrentNetwork>,
+) {
+    let rng = &mut TestRng::default();
+    let transmission_id = sample_transmission_id(rng);
+    let transmission = sample_transmission(b"payload");
+
+    // An earlier certificate recorded the ID as aborted, so storage contains it without bytes.
+    record_as_aborted(service, transmission_id, rng);
+    assert!(service.contains_transmission(transmission_id));
+    assert!(service.get_transmission(transmission_id).is_none());
+
+    // A later certificate declares the same ID and provides its bytes.
+    let batch_header = sample_batch_header(&[transmission_id], rng);
+    let missing_transmissions = service
+        .find_missing_transmissions(&batch_header, [(transmission_id, transmission.clone())].into(), Default::default())
+        .unwrap();
+
+    // The bytes have to be collected...
+    assert_eq!(
+        missing_transmissions.get(&transmission_id),
+        Some(&transmission),
+        "the provided bytes were discarded, so they will never reach storage"
+    );
+
+    // ...and, once inserted, they have to be retrievable, or the certificate that declares this
+    // transmission ID cannot be committed.
+    service.insert_transmissions(
+        Field::rand(rng),
+        indexset![transmission_id],
+        Default::default(),
+        missing_transmissions,
+    );
+    assert_eq!(service.get_transmission(transmission_id), Some(transmission));
+}
+
+/// This is the check that stops a peer from having its certificate accepted while withholding the
+/// transmissions the certificate commits to.
+fn check_find_missing_transmissions_rejects_an_unprovided_undeclared_id(service: &impl StorageService<CurrentNetwork>) {
+    let rng = &mut TestRng::default();
+    let undeclared_id = sample_transmission_id(rng);
+
+    let batch_header = sample_batch_header(&[undeclared_id], rng);
+
+    assert!(service.find_missing_transmissions(&batch_header, Default::default(), Default::default()).is_err());
+}
+
+/// Instantiates every shared expectation against the given storage service.
+macro_rules! storage_service_tests {
+    ($module:ident, $service:expr) => {
+        mod $module {
+            use super::*;
+
+            #[test]
+            fn containment_queries_distinguish_stored_from_aborted_ids() {
+                check_containment_queries_distinguish_stored_from_aborted_ids(&$service);
+            }
+
+            #[test]
+            fn find_missing_transmissions_returns_only_what_storage_lacks() {
+                check_find_missing_transmissions_returns_only_what_storage_lacks(&$service);
+            }
+
+            #[test]
+            fn find_missing_transmissions_accepts_a_declared_aborted_id() {
+                check_find_missing_transmissions_accepts_a_declared_aborted_id(&$service);
+            }
+
+            #[test]
+            fn find_missing_transmissions_accepts_an_already_aborted_id_without_bytes() {
+                check_find_missing_transmissions_accepts_an_already_aborted_id_without_bytes(&$service);
+            }
+
+            #[test]
+            fn find_missing_transmissions_keeps_provided_bytes_for_an_aborted_id() {
+                check_find_missing_transmissions_keeps_provided_bytes_for_an_aborted_id(&$service);
+            }
+
+            #[test]
+            fn find_missing_transmissions_rejects_an_unprovided_undeclared_id() {
+                check_find_missing_transmissions_rejects_an_unprovided_undeclared_id(&$service);
+            }
+        }
+    };
+}
+
+storage_service_tests!(memory, BFTMemoryService::<CurrentNetwork>::new());
+storage_service_tests!(persistent, BFTPersistentStorage::<CurrentNetwork>::open(StorageMode::new_test(None)).unwrap());

--- a/node/bft/storage-service/src/tests.rs
+++ b/node/bft/storage-service/src/tests.rs
@@ -20,13 +20,18 @@
 //! once and instantiated per service rather than restated in each one. Behavior specific to a single
 //! service - the persistent one's cache, the in-memory one's locking - stays in its own module.
 
-use crate::{StorageService, memory::BFTMemoryService, persistent::BFTPersistentStorage};
+use crate::StorageService;
+#[cfg(feature = "memory")]
+use crate::memory::BFTMemoryService;
+#[cfg(feature = "persistent")]
+use crate::persistent::BFTPersistentStorage;
 use snarkvm::{
     console::network::MainnetV0,
     ledger::narwhal::{BatchHeader, Data, Transmission, TransmissionID},
     prelude::{Field, Network, PrivateKey, Rng, TestRng, Uniform},
 };
 
+#[cfg(feature = "persistent")]
 use aleo_std::StorageMode;
 use bytes::Bytes;
 use indexmap::indexset;
@@ -296,5 +301,7 @@ macro_rules! storage_service_tests {
     };
 }
 
+#[cfg(feature = "memory")]
 storage_service_tests!(memory, BFTMemoryService::<CurrentNetwork>::new());
+#[cfg(feature = "persistent")]
 storage_service_tests!(persistent, BFTPersistentStorage::<CurrentNetwork>::open(StorageMode::new_test(None)).unwrap());

--- a/node/bft/storage-service/src/tests.rs
+++ b/node/bft/storage-service/src/tests.rs
@@ -72,8 +72,8 @@ fn record_as_aborted(
     service.insert_transmissions(Field::rand(rng), Default::default(), [transmission_id].into(), Default::default());
 }
 
-/// The three containment queries must answer three different questions: a stored transmission is
-/// retrievable, an aborted ID is known but has nothing to return, and both are contained.
+/// The two containment queries answer different questions: a stored transmission is retrievable,
+/// and an ID recorded as aborted is known but has nothing to return.
 fn check_containment_queries_distinguish_stored_from_aborted_ids(service: &impl StorageService<CurrentNetwork>) {
     let rng = &mut TestRng::default();
     let (stored_id, aborted_id, unknown_id) =
@@ -86,18 +86,15 @@ fn check_containment_queries_distinguish_stored_from_aborted_ids(service: &impl 
         [(stored_id, sample_transmission(b"payload"))].into(),
     );
 
-    // The stored transmission is contained and retrievable, but not aborted.
-    assert!(service.contains_transmission(stored_id));
+    // The stored transmission is retrievable, but not aborted.
     assert!(service.contains_retrievable_transmission(stored_id));
     assert!(!service.contains_aborted_transmission(stored_id));
 
-    // The aborted ID is contained and aborted, but not retrievable.
-    assert!(service.contains_transmission(aborted_id));
+    // The aborted ID is aborted, but not retrievable.
     assert!(!service.contains_retrievable_transmission(aborted_id));
     assert!(service.contains_aborted_transmission(aborted_id));
 
-    // An unknown ID is none of the three.
-    assert!(!service.contains_transmission(unknown_id));
+    // An unknown ID is neither.
     assert!(!service.contains_retrievable_transmission(unknown_id));
     assert!(!service.contains_aborted_transmission(unknown_id));
 }
@@ -142,7 +139,6 @@ fn check_an_id_can_be_aborted_and_retrievable_at_once(service: &impl StorageServ
     service.remove_transmissions(&storing, &indexset![stored_first]);
     assert!(!service.contains_retrievable_transmission(stored_first));
     assert!(service.contains_aborted_transmission(stored_first));
-    assert!(service.contains_transmission(stored_first));
 }
 
 /// Only the transmissions that storage lacks are returned, so the primary does not re-insert a
@@ -218,7 +214,7 @@ fn check_find_missing_transmissions_keeps_provided_bytes_for_an_aborted_id(
 
     // An earlier certificate recorded the ID as aborted, so storage contains it without bytes.
     record_as_aborted(service, transmission_id, rng);
-    assert!(service.contains_transmission(transmission_id));
+    assert!(service.contains_aborted_transmission(transmission_id));
     assert!(service.get_transmission(transmission_id).is_none());
 
     // A later certificate declares the same ID and provides its bytes.

--- a/node/bft/storage-service/src/tests.rs
+++ b/node/bft/storage-service/src/tests.rs
@@ -102,6 +102,49 @@ fn check_containment_queries_distinguish_stored_from_aborted_ids(service: &impl 
     assert!(!service.contains_aborted_transmission(unknown_id));
 }
 
+/// Being recorded as aborted and holding a transmission are not mutually exclusive: one certificate
+/// can record an ID as aborted while another provides the bytes for it.
+///
+/// Each entry is reference counted against its own certificates, so removing either certificate has
+/// to leave the other entry untouched. Code that means "aborted, with nothing to hand back" has to
+/// say so with both queries; `contains_aborted_transmission` alone does not express it.
+fn check_an_id_can_be_aborted_and_retrievable_at_once(service: &impl StorageService<CurrentNetwork>) {
+    let rng = &mut TestRng::default();
+    let transmission = sample_transmission(b"payload");
+
+    // Puts an ID into the both-true state, returning the aborting and the storing certificate ID.
+    let record_both_ways = |transmission_id, rng: &mut TestRng| {
+        let (aborting, storing) = (Field::rand(rng), Field::rand(rng));
+        service.insert_transmissions(aborting, Default::default(), [transmission_id].into(), Default::default());
+        service.insert_transmissions(
+            storing,
+            indexset![transmission_id],
+            Default::default(),
+            [(transmission_id, transmission.clone())].into(),
+        );
+        assert!(service.contains_retrievable_transmission(transmission_id));
+        assert!(service.contains_aborted_transmission(transmission_id));
+        assert_eq!(service.get_transmission(transmission_id), Some(transmission.clone()));
+        (aborting, storing)
+    };
+
+    // Dropping the certificate that recorded the abort leaves the transmission retrievable.
+    let aborted_first = sample_transmission_id(rng);
+    let (aborting, _) = record_both_ways(aborted_first, rng);
+    service.remove_transmissions(&aborting, &indexset![aborted_first]);
+    assert!(service.contains_retrievable_transmission(aborted_first));
+    assert!(!service.contains_aborted_transmission(aborted_first));
+    assert_eq!(service.get_transmission(aborted_first), Some(transmission.clone()));
+
+    // Dropping the certificate that provided the bytes leaves the aborted entry in place.
+    let stored_first = sample_transmission_id(rng);
+    let (_, storing) = record_both_ways(stored_first, rng);
+    service.remove_transmissions(&storing, &indexset![stored_first]);
+    assert!(!service.contains_retrievable_transmission(stored_first));
+    assert!(service.contains_aborted_transmission(stored_first));
+    assert!(service.contains_transmission(stored_first));
+}
+
 /// Only the transmissions that storage lacks are returned, so the primary does not re-insert a
 /// payload it already holds.
 fn check_find_missing_transmissions_returns_only_what_storage_lacks(service: &impl StorageService<CurrentNetwork>) {
@@ -222,6 +265,11 @@ macro_rules! storage_service_tests {
             #[test]
             fn containment_queries_distinguish_stored_from_aborted_ids() {
                 check_containment_queries_distinguish_stored_from_aborted_ids(&$service);
+            }
+
+            #[test]
+            fn an_id_can_be_aborted_and_retrievable_at_once() {
+                check_an_id_can_be_aborted_and_retrievable_at_once(&$service);
             }
 
             #[test]

--- a/node/bft/storage-service/src/tests.rs
+++ b/node/bft/storage-service/src/tests.rs
@@ -252,6 +252,54 @@ fn check_aborted_transmission_ids_are_reference_counted_too(service: &impl Stora
     assert!(!service.contains_aborted_transmission(transmission_id));
 }
 
+/// A certificate that neither provides nor declares an ID that storage already recorded as aborted
+/// still has to be counted against the aborted entry.
+///
+/// Callers outside the block sync pass an empty set of aborted IDs, so this is the only place that
+/// can recognize such an ID - and it has to, because `remove_transmissions` decrements the aborted
+/// entry for every ID the certificate declares. Crediting neither map would let the certificate that
+/// first recorded the abort take the entry with it, leaving this one referring to an ID storage no
+/// longer knows.
+fn check_an_already_aborted_id_is_counted_against_a_later_certificate(service: &impl StorageService<CurrentNetwork>) {
+    let rng = &mut TestRng::default();
+    let transmission_id = sample_transmission_id(rng);
+    let (aborting, later) = (Field::rand(rng), Field::rand(rng));
+
+    // An earlier certificate records the ID as aborted.
+    service.insert_transmissions(aborting, Default::default(), [transmission_id].into(), Default::default());
+
+    // A later certificate declares the same ID, the way the primary does: no transmissions, and
+    // nothing declared as aborted.
+    service.insert_transmissions(later, indexset![transmission_id], Default::default(), Default::default());
+
+    // Dropping the certificate that recorded the abort must leave the entry for the later one...
+    service.remove_transmissions(&aborting, &indexset![transmission_id]);
+    assert!(
+        service.contains_aborted_transmission(transmission_id),
+        "the later certificate was not counted, so its transmission ID is now unknown to storage"
+    );
+
+    // ...and dropping that one as well must then remove it.
+    service.remove_transmissions(&later, &indexset![transmission_id]);
+    assert!(!service.contains_aborted_transmission(transmission_id));
+}
+
+/// An ID that storage does not know at all is not recorded as aborted on the way past.
+///
+/// The counting above applies only to an ID storage already recorded as aborted; a declared ID that
+/// nobody can produce is undeliverable, and must not be turned into an aborted entry that would
+/// answer for it.
+fn check_an_unknown_undeliverable_id_is_not_recorded_as_aborted(service: &impl StorageService<CurrentNetwork>) {
+    let rng = &mut TestRng::default();
+    let transmission_id = sample_transmission_id(rng);
+
+    service.insert_transmissions(Field::rand(rng), indexset![transmission_id], Default::default(), Default::default());
+
+    assert!(!service.contains_aborted_transmission(transmission_id));
+    assert!(!service.contains_retrievable_transmission(transmission_id));
+    assert!(service.as_hashmap().is_empty());
+}
+
 /// Being recorded as aborted and holding a transmission are not mutually exclusive: one certificate
 /// can record an ID as aborted while another provides the bytes for it.
 ///
@@ -454,6 +502,16 @@ macro_rules! storage_service_tests {
             #[test]
             fn aborted_transmission_ids_are_reference_counted_too() {
                 check_aborted_transmission_ids_are_reference_counted_too(&$service);
+            }
+
+            #[test]
+            fn an_already_aborted_id_is_counted_against_a_later_certificate() {
+                check_an_already_aborted_id_is_counted_against_a_later_certificate(&$service);
+            }
+
+            #[test]
+            fn an_unknown_undeliverable_id_is_not_recorded_as_aborted() {
+                check_an_unknown_undeliverable_id_is_not_recorded_as_aborted(&$service);
             }
 
             #[test]

--- a/node/bft/storage-service/src/tests.rs
+++ b/node/bft/storage-service/src/tests.rs
@@ -77,6 +77,121 @@ fn record_as_aborted(
     service.insert_transmissions(Field::rand(rng), Default::default(), [transmission_id].into(), Default::default());
 }
 
+/// A service that was handed nothing knows nothing.
+fn check_a_new_service_holds_nothing(service: &impl StorageService<CurrentNetwork>) {
+    let rng = &mut TestRng::default();
+    let transmission_id = sample_transmission_id(rng);
+
+    assert!(!service.contains_retrievable_transmission(transmission_id));
+    assert!(!service.contains_aborted_transmission(transmission_id));
+    assert!(service.get_transmission(transmission_id).is_none());
+    assert!(service.as_hashmap().is_empty());
+}
+
+/// An inserted transmission is the one that comes back out.
+fn check_an_inserted_transmission_is_retrievable(service: &impl StorageService<CurrentNetwork>) {
+    let rng = &mut TestRng::default();
+    let transmission_id = sample_transmission_id(rng);
+    let transmission = sample_transmission(b"payload");
+    let certificate_id = Field::rand(rng);
+
+    service.insert_transmissions(
+        certificate_id,
+        indexset![transmission_id],
+        Default::default(),
+        [(transmission_id, transmission.clone())].into(),
+    );
+
+    assert!(service.contains_retrievable_transmission(transmission_id));
+    assert_eq!(service.get_transmission(transmission_id), Some(transmission));
+}
+
+/// A second certificate carrying a different payload under the same ID does not replace the stored
+/// transmission; it only adds its reference.
+fn check_a_stored_transmission_is_not_overwritten_by_a_later_insert(service: &impl StorageService<CurrentNetwork>) {
+    let rng = &mut TestRng::default();
+    let transmission_id = sample_transmission_id(rng);
+    let original = sample_transmission(b"original");
+    let (first, second) = (Field::rand(rng), Field::rand(rng));
+
+    service.insert_transmissions(
+        first,
+        indexset![transmission_id],
+        Default::default(),
+        [(transmission_id, original.clone())].into(),
+    );
+    // A second certificate arrives carrying a different payload under the same ID. The stored
+    // transmission wins: the occupied branch only records the new certificate ID.
+    service.insert_transmissions(
+        second,
+        indexset![transmission_id],
+        Default::default(),
+        [(transmission_id, sample_transmission(b"replacement"))].into(),
+    );
+
+    assert_eq!(service.get_transmission(transmission_id), Some(original));
+}
+
+/// A transmission is reference counted, and survives until its last certificate is removed.
+fn check_a_transmission_survives_until_its_last_certificate_is_removed(service: &impl StorageService<CurrentNetwork>) {
+    let rng = &mut TestRng::default();
+    let transmission_id = sample_transmission_id(rng);
+    let transmission = sample_transmission(b"payload");
+    let (first, second) = (Field::rand(rng), Field::rand(rng));
+
+    // Two certificates referencing one transmission, as happens when the primary processes
+    // batches from several peers that all include the same transaction.
+    service.insert_transmissions(
+        first,
+        indexset![transmission_id],
+        Default::default(),
+        [(transmission_id, transmission.clone())].into(),
+    );
+    service.insert_transmissions(second, indexset![transmission_id], Default::default(), Default::default());
+
+    let (_, certificate_ids) = service.as_hashmap().remove(&transmission_id).unwrap();
+    assert_eq!(certificate_ids.len(), 2);
+
+    // Dropping one reference must not drop the transmission...
+    service.remove_transmissions(&first, &indexset![transmission_id]);
+    assert!(service.contains_retrievable_transmission(transmission_id));
+
+    // ...but dropping the last one must.
+    service.remove_transmissions(&second, &indexset![transmission_id]);
+    assert!(!service.contains_retrievable_transmission(transmission_id));
+    assert!(service.get_transmission(transmission_id).is_none());
+}
+
+/// Removing a certificate that never referenced a transmission leaves it in place.
+fn check_removing_an_unrelated_certificate_leaves_the_transmission_in_place(
+    service: &impl StorageService<CurrentNetwork>,
+) {
+    let rng = &mut TestRng::default();
+    let transmission_id = sample_transmission_id(rng);
+    let certificate_id = Field::rand(rng);
+
+    service.insert_transmissions(
+        certificate_id,
+        indexset![transmission_id],
+        Default::default(),
+        [(transmission_id, sample_transmission(b"payload"))].into(),
+    );
+
+    // Removing a certificate that never referenced this transmission must not evict it.
+    service.remove_transmissions(&Field::rand(rng), &indexset![transmission_id]);
+
+    assert!(service.contains_retrievable_transmission(transmission_id));
+}
+
+/// Removing from a service that holds nothing is a no-op, rather than an error or a phantom entry.
+fn check_removing_from_an_empty_service_is_a_no_op(service: &impl StorageService<CurrentNetwork>) {
+    let rng = &mut TestRng::default();
+
+    service.remove_transmissions(&Field::rand(rng), &indexset![sample_transmission_id(rng)]);
+
+    assert!(service.as_hashmap().is_empty());
+}
+
 /// The two containment queries answer different questions: a stored transmission is retrievable,
 /// and an ID recorded as aborted is known but has nothing to return.
 fn check_containment_queries_distinguish_stored_from_aborted_ids(service: &impl StorageService<CurrentNetwork>) {
@@ -102,6 +217,39 @@ fn check_containment_queries_distinguish_stored_from_aborted_ids(service: &impl 
     // An unknown ID is neither.
     assert!(!service.contains_retrievable_transmission(unknown_id));
     assert!(!service.contains_aborted_transmission(unknown_id));
+}
+
+/// An aborted ID is recorded on its own, without creating an entry in the transmissions map.
+fn check_an_aborted_transmission_id_is_recorded_but_has_no_payload(service: &impl StorageService<CurrentNetwork>) {
+    let rng = &mut TestRng::default();
+    let transmission_id = sample_transmission_id(rng);
+
+    record_as_aborted(service, transmission_id, rng);
+
+    // The asymmetry is deliberate: an aborted ID is known to storage, but there is no
+    // transmission to hand back for it.
+    assert!(service.contains_aborted_transmission(transmission_id));
+    assert!(!service.contains_retrievable_transmission(transmission_id));
+    assert!(service.get_transmission(transmission_id).is_none());
+    assert!(service.as_hashmap().is_empty());
+}
+
+/// An aborted ID is reference counted the same way a transmission is, and survives until the last
+/// certificate that recorded it is removed.
+fn check_aborted_transmission_ids_are_reference_counted_too(service: &impl StorageService<CurrentNetwork>) {
+    let rng = &mut TestRng::default();
+    let transmission_id = sample_transmission_id(rng);
+    let (first, second) = (Field::rand(rng), Field::rand(rng));
+
+    for certificate_id in [first, second] {
+        service.insert_transmissions(certificate_id, Default::default(), [transmission_id].into(), Default::default());
+    }
+
+    service.remove_transmissions(&first, &indexset![transmission_id]);
+    assert!(service.contains_aborted_transmission(transmission_id));
+
+    service.remove_transmissions(&second, &indexset![transmission_id]);
+    assert!(!service.contains_aborted_transmission(transmission_id));
 }
 
 /// Being recorded as aborted and holding a transmission are not mutually exclusive: one certificate
@@ -264,8 +412,48 @@ macro_rules! storage_service_tests {
             use super::*;
 
             #[test]
+            fn a_new_service_holds_nothing() {
+                check_a_new_service_holds_nothing(&$service);
+            }
+
+            #[test]
+            fn an_inserted_transmission_is_retrievable() {
+                check_an_inserted_transmission_is_retrievable(&$service);
+            }
+
+            #[test]
+            fn a_stored_transmission_is_not_overwritten_by_a_later_insert() {
+                check_a_stored_transmission_is_not_overwritten_by_a_later_insert(&$service);
+            }
+
+            #[test]
+            fn a_transmission_survives_until_its_last_certificate_is_removed() {
+                check_a_transmission_survives_until_its_last_certificate_is_removed(&$service);
+            }
+
+            #[test]
+            fn removing_an_unrelated_certificate_leaves_the_transmission_in_place() {
+                check_removing_an_unrelated_certificate_leaves_the_transmission_in_place(&$service);
+            }
+
+            #[test]
+            fn removing_from_an_empty_service_is_a_no_op() {
+                check_removing_from_an_empty_service_is_a_no_op(&$service);
+            }
+
+            #[test]
             fn containment_queries_distinguish_stored_from_aborted_ids() {
                 check_containment_queries_distinguish_stored_from_aborted_ids(&$service);
+            }
+
+            #[test]
+            fn an_aborted_transmission_id_is_recorded_but_has_no_payload() {
+                check_an_aborted_transmission_id_is_recorded_but_has_no_payload(&$service);
+            }
+
+            #[test]
+            fn aborted_transmission_ids_are_reference_counted_too() {
+                check_aborted_transmission_ids_are_reference_counted_too(&$service);
             }
 
             #[test]

--- a/node/bft/storage-service/src/tests.rs
+++ b/node/bft/storage-service/src/tests.rs
@@ -287,8 +287,8 @@ fn check_an_already_aborted_id_is_counted_against_a_later_certificate(service: &
 /// An ID that storage does not know at all is not recorded as aborted on the way past.
 ///
 /// The counting above applies only to an ID storage already recorded as aborted; a declared ID that
-/// nobody can produce is undeliverable, and must not be turned into an aborted entry that would
-/// answer for it.
+/// neither storage nor the caller can produce is undeliverable, and must not be turned into an
+/// aborted entry that would answer for it.
 fn check_an_unknown_undeliverable_id_is_not_recorded_as_aborted(service: &impl StorageService<CurrentNetwork>) {
     let rng = &mut TestRng::default();
     let transmission_id = sample_transmission_id(rng);
@@ -381,11 +381,12 @@ fn check_find_missing_transmissions_accepts_a_declared_aborted_id(service: &impl
     assert!(result.is_empty());
 }
 
-/// An ID that storage already recorded as aborted needs neither bytes nor a fresh declaration:
-/// there is nothing to fetch, because no peer holds a transmission for an aborted ID either.
+/// An ID that storage already recorded as aborted needs neither bytes nor a fresh declaration: the
+/// marker is enough for the service to accept it.
 ///
 /// Only the caller that has the block can declare the ID itself; a batch proposed or certified by a
-/// peer arrives with an empty set of aborted IDs.
+/// peer arrives with an empty set of aborted IDs. Whether a peer can still serve the bytes is the
+/// caller's question, not this one's.
 fn check_find_missing_transmissions_accepts_an_already_aborted_id_without_bytes(
     service: &impl StorageService<CurrentNetwork>,
 ) {

--- a/node/bft/storage-service/src/traits.rs
+++ b/node/bft/storage-service/src/traits.rs
@@ -15,7 +15,7 @@
 
 use snarkvm::{
     ledger::narwhal::{BatchHeader, Transmission, TransmissionID},
-    prelude::{Field, Network, Result},
+    prelude::{Field, Network, Result, bail},
 };
 
 use indexmap::IndexSet;
@@ -52,14 +52,48 @@ pub trait StorageService<N: Network>: Debug + Send + Sync {
     /// If the transmission ID does not exist in storage, `None` is returned.
     fn get_transmission(&self, transmission_id: TransmissionID<N>) -> Option<Transmission<N>>;
 
-    /// Takes a certificate and its transmissions, and returns the subset of transmissions that
-    /// did not yet exists in the storage.
+    /// Takes a batch header and the transmissions provided for it, and returns the subset of those
+    /// transmissions that the storage does not already hold.
+    ///
+    /// A transmission that cannot be retrieved from storage has to be provided by the caller, or be
+    /// aborted - either as declared by the caller, or as already recorded in storage, in which case
+    /// there are no bytes to be had from anyone. Anything else is an error: a peer does not get to
+    /// have a certificate accepted while withholding a transmission that it commits to.
     fn find_missing_transmissions(
         &self,
         batch_header: &BatchHeader<N>,
-        transmissions: HashMap<TransmissionID<N>, Transmission<N>>,
+        mut transmissions: HashMap<TransmissionID<N>, Transmission<N>>,
         aborted_transmissions: HashSet<TransmissionID<N>>,
-    ) -> Result<HashMap<TransmissionID<N>, Transmission<N>>>;
+    ) -> Result<HashMap<TransmissionID<N>, Transmission<N>>> {
+        // Initialize a list for the missing transmissions from storage.
+        let mut missing_transmissions = HashMap::new();
+        // Ensure the declared transmission IDs are all present in storage or the given transmissions map.
+        for transmission_id in batch_header.transmission_ids() {
+            // If the transmission cannot be retrieved from storage, ensure it was provided by the
+            // caller. Note that an ID recorded as aborted holds no transmission, so bytes provided
+            // for it must still be collected here in order to become retrievable.
+            if !self.contains_retrievable_transmission(*transmission_id) {
+                // Retrieve the transmission.
+                match transmissions.remove(transmission_id) {
+                    // Append the transmission if it exists.
+                    Some(transmission) => {
+                        missing_transmissions.insert(*transmission_id, transmission);
+                    }
+                    // If the transmission does not exist, it must be aborted: either the caller
+                    // declares it as such, or storage already recorded it as aborted for an earlier
+                    // certificate - in which case there are no bytes to be had from anyone.
+                    None => {
+                        if !aborted_transmissions.contains(transmission_id)
+                            && !self.contains_aborted_transmission(*transmission_id)
+                        {
+                            bail!("Failed to provide a transmission");
+                        }
+                    }
+                }
+            }
+        }
+        Ok(missing_transmissions)
+    }
 
     /// Inserts the given certificate ID for each of the transmission IDs, using the missing transmissions map, into storage.
     fn insert_transmissions(

--- a/node/bft/storage-service/src/traits.rs
+++ b/node/bft/storage-service/src/traits.rs
@@ -96,6 +96,17 @@ pub trait StorageService<N: Network>: Debug + Send + Sync {
     }
 
     /// Inserts the given certificate ID for each of the transmission IDs, using the missing transmissions map, into storage.
+    ///
+    /// The certificate has to be counted against every ID it declares: against the transmission
+    /// entry for the IDs whose bytes storage holds or the caller provides, and against the aborted
+    /// entry for the rest - both the IDs the caller declares as aborted, and the ones storage
+    /// already recorded as aborted for an earlier certificate. [`Self::remove_transmissions`]
+    /// decrements both maps for every declared ID, so an ID that is credited to neither is dropped
+    /// from storage while this certificate still refers to it.
+    ///
+    /// Note that this makes the implementation, rather than the caller, responsible for recognizing
+    /// an already-aborted ID: only the implementation can decide it under the locks that
+    /// [`Self::remove_transmissions`] takes as well.
     fn insert_transmissions(
         &self,
         certificate_id: Field<N>,

--- a/node/bft/storage-service/src/traits.rs
+++ b/node/bft/storage-service/src/traits.rs
@@ -37,15 +37,18 @@ pub trait StorageService<N: Network>: Debug + Send + Sync {
     /// Returns `true` if the storage holds the transmission for the specified `transmission ID`,
     /// i.e. exactly when [`Self::get_transmission`] would return `Some`.
     ///
-    /// Unlike [`Self::contains_transmission`], this is `false` for an ID that is only recorded as
+    /// Unlike [`Self::contains_transmission`], this is `false` for an ID that storage knows only as
     /// aborted. Prefer this over `get_transmission(id).is_some()`, which clones the transmission.
     fn contains_retrievable_transmission(&self, transmission_id: TransmissionID<N>) -> bool;
 
-    /// Returns `true` if the specified `transmission ID` is recorded as aborted, i.e. the storage
-    /// knows the ID but holds no transmission for it.
+    /// Returns `true` if the specified `transmission ID` is recorded as aborted.
     ///
-    /// This is `true` for the IDs that [`Self::contains_transmission`] reports but
-    /// [`Self::contains_retrievable_transmission`] does not.
+    /// This and [`Self::contains_retrievable_transmission`] are **not** mutually exclusive: one
+    /// certificate can record an ID as aborted while another provides the bytes for it, in which
+    /// case storage holds both entries and both queries answer `true`. Each entry is reference
+    /// counted against its own certificates, so removing one leaves the other in place. Use
+    /// `contains_aborted_transmission(id) && !contains_retrievable_transmission(id)` to ask the
+    /// narrower question of whether an ID is aborted *and* has nothing to hand back.
     fn contains_aborted_transmission(&self, transmission_id: TransmissionID<N>) -> bool;
 
     /// Returns the transmission for the given `transmission ID`.

--- a/node/bft/storage-service/src/traits.rs
+++ b/node/bft/storage-service/src/traits.rs
@@ -25,20 +25,17 @@ use std::{
 };
 
 pub trait StorageService<N: Network>: Debug + Send + Sync {
-    /// Returns `true` if the storage knows the specified `transmission ID`, whether or not the
-    /// transmission itself can be retrieved.
-    ///
-    /// This is the union of [`Self::contains_retrievable_transmission`] and
-    /// [`Self::contains_aborted_transmission`]: it is `true` both for a transmission held in
-    /// storage and for an ID recorded as aborted, for which there is nothing to hand back. Prefer
-    /// one of those two whenever the distinction matters.
-    fn contains_transmission(&self, transmission_id: TransmissionID<N>) -> bool;
-
     /// Returns `true` if the storage holds the transmission for the specified `transmission ID`,
     /// i.e. exactly when [`Self::get_transmission`] would return `Some`.
     ///
-    /// Unlike [`Self::contains_transmission`], this is `false` for an ID that storage knows only as
-    /// aborted. Prefer this over `get_transmission(id).is_some()`, which clones the transmission.
+    /// This is `false` for an ID that storage knows only as aborted, which holds no transmission to
+    /// hand back; see [`Self::contains_aborted_transmission`]. Prefer this over
+    /// `get_transmission(id).is_some()`, which clones the transmission.
+    ///
+    /// Note: there is deliberately no single query for "storage knows this ID, either way". The two
+    /// states answer different questions, and conflating them is what let a batch be certified
+    /// while committing to a transmission that nobody can produce, so a caller that genuinely wants
+    /// both has to name both.
     fn contains_retrievable_transmission(&self, transmission_id: TransmissionID<N>) -> bool;
 
     /// Returns `true` if the specified `transmission ID` is recorded as aborted.

--- a/node/bft/storage-service/src/traits.rs
+++ b/node/bft/storage-service/src/traits.rs
@@ -25,8 +25,28 @@ use std::{
 };
 
 pub trait StorageService<N: Network>: Debug + Send + Sync {
-    /// Returns `true` if the storage contains the specified `transmission ID`.
+    /// Returns `true` if the storage knows the specified `transmission ID`, whether or not the
+    /// transmission itself can be retrieved.
+    ///
+    /// This is the union of [`Self::contains_retrievable_transmission`] and
+    /// [`Self::contains_aborted_transmission`]: it is `true` both for a transmission held in
+    /// storage and for an ID recorded as aborted, for which there is nothing to hand back. Prefer
+    /// one of those two whenever the distinction matters.
     fn contains_transmission(&self, transmission_id: TransmissionID<N>) -> bool;
+
+    /// Returns `true` if the storage holds the transmission for the specified `transmission ID`,
+    /// i.e. exactly when [`Self::get_transmission`] would return `Some`.
+    ///
+    /// Unlike [`Self::contains_transmission`], this is `false` for an ID that is only recorded as
+    /// aborted. Prefer this over `get_transmission(id).is_some()`, which clones the transmission.
+    fn contains_retrievable_transmission(&self, transmission_id: TransmissionID<N>) -> bool;
+
+    /// Returns `true` if the specified `transmission ID` is recorded as aborted, i.e. the storage
+    /// knows the ID but holds no transmission for it.
+    ///
+    /// This is `true` for the IDs that [`Self::contains_transmission`] reports but
+    /// [`Self::contains_retrievable_transmission`] does not.
+    fn contains_aborted_transmission(&self, transmission_id: TransmissionID<N>) -> bool;
 
     /// Returns the transmission for the given `transmission ID`.
     /// If the transmission ID does not exist in storage, `None` is returned.

--- a/node/bft/storage-service/src/traits.rs
+++ b/node/bft/storage-service/src/traits.rs
@@ -34,8 +34,8 @@ pub trait StorageService<N: Network>: Debug + Send + Sync {
     ///
     /// Note: there is deliberately no single query for "storage knows this ID, either way". The two
     /// states answer different questions, and conflating them is what let a batch be certified
-    /// while committing to a transmission that nobody can produce, so a caller that genuinely wants
-    /// both has to name both.
+    /// while committing to a transmission that storage cannot hand back, so a caller that genuinely
+    /// wants both has to name both.
     fn contains_retrievable_transmission(&self, transmission_id: TransmissionID<N>) -> bool;
 
     /// Returns `true` if the specified `transmission ID` is recorded as aborted.
@@ -55,10 +55,13 @@ pub trait StorageService<N: Network>: Debug + Send + Sync {
     /// Takes a batch header and the transmissions provided for it, and returns the subset of those
     /// transmissions that the storage does not already hold.
     ///
-    /// A transmission that cannot be retrieved from storage has to be provided by the caller, or be
-    /// aborted - either as declared by the caller, or as already recorded in storage, in which case
-    /// there are no bytes to be had from anyone. Anything else is an error: a peer does not get to
-    /// have a certificate accepted while withholding a transmission that it commits to.
+    /// A transmission that cannot be retrieved from this storage must either be provided by the
+    /// caller or be classified as aborted, whether declared by the caller or already recorded in
+    /// storage. Anything else is an error: a peer does not get to have a certificate accepted while
+    /// withholding a transmission that it commits to.
+    ///
+    /// An aborted marker only means that this storage has no payload for that entry; it does not
+    /// imply that a peer cannot provide the bytes.
     fn find_missing_transmissions(
         &self,
         batch_header: &BatchHeader<N>,
@@ -81,7 +84,8 @@ pub trait StorageService<N: Network>: Debug + Send + Sync {
                     }
                     // If the transmission does not exist, it must be aborted: either the caller
                     // declares it as such, or storage already recorded it as aborted for an earlier
-                    // certificate - in which case there are no bytes to be had from anyone.
+                    // certificate. Note that this accepts the ID without bytes; obtaining them, if
+                    // a peer has them, is the caller's business - see `fetch_missing_transmissions`.
                     None => {
                         if !aborted_transmissions.contains(transmission_id)
                             && !self.contains_aborted_transmission(*transmission_id)


### PR DESCRIPTION
An alternative to #4383, building on some of its changes. Same bug, different fix.

BFT storage knows two kinds of transmission ID:
- ones it holds a transmission for
- ones it only recorded as aborted, where it knows the ID but has no bytes to hand back

`contains_transmission` returns true for both, while `get_transmission` returns `Some` only for the first. That was the only containment query available, so callers that needed to tell the two apart could not. A few things went wrong as a result.

1. The primary could propose a transmission that nobody can produce.
In `propose_batch`, the storage check was skipped while the proposal was still empty - an exception meant to avoid proposing an empty batch. So if the first ID drained from the worker queue was one that storage knows only as aborted, it was proposed as if it were a real transmission. The ledger check just above it catches that case only once the aborting block has reached the ledger; while that block is still pending, BFT storage is the only place that knows, and its check was the one being skipped.

2. Persistent storage discarded transmissions it was handed.
`BFTPersistentStorage::find_missing_transmissions` used `contains_transmission`, which is true for an aborted ID, so it treated the ID as already taken care of and never pulled the bytes out of the caller's map. The certificate was accepted, but the transmission never reached storage - `get_transmission` still returned `None`, so the certificate could not be committed. `BFTMemoryService` did not have this problem, because it checked only its map of concrete transmissions.

3. In-memory storage rejected certificates it should have accepted.
The other side of the same coin. Checking only the concrete map, `BFTMemoryService::find_missing_transmissions` then demanded that any remaining ID be either provided by the caller or declared aborted by the caller. Neither ever happens for an already-aborted ID: `fetch_missing_transmissions` does not fetch bytes for an ID storage already knows, and the primary always passes an empty aborted set. So a peer's certificate referencing such an ID was rejected outright.

4. A reference to an already-aborted ID was never counted.
`insert_transmissions` credits the certificate to the transmissions map for the IDs it stores, and to the aborted map only for the IDs in the aborted set it was given. An ID that storage already knows as aborted, and that the caller did not re-declare, is credited to neither - yet `remove_transmissions` later decrements both maps for every ID in the certificate. The two sides are therefore asymmetric: once the certificate that first recorded the abort is garbage collected, the entry's count drops to zero and the entry is deleted, even though a second certificate still references that ID. The node then no longer knows the ID at all, and goes looking for bytes that no peer has.

5. Block sync left those IDs unaccounted for.
`sync_certificate_with_block` skipped any ID that `contains_transmission` reported, so an already-aborted one never reached the classification below it and ended up in neither the transmission map nor the aborted set. Same hole as (4), reached from the sync path instead of the primary.

The fix splits the one query into three: `contains_transmission` (either kind, unchanged), `contains_retrievable_transmission` (storage holds a transmission), and `contains_aborted_transmission` (storage recorded an abort). Each caller now asks what it actually means. find_missing_transmissions becomes one default trait method shared by both services, instead of two copies that had drifted apart.

What differs from #4383:

- This PR adds two queries instead of one, so a caller can also ask whether an ID was aborted.
- Here, `find_missing_transmissions` accepts an ID that storage already knows as aborted, instead of rejecting it.
- The reference counting is fixed in `insert_certificate`, which covers the primary's call sites too, in addition to the block sync path.
- On block sync, an aborted ID goes through the normal classification instead of being skipped, so the block's bytes are used if it happens to carry them.
- The shared tests also cover the three queries and the already-aborted cases.
- Refuses to sign a peer's batch proposal that references an ID the node knows only as aborted.

Each new test was checked to fail with its fix reverted.