### PR TITLE
fix(router): reject BlockResponse on a validator's router connections

### DIFF
--- a/node/router/messages/src/helpers/codec.rs
+++ b/node/router/messages/src/helpers/codec.rs
@@ -65,18 +65,62 @@ impl<N: Network> Encoder<Message<N>> for MessageCodec<N> {
     }
 }
 
+/// The width, in bytes, of the length prefix on the wire. Matches `LengthDelimitedCodec`'s
+/// default (`.little_endian()` is the only builder option `MessageCodec` sets besides
+/// `max_frame_length`, so the rest of the format - a 4-byte length field, not itself included in
+/// the count, immediately followed by that many payload bytes - is `LengthDelimitedCodec`'s
+/// default framing).
+const LENGTH_PREFIX_SIZE: usize = 4;
+
+/// The width, in bytes, of the message ID that leads every payload (see `Message::id`/`ToBytes`).
+const ID_SIZE: usize = 2;
+
 impl<N: Network> Decoder for MessageCodec<N> {
     type Error = std::io::Error;
     type Item = Message<N>;
 
     fn decode(&mut self, source: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
-        // Decode a frame containing bytes belonging to a message.
-        let bytes = match self.codec.decode(source)? {
-            Some(bytes) => bytes,
-            None => return Ok(None),
-        };
+        // Wait for the length prefix to fully arrive.
+        if source.len() < LENGTH_PREFIX_SIZE {
+            return Ok(None);
+        }
+        let declared_len = u32::from_le_bytes(source[..LENGTH_PREFIX_SIZE].try_into().unwrap()) as usize;
 
-        Self::Item::check_size(&bytes)?;
+        // Reject a frame that couldn't be valid for any message type, without waiting for the
+        // rest of a peer-declared, possibly enormous, body to arrive.
+        if declared_len > self.codec.max_frame_length() {
+            return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "frame is too large"));
+        }
+
+        // Wait for the message ID - which leads the payload - to arrive. This is at most
+        // `LENGTH_PREFIX_SIZE + ID_SIZE` bytes, arriving effectively immediately regardless of how
+        // large the declared frame is, since it's the front of whatever the peer sends first.
+        if source.len() < LENGTH_PREFIX_SIZE + ID_SIZE {
+            return Ok(None);
+        }
+        let id_bytes = source[LENGTH_PREFIX_SIZE..LENGTH_PREFIX_SIZE + ID_SIZE].try_into().unwrap();
+        let id = u16::from_le_bytes(id_bytes);
+
+        // Reject a declared length that exceeds what this specific message type could
+        // legitimately need - before waiting for, and buffering, the rest of the body. An
+        // unrecognized ID is rejected outright rather than falling through to the generic ceiling.
+        match Message::<N>::max_size_for_id(id) {
+            Some(max_size) if declared_len <= max_size => {}
+            _ => {
+                return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "message is too large for its type"));
+            }
+        }
+
+        // Wait for the rest of the frame body to arrive.
+        let frame_len = LENGTH_PREFIX_SIZE + declared_len;
+        if source.len() < frame_len {
+            source.reserve(frame_len - source.len());
+            return Ok(None);
+        }
+
+        // Extract the frame body.
+        source.advance(LENGTH_PREFIX_SIZE);
+        let bytes = source.split_to(declared_len);
 
         // Convert the bytes to a message, or fail if it is not valid.
         let reader = bytes.reader();
@@ -95,7 +139,11 @@ mod tests {
     use super::*;
 
     use crate::{
+        PuzzleResponse,
+        UnconfirmedSolution,
         UnconfirmedTransaction,
+        puzzle_response::prop_tests::any_large_puzzle_response,
+        unconfirmed_solution::prop_tests::any_large_unconfirmed_solution,
         unconfirmed_transaction::prop_tests::{any_large_unconfirmed_transaction, any_unconfirmed_transaction},
     };
 
@@ -120,5 +168,58 @@ mod tests {
         let mut codec = MessageCodec::<CurrentNetwork>::default();
         assert!(codec.encode(Message::UnconfirmedTransaction(tx), &mut bytes).is_ok());
         assert!(matches!(codec.decode(&mut bytes), Err(err) if err.kind() == std::io::ErrorKind::InvalidData));
+    }
+
+    #[proptest(ProptestConfig { cases : 10, ..ProptestConfig::default() })]
+    fn overly_large_puzzle_response(#[strategy(any_large_puzzle_response())] message: PuzzleResponse<CurrentNetwork>) {
+        let mut bytes = BytesMut::new();
+        let mut codec = MessageCodec::<CurrentNetwork>::default();
+        assert!(codec.encode(Message::PuzzleResponse(message), &mut bytes).is_ok());
+        assert!(matches!(codec.decode(&mut bytes), Err(err) if err.kind() == std::io::ErrorKind::InvalidData));
+    }
+
+    #[proptest(ProptestConfig { cases : 10, ..ProptestConfig::default() })]
+    fn overly_large_unconfirmed_solution(
+        #[strategy(any_large_unconfirmed_solution())] solution: UnconfirmedSolution<CurrentNetwork>,
+    ) {
+        let mut bytes = BytesMut::new();
+        let mut codec = MessageCodec::<CurrentNetwork>::default();
+        assert!(codec.encode(Message::UnconfirmedSolution(solution), &mut bytes).is_ok());
+        assert!(matches!(codec.decode(&mut bytes), Err(err) if err.kind() == std::io::ErrorKind::InvalidData));
+    }
+
+    /// The property that actually matters: an oversized message for a capped type is rejected
+    /// the moment its length prefix and ID are visible - without ever waiting for (and buffering)
+    /// the rest of a peer-declared body that may not even be sent.
+    #[test]
+    fn oversized_message_is_rejected_without_buffering_its_body() {
+        let declared_len: u32 = 100_000_000; // far beyond any small-message cap, never actually sent
+        let id: u16 = 10; // PuzzleResponse
+
+        let mut bytes = BytesMut::new();
+        bytes.extend_from_slice(&declared_len.to_le_bytes());
+        bytes.extend_from_slice(&id.to_le_bytes());
+        // Deliberately no further bytes: a real peer sending this much data would need to
+        // actually transmit `declared_len` bytes, which we never provide here.
+
+        let mut codec = MessageCodec::<CurrentNetwork>::default();
+        let result = codec.decode(&mut bytes);
+        assert!(matches!(result, Err(err) if err.kind() == std::io::ErrorKind::InvalidData));
+    }
+
+    /// A message ID this node doesn't recognize is rejected outright, not treated as unbounded.
+    #[test]
+    fn unrecognized_message_id_is_rejected() {
+        let declared_len: u32 = 1;
+        let id: u16 = 9999;
+
+        let mut bytes = BytesMut::new();
+        bytes.extend_from_slice(&declared_len.to_le_bytes());
+        bytes.extend_from_slice(&id.to_le_bytes());
+        bytes.extend_from_slice(&[0u8]);
+
+        let mut codec = MessageCodec::<CurrentNetwork>::default();
+        let result = codec.decode(&mut bytes);
+        assert!(matches!(result, Err(err) if err.kind() == std::io::ErrorKind::InvalidData));
     }
 }

--- a/node/router/messages/src/helpers/codec.rs
+++ b/node/router/messages/src/helpers/codec.rs
@@ -43,34 +43,69 @@ impl<N: Network> MessageCodec<N> {
 impl<N: Network> Default for MessageCodec<N> {
     fn default() -> Self {
         Self {
-            codec: LengthDelimitedCodec::builder().max_frame_length(MAXIMUM_MESSAGE_SIZE).little_endian().new_codec(),
+            codec: LengthDelimitedCodec::builder()
+                .max_frame_length(MAXIMUM_MESSAGE_SIZE)
+                .length_field_type::<FrameLength>()
+                .little_endian()
+                .new_codec(),
             _phantom: Default::default(),
         }
     }
 }
 
+/// The type of a frame's length prefix on the wire.
+///
+/// The encoder below writes this prefix by hand, while `self.codec` is what enforces
+/// `max_frame_length`; passing the type to `length_field_type` on the builder keeps the two from
+/// disagreeing about the framing, rather than leaving it to `LengthDelimitedCodec`'s defaults.
+type FrameLength = u32;
+
+/// The width, in bytes, of the length prefix on the wire. The prefix is not itself included in
+/// the length it declares.
+const LENGTH_PREFIX_SIZE: usize = size_of::<FrameLength>();
+
 impl<N: Network> Encoder<Message<N>> for MessageCodec<N> {
     type Error = std::io::Error;
 
     fn encode(&mut self, message: Message<N>, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        // Reserve the frame's length prefix, remembering where it has to be written.
+        //
+        // The length is not known until the message has been serialized, so the alternative is to
+        // serialize the message elsewhere and copy the result in once its size is known.
+        //
+        // Note that `dst` is the connection's write buffer and is not necessarily empty: it may
+        // still hold a frame that has not been flushed yet. Everything below is therefore relative
+        // to where this frame starts, not to the start of the buffer - taking the whole buffer
+        // would fold an already-encoded frame into this one's payload. This mirrors what
+        // `EventCodec` does, for the same reason.
+        let frame_offset = dst.len();
+        dst.extend_from_slice(&[0u8; LENGTH_PREFIX_SIZE]);
+
         // Serialize the payload directly into dst.
-        message
-            .write_le(&mut dst.writer())
+        if let Err(error) = message.write_le(&mut dst.writer()) {
+            // Leave the buffer as it was found, so a failed encode cannot corrupt the stream.
+            dst.truncate(frame_offset);
+            error!("Failed to serialize a message - {error}");
             // This error should never happen, the conversion is for greater compatibility.
-            .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidData, "serialization error"))?;
+            return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "serialization error"));
+        }
 
-        let serialized_message = dst.split_to(dst.len()).freeze();
+        // Determine the length of what was just written, and ensure it is a permitted frame size.
+        let frame_len = dst.len() - frame_offset - LENGTH_PREFIX_SIZE;
+        if frame_len > self.codec.max_frame_length() {
+            dst.truncate(frame_offset);
+            return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, "frame size too big"));
+        }
 
-        self.codec.encode(serialized_message, dst)
+        // Fill in the length prefix, in the same little-endian `FrameLength` framing the decoder
+        // below reads back. The roundtrip tests cover that agreement.
+        let frame_len = FrameLength::try_from(frame_len)
+            .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidInput, "frame size too big"))?;
+        dst[frame_offset..frame_offset + LENGTH_PREFIX_SIZE].copy_from_slice(&frame_len.to_le_bytes());
+
+        Ok(())
     }
 }
-
-/// The width, in bytes, of the length prefix on the wire. Matches `LengthDelimitedCodec`'s
-/// default (`.little_endian()` is the only builder option `MessageCodec` sets besides
-/// `max_frame_length`, so the rest of the format - a 4-byte length field, not itself included in
-/// the count, immediately followed by that many payload bytes - is `LengthDelimitedCodec`'s
-/// default framing).
-const LENGTH_PREFIX_SIZE: usize = 4;
 
 /// The width, in bytes, of the message ID that leads every payload (see `Message::id`/`ToBytes`).
 const ID_SIZE: usize = 2;
@@ -139,6 +174,8 @@ mod tests {
     use super::*;
 
     use crate::{
+        PeerRequest,
+        PuzzleRequest,
         PuzzleResponse,
         UnconfirmedSolution,
         UnconfirmedTransaction,
@@ -221,5 +258,22 @@ mod tests {
         let mut codec = MessageCodec::<CurrentNetwork>::default();
         let result = codec.decode(&mut bytes);
         assert!(matches!(result, Err(err) if err.kind() == std::io::ErrorKind::InvalidData));
+    }
+
+    /// Encoding into a buffer that already holds an unflushed frame must append a second frame,
+    /// not fold the first one into the second one's payload. `FramedWrite::feed` encodes into a
+    /// persistent write buffer, so the codec cannot assume it is handed an empty one.
+    #[test]
+    fn encoding_appends_to_a_non_empty_buffer() {
+        let mut codec = MessageCodec::<CurrentNetwork>::default();
+
+        let mut bytes = BytesMut::new();
+        codec.encode(Message::PeerRequest(PeerRequest), &mut bytes).unwrap();
+        codec.encode(Message::PuzzleRequest(PuzzleRequest), &mut bytes).unwrap();
+
+        assert!(matches!(codec.decode(&mut bytes), Ok(Some(Message::PeerRequest(_)))));
+        assert!(matches!(codec.decode(&mut bytes), Ok(Some(Message::PuzzleRequest(_)))));
+        assert!(matches!(codec.decode(&mut bytes), Ok(None)));
+        assert!(bytes.is_empty());
     }
 }

--- a/node/router/messages/src/helpers/codec.rs
+++ b/node/router/messages/src/helpers/codec.rs
@@ -29,6 +29,10 @@ pub(crate) const MAXIMUM_MESSAGE_SIZE: usize = 128 * 1024 * 1024; // 128 MiB
 /// The codec used to decode and encode network `Message`s.
 pub struct MessageCodec<N: Network> {
     codec: LengthDelimitedCodec,
+    /// Message IDs this codec refuses to decode, rejecting them the moment the ID is visible -
+    /// before waiting for or buffering the rest of the body. Empty by default (every ID this node
+    /// recognizes is decodable); see [`Self::restricted`].
+    excluded_ids: &'static [MessageId],
     _phantom: PhantomData<N>,
 }
 
@@ -37,6 +41,16 @@ impl<N: Network> MessageCodec<N> {
         let mut codec = Self::default();
         codec.codec.set_max_frame_length(MAXIMUM_HANDSHAKE_MESSAGE_SIZE);
         codec
+    }
+
+    /// Returns a codec that refuses to decode any message whose ID is in `excluded_ids`, rejecting
+    /// the connection the moment the ID is visible rather than after buffering and parsing a body
+    /// that was never going to be accepted. Use this for connections that structurally have no
+    /// legitimate reason to ever receive certain message types - for instance, a validator's
+    /// router connections, which never expect `BlockResponse` since validators sync blocks over
+    /// the committee-gated BFT gateway instead.
+    pub fn restricted(excluded_ids: &'static [MessageId]) -> Self {
+        Self { excluded_ids, ..Self::default() }
     }
 }
 
@@ -48,6 +62,7 @@ impl<N: Network> Default for MessageCodec<N> {
                 .length_field_type::<FrameLength>()
                 .little_endian()
                 .new_codec(),
+            excluded_ids: &[],
             _phantom: Default::default(),
         }
     }
@@ -157,6 +172,12 @@ impl<N: Network> Decoder for MessageCodec<N> {
             return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "unrecognized message ID"));
         };
 
+        // Reject a message type this connection has no legitimate reason to ever receive, before
+        // waiting for or buffering its body. See `MessageCodec::restricted`.
+        if self.excluded_ids.contains(&id) {
+            return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "message type is not permitted"));
+        }
+
         // Reject a declared length that exceeds what this specific message type could
         // legitimately need - before waiting for, and buffering, the rest of the body.
         if declared_len > id.max_size::<N>() {
@@ -198,11 +219,12 @@ mod tests {
         PeerRequest,
         PeerResponse,
         Ping,
+        Pong,
         PuzzleRequest,
         PuzzleResponse,
         UnconfirmedSolution,
         UnconfirmedTransaction,
-        puzzle_response::prop_tests::any_large_puzzle_response,
+        puzzle_response::prop_tests::{any_large_puzzle_response, any_puzzle_response},
         unconfirmed_solution::prop_tests::any_large_unconfirmed_solution,
         unconfirmed_transaction::prop_tests::{
             any_max_size_unconfirmed_transaction,
@@ -491,5 +513,31 @@ mod tests {
         bytes.extend_from_slice(&(declared_len as FrameLength).to_le_bytes());
         bytes.extend_from_slice(&id.to_le_bytes());
         bytes
+    }
+
+    #[proptest]
+    fn restricted_codec_rejects_an_excluded_id_even_when_well_formed(
+        #[strategy(any_puzzle_response())] message: PuzzleResponse<CurrentNetwork>,
+    ) {
+        const EXCLUDED: &[u16] = &[10]; // PuzzleResponse
+
+        let mut bytes = BytesMut::new();
+        let mut encoder = MessageCodec::<CurrentNetwork>::default();
+        assert!(encoder.encode(Message::PuzzleResponse(message), &mut bytes).is_ok());
+
+        let mut restricted = MessageCodec::<CurrentNetwork>::restricted(EXCLUDED);
+        assert!(matches!(restricted.decode(&mut bytes), Err(err) if err.kind() == std::io::ErrorKind::InvalidData));
+    }
+
+    #[test]
+    fn restricted_codec_still_allows_a_permitted_message() {
+        const EXCLUDED: &[u16] = &[1]; // BlockResponse; unrelated to the message sent below
+
+        let mut bytes = BytesMut::new();
+        let mut encoder = MessageCodec::<CurrentNetwork>::default();
+        assert!(encoder.encode(Message::Pong(Pong { is_fork: Some(false) }), &mut bytes).is_ok());
+
+        let mut restricted = MessageCodec::<CurrentNetwork>::restricted(EXCLUDED);
+        assert!(restricted.decode(&mut bytes).is_ok());
     }
 }

--- a/node/router/messages/src/helpers/codec.rs
+++ b/node/router/messages/src/helpers/codec.rs
@@ -91,16 +91,20 @@ impl<N: Network> Encoder<Message<N>> for MessageCodec<N> {
         }
 
         // Determine the length of what was just written, and ensure it is a permitted frame size.
+        // Both ways this can fail share one arm, so that neither can leave a half-written frame
+        // behind for the next `encode` to append to.
         let frame_len = dst.len() - frame_offset - LENGTH_PREFIX_SIZE;
-        if frame_len > self.codec.max_frame_length() {
-            dst.truncate(frame_offset);
-            return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, "frame size too big"));
-        }
+        let frame_len = match FrameLength::try_from(frame_len) {
+            Ok(frame_len) if frame_len as usize <= self.codec.max_frame_length() => frame_len,
+            _ => {
+                // Leave the buffer as it was found, so a failed encode cannot corrupt the stream.
+                dst.truncate(frame_offset);
+                return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, "frame size too big"));
+            }
+        };
 
         // Fill in the length prefix, in the same little-endian `FrameLength` framing the decoder
         // below reads back. The roundtrip tests cover that agreement.
-        let frame_len = FrameLength::try_from(frame_len)
-            .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidInput, "frame size too big"))?;
         dst[frame_offset..frame_offset + LENGTH_PREFIX_SIZE].copy_from_slice(&frame_len.to_le_bytes());
 
         Ok(())
@@ -209,7 +213,7 @@ mod tests {
 
     use crate::message_id::UNCONFIRMED_TRANSACTION_OVERHEAD;
     use snarkos_node_network::NodeType;
-    use snarkos_node_sync_locators::{CHECKPOINT_INTERVAL, test_helpers::sample_block_locators};
+    use snarkos_node_sync_locators::{CHECKPOINT_INTERVAL, MAX_CHECKPOINTS, test_helpers::sample_block_locators};
 
     use proptest::prelude::ProptestConfig;
     use std::net::{Ipv6Addr, SocketAddr};
@@ -339,7 +343,7 @@ mod tests {
     /// on top of the transaction itself.
     #[test]
     fn size_gate_boundary_is_exact() {
-        for id in MessageId::ALL {
+        for id in MessageId::all() {
             let max_size = id.max_size::<CurrentNetwork>();
 
             // Exactly at the cap: accepted by the gate, still waiting for the body, which is
@@ -455,14 +459,13 @@ mod tests {
     /// serializer really produces rather than against that arithmetic.
     ///
     /// The height used is the largest one whose checkpoint count `BlockLocators::read_le` still
-    /// accepts, i.e. exactly `u32::MAX / CHECKPOINT_INTERVAL` checkpoints.
+    /// accepts, i.e. exactly `MAX_CHECKPOINTS` checkpoints.
     #[test]
     fn largest_possible_ping_is_accepted() {
-        let max_checkpoints = u32::MAX / CHECKPOINT_INTERVAL;
-        let height = max_checkpoints * CHECKPOINT_INTERVAL - 1;
+        let height = MAX_CHECKPOINTS as u32 * CHECKPOINT_INTERVAL - 1;
 
         let locators = sample_block_locators(height);
-        assert_eq!(locators.checkpoints.len(), max_checkpoints as usize, "not the largest acceptable locator set");
+        assert_eq!(locators.checkpoints.len(), MAX_CHECKPOINTS, "not the largest acceptable locator set");
 
         let ping = Ping {
             version: Message::<CurrentNetwork>::latest_message_version(),

--- a/node/router/messages/src/helpers/codec.rs
+++ b/node/router/messages/src/helpers/codec.rs
@@ -519,7 +519,7 @@ mod tests {
     fn restricted_codec_rejects_an_excluded_id_even_when_well_formed(
         #[strategy(any_puzzle_response())] message: PuzzleResponse<CurrentNetwork>,
     ) {
-        const EXCLUDED: &[u16] = &[10]; // PuzzleResponse
+        const EXCLUDED: &[MessageId] = &[MessageId::PuzzleResponse];
 
         let mut bytes = BytesMut::new();
         let mut encoder = MessageCodec::<CurrentNetwork>::default();
@@ -531,7 +531,7 @@ mod tests {
 
     #[test]
     fn restricted_codec_still_allows_a_permitted_message() {
-        const EXCLUDED: &[u16] = &[1]; // BlockResponse; unrelated to the message sent below
+        const EXCLUDED: &[MessageId] = &[MessageId::BlockResponse]; // unrelated to the message sent below
 
         let mut bytes = BytesMut::new();
         let mut encoder = MessageCodec::<CurrentNetwork>::default();

--- a/node/router/messages/src/helpers/codec.rs
+++ b/node/router/messages/src/helpers/codec.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::Message;
+use crate::{MESSAGE_ID_SIZE, Message, MessageId};
 use snarkvm::prelude::{FromBytes, Network, ToBytes};
 
 use ::bytes::{Buf, BufMut, BytesMut};
@@ -55,8 +55,8 @@ impl<N: Network> Default for MessageCodec<N> {
 
 /// The type of a frame's length prefix on the wire.
 ///
-/// The encoder below writes this prefix by hand, while `self.codec` is what enforces
-/// `max_frame_length`; passing the type to `length_field_type` on the builder keeps the two from
+/// Both directions below write and parse this prefix by hand, while `self.codec` is what enforces
+/// `max_frame_length`; passing the type to `length_field_type` on the builder keeps the three from
 /// disagreeing about the framing, rather than leaving it to `LengthDelimitedCodec`'s defaults.
 type FrameLength = u32;
 
@@ -107,9 +107,6 @@ impl<N: Network> Encoder<Message<N>> for MessageCodec<N> {
     }
 }
 
-/// The width, in bytes, of the message ID that leads every payload (see `Message::id`/`ToBytes`).
-const ID_SIZE: usize = 2;
-
 impl<N: Network> Decoder for MessageCodec<N> {
     type Error = std::io::Error;
     type Item = Message<N>;
@@ -119,7 +116,7 @@ impl<N: Network> Decoder for MessageCodec<N> {
         if source.len() < LENGTH_PREFIX_SIZE {
             return Ok(None);
         }
-        let declared_len = u32::from_le_bytes(source[..LENGTH_PREFIX_SIZE].try_into().unwrap()) as usize;
+        let declared_len = FrameLength::from_le_bytes(source[..LENGTH_PREFIX_SIZE].try_into().unwrap()) as usize;
 
         // Reject a frame that couldn't be valid for any message type, without waiting for the
         // rest of a peer-declared, possibly enormous, body to arrive.
@@ -127,29 +124,49 @@ impl<N: Network> Decoder for MessageCodec<N> {
             return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "frame is too large"));
         }
 
+        // Reject a frame too short to carry a message ID. Such a frame is *already complete* at
+        // this point, so it has to be rejected here rather than waited on: no further bytes are
+        // coming that would make it decodable, and reading an ID past its end would read bytes
+        // belonging to the next frame.
+        if declared_len < MESSAGE_ID_SIZE {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "frame is too short to hold a message ID",
+            ));
+        }
+
         // Wait for the message ID - which leads the payload - to arrive. This is at most
-        // `LENGTH_PREFIX_SIZE + ID_SIZE` bytes, arriving effectively immediately regardless of how
-        // large the declared frame is, since it's the front of whatever the peer sends first.
-        if source.len() < LENGTH_PREFIX_SIZE + ID_SIZE {
+        // `LENGTH_PREFIX_SIZE + MESSAGE_ID_SIZE` bytes, arriving effectively immediately
+        // regardless of how large the declared frame is, since it's the front of whatever the
+        // peer sends first.
+        if source.len() < LENGTH_PREFIX_SIZE + MESSAGE_ID_SIZE {
             return Ok(None);
         }
-        let id_bytes = source[LENGTH_PREFIX_SIZE..LENGTH_PREFIX_SIZE + ID_SIZE].try_into().unwrap();
+        let id_bytes = source[LENGTH_PREFIX_SIZE..LENGTH_PREFIX_SIZE + MESSAGE_ID_SIZE].try_into().unwrap();
         let id = u16::from_le_bytes(id_bytes);
 
+        // Reject an ID that no message this node understands uses. `Message::read_le` could not
+        // have deserialized such a payload either, so this only moves the rejection earlier - but
+        // it is reported separately from a size violation, since a peer speaking a protocol we
+        // don't know and a peer sending an oversized frame are different problems.
+        let Some(id) = MessageId::from_u16(id) else {
+            return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "unrecognized message ID"));
+        };
+
         // Reject a declared length that exceeds what this specific message type could
-        // legitimately need - before waiting for, and buffering, the rest of the body. An
-        // unrecognized ID is rejected outright rather than falling through to the generic ceiling.
-        match Message::<N>::max_size_for_id(id) {
-            Some(max_size) if declared_len <= max_size => {}
-            _ => {
-                return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "message is too large for its type"));
-            }
+        // legitimately need - before waiting for, and buffering, the rest of the body.
+        if declared_len > id.max_size::<N>() {
+            return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "message is too large for its type"));
         }
 
         // Wait for the rest of the frame body to arrive.
+        //
+        // Note there is deliberately no `reserve` of the declared length here. Reserving it would
+        // hand a peer that has sent six bytes an allocation of whatever size it named - which is
+        // the cost this check exists to avoid. Letting the read buffer grow as bytes actually
+        // arrive keeps the memory a connection holds proportional to what it has really sent.
         let frame_len = LENGTH_PREFIX_SIZE + declared_len;
         if source.len() < frame_len {
-            source.reserve(frame_len - source.len());
             return Ok(None);
         }
 
@@ -175,16 +192,27 @@ mod tests {
 
     use crate::{
         PeerRequest,
+        PeerResponse,
+        Ping,
         PuzzleRequest,
         PuzzleResponse,
         UnconfirmedSolution,
         UnconfirmedTransaction,
         puzzle_response::prop_tests::any_large_puzzle_response,
         unconfirmed_solution::prop_tests::any_large_unconfirmed_solution,
-        unconfirmed_transaction::prop_tests::{any_large_unconfirmed_transaction, any_unconfirmed_transaction},
+        unconfirmed_transaction::prop_tests::{
+            any_max_size_unconfirmed_transaction,
+            any_oversized_unconfirmed_transaction,
+            any_unconfirmed_transaction,
+        },
     };
 
+    use crate::message_id::UNCONFIRMED_TRANSACTION_OVERHEAD;
+    use snarkos_node_network::NodeType;
+    use snarkos_node_sync_locators::{CHECKPOINT_INTERVAL, test_helpers::sample_block_locators};
+
     use proptest::prelude::ProptestConfig;
+    use std::net::{Ipv6Addr, SocketAddr};
     use test_strategy::proptest;
 
     type CurrentNetwork = snarkvm::prelude::MainnetV0;
@@ -199,12 +227,31 @@ mod tests {
 
     #[proptest(ProptestConfig { cases : 10, ..ProptestConfig::default() })]
     fn overly_large_unconfirmed_transaction(
-        #[strategy(any_large_unconfirmed_transaction())] tx: UnconfirmedTransaction<CurrentNetwork>,
+        #[strategy(any_oversized_unconfirmed_transaction())] tx: UnconfirmedTransaction<CurrentNetwork>,
     ) {
         let mut bytes = BytesMut::new();
         let mut codec = MessageCodec::<CurrentNetwork>::default();
         assert!(codec.encode(Message::UnconfirmedTransaction(tx), &mut bytes).is_ok());
         assert!(matches!(codec.decode(&mut bytes), Err(err) if err.kind() == std::io::ErrorKind::InvalidData));
+    }
+
+    /// A transaction of exactly the maximum permitted size is valid, so the message carrying it
+    /// has to survive the wire. The cap is on the frame, and the frame is larger than the
+    /// transaction by the message ID and the transaction ID that precede it.
+    #[proptest(ProptestConfig { cases : 10, ..ProptestConfig::default() })]
+    fn max_size_unconfirmed_transaction_is_accepted(
+        #[strategy(any_max_size_unconfirmed_transaction())] tx: UnconfirmedTransaction<CurrentNetwork>,
+    ) {
+        let mut bytes = BytesMut::new();
+        let mut codec = MessageCodec::<CurrentNetwork>::default();
+        assert!(codec.encode(Message::UnconfirmedTransaction(tx), &mut bytes).is_ok());
+
+        // The frame is exactly the transaction plus its envelope, and that is exactly the cap.
+        let frame_len = bytes.len() - LENGTH_PREFIX_SIZE;
+        assert_eq!(frame_len, CurrentNetwork::LATEST_MAX_TRANSACTION_SIZE() + UNCONFIRMED_TRANSACTION_OVERHEAD);
+        assert_eq!(frame_len, MessageId::UnconfirmedTransaction.max_size::<CurrentNetwork>());
+
+        assert_eq!(codec.decode(&mut bytes).unwrap().unwrap().id(), MessageId::UnconfirmedTransaction);
     }
 
     #[proptest(ProptestConfig { cases : 10, ..ProptestConfig::default() })]
@@ -244,25 +291,129 @@ mod tests {
         assert!(matches!(result, Err(err) if err.kind() == std::io::ErrorKind::InvalidData));
     }
 
-    /// A message ID this node doesn't recognize is rejected outright, not treated as unbounded.
+    /// A message ID this node doesn't recognize is rejected outright, not treated as unbounded,
+    /// and is reported as an unknown ID rather than as a size problem.
     #[test]
     fn unrecognized_message_id_is_rejected() {
-        let declared_len: u32 = 1;
-        let id: u16 = 9999;
-
-        let mut bytes = BytesMut::new();
-        bytes.extend_from_slice(&declared_len.to_le_bytes());
-        bytes.extend_from_slice(&id.to_le_bytes());
+        let mut bytes = header(3, 9999);
         bytes.extend_from_slice(&[0u8]);
 
         let mut codec = MessageCodec::<CurrentNetwork>::default();
-        let result = codec.decode(&mut bytes);
-        assert!(matches!(result, Err(err) if err.kind() == std::io::ErrorKind::InvalidData));
+        let err = codec.decode(&mut bytes).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("unrecognized message ID"), "misreported as: {err}");
+    }
+
+    /// A frame too short to hold a message ID is already complete when its length prefix lands,
+    /// so it has to be rejected there. Waiting for more bytes would park the connection until the
+    /// idle timeout on a frame that can never become decodable, and reading an ID past the end of
+    /// the frame would read bytes belonging to the frame after it.
+    #[test]
+    fn short_frame_is_rejected_rather_than_awaited() {
+        for declared_len in 0..MESSAGE_ID_SIZE {
+            // The frame alone, with nothing following it.
+            let mut bytes = BytesMut::new();
+            bytes.extend_from_slice(&(declared_len as FrameLength).to_le_bytes());
+            bytes.extend_from_slice(&vec![0u8; declared_len]);
+
+            let mut codec = MessageCodec::<CurrentNetwork>::default();
+            let err = codec.decode(&mut bytes).unwrap_err();
+            assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+
+            // The same frame with a well-formed frame behind it, whose bytes must not be
+            // mistaken for this frame's message ID.
+            let mut codec = MessageCodec::<CurrentNetwork>::default();
+            let mut bytes = BytesMut::new();
+            bytes.extend_from_slice(&(declared_len as FrameLength).to_le_bytes());
+            bytes.extend_from_slice(&vec![0u8; declared_len]);
+            codec.encode(Message::PeerRequest(PeerRequest), &mut bytes).unwrap();
+
+            let err = codec.decode(&mut bytes).unwrap_err();
+            assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        }
+    }
+
+    /// The size gate is checked against the declared length exactly: a frame declaring precisely
+    /// the type's maximum is let through to wait for its body, one byte more is rejected. This
+    /// pins every ID's boundary at once, including the envelope `UnconfirmedTransaction` carries
+    /// on top of the transaction itself.
+    #[test]
+    fn size_gate_boundary_is_exact() {
+        for id in MessageId::ALL {
+            let max_size = id.max_size::<CurrentNetwork>();
+
+            // Exactly at the cap: accepted by the gate, still waiting for the body, which is
+            // deliberately never supplied.
+            let mut codec = MessageCodec::<CurrentNetwork>::default();
+            let mut bytes = header(max_size, id.as_u16());
+            assert!(
+                matches!(codec.decode(&mut bytes), Ok(None)),
+                "{id:?} rejected a frame of exactly its maximum size ({max_size})"
+            );
+
+            // One byte over. `BlockResponse` sits at the general frame ceiling, so for it this is
+            // the frame-level rejection rather than the per-type one; either way it is refused.
+            let mut codec = MessageCodec::<CurrentNetwork>::default();
+            let mut bytes = header(max_size + 1, id.as_u16());
+            let err = codec.decode(&mut bytes).unwrap_err();
+            assert_eq!(err.kind(), std::io::ErrorKind::InvalidData, "{id:?} admitted a frame one byte over its cap");
+        }
+    }
+
+    /// The decoder must not allocate a peer's declared length before that peer has sent it.
+    #[test]
+    fn declared_length_is_not_preallocated() {
+        for id in [MessageId::Ping, MessageId::BlockResponse] {
+            let declared_len = id.max_size::<CurrentNetwork>();
+
+            let mut codec = MessageCodec::<CurrentNetwork>::default();
+            let mut bytes = header(declared_len, id.as_u16());
+            let capacity_before = bytes.capacity();
+
+            assert!(matches!(codec.decode(&mut bytes), Ok(None)));
+            assert!(
+                bytes.capacity() <= capacity_before,
+                "{id:?}: {} bytes on the wire grew the read buffer to {} bytes",
+                LENGTH_PREFIX_SIZE + MESSAGE_ID_SIZE,
+                bytes.capacity()
+            );
+        }
+    }
+
+    /// `decode` is called again on every read, with whatever has arrived so far, so it has to be
+    /// correct at every chunk boundary - not just when a frame happens to arrive whole. Feeding a
+    /// real message one byte at a time also exercises the agreement between the hand-parsed
+    /// length prefix and the prefix `self.codec` writes.
+    #[proptest(ProptestConfig { cases : 16, ..ProptestConfig::default() })]
+    fn decodes_at_every_chunk_boundary(
+        #[strategy(any_unconfirmed_transaction())] tx: UnconfirmedTransaction<CurrentNetwork>,
+    ) {
+        let expected = Message::UnconfirmedTransaction(tx);
+
+        let mut encoded = BytesMut::new();
+        MessageCodec::<CurrentNetwork>::default().encode(expected.clone(), &mut encoded).unwrap();
+
+        let mut codec = MessageCodec::<CurrentNetwork>::default();
+        let mut source = BytesMut::new();
+        for (index, byte) in encoded.iter().enumerate() {
+            source.extend_from_slice(&[*byte]);
+            let is_last = index + 1 == encoded.len();
+            match codec.decode(&mut source) {
+                Ok(None) if !is_last => {}
+                Ok(Some(decoded)) if is_last => {
+                    assert_eq!(decoded.id(), expected.id());
+                    assert!(source.is_empty(), "the frame was not fully consumed");
+                }
+                other => panic!("at byte {}/{}: {other:?}", index + 1, encoded.len()),
+            }
+        }
     }
 
     /// Encoding into a buffer that already holds an unflushed frame must append a second frame,
-    /// not fold the first one into the second one's payload. `FramedWrite::feed` encodes into a
-    /// persistent write buffer, so the codec cannot assume it is handed an empty one.
+    /// not fold the first one into the second one's payload - `FramedWrite::feed` encodes into a
+    /// persistent write buffer, so the codec cannot assume it is handed an empty one. Decoding
+    /// the result then has to yield the two frames in order, without either one's bytes leaking
+    /// into the other.
     #[test]
     fn encoding_appends_to_a_non_empty_buffer() {
         let mut codec = MessageCodec::<CurrentNetwork>::default();
@@ -271,9 +422,71 @@ mod tests {
         codec.encode(Message::PeerRequest(PeerRequest), &mut bytes).unwrap();
         codec.encode(Message::PuzzleRequest(PuzzleRequest), &mut bytes).unwrap();
 
-        assert!(matches!(codec.decode(&mut bytes), Ok(Some(Message::PeerRequest(_)))));
-        assert!(matches!(codec.decode(&mut bytes), Ok(Some(Message::PuzzleRequest(_)))));
+        assert_eq!(codec.decode(&mut bytes).unwrap().unwrap().id(), MessageId::PeerRequest);
+        assert_eq!(codec.decode(&mut bytes).unwrap().unwrap().id(), MessageId::PuzzleRequest);
         assert!(matches!(codec.decode(&mut bytes), Ok(None)));
         assert!(bytes.is_empty());
+    }
+
+    /// The caps have to admit the largest message an honest node will actually send, or peers
+    /// start disconnecting each other. `PeerResponse` is the tightest of the small messages: a
+    /// full peer list of IPv6 addresses, every one of them carrying a height.
+    #[test]
+    fn largest_honest_peer_response_is_accepted() {
+        let peers = (0..u8::MAX as u16)
+            .map(|i| (SocketAddr::new(Ipv6Addr::new(0x2001, 0xdb8, i, i, i, i, i, i).into(), 4130), Some(u32::MAX)))
+            .collect::<Vec<_>>();
+
+        let mut codec = MessageCodec::<CurrentNetwork>::default();
+        let mut bytes = BytesMut::new();
+        codec.encode(Message::PeerResponse(PeerResponse { peers }), &mut bytes).unwrap();
+
+        assert!(
+            bytes.len() - LENGTH_PREFIX_SIZE <= MessageId::PeerResponse.max_size::<CurrentNetwork>(),
+            "a full PeerResponse of IPv6 peers with heights is {} bytes, over the cap",
+            bytes.len() - LENGTH_PREFIX_SIZE
+        );
+        assert_eq!(codec.decode(&mut bytes).unwrap().unwrap().id(), MessageId::PeerResponse);
+    }
+
+    /// `Ping` is the one capped message whose size is not fixed: it grows with the height of the
+    /// chain. The cap has to hold the largest locator set the wire format permits, which is the
+    /// arithmetic `MAX_PING_MESSAGE_SIZE` asserts against - checked here against what the
+    /// serializer really produces rather than against that arithmetic.
+    ///
+    /// The height used is the largest one whose checkpoint count `BlockLocators::read_le` still
+    /// accepts, i.e. exactly `u32::MAX / CHECKPOINT_INTERVAL` checkpoints.
+    #[test]
+    fn largest_possible_ping_is_accepted() {
+        let max_checkpoints = u32::MAX / CHECKPOINT_INTERVAL;
+        let height = max_checkpoints * CHECKPOINT_INTERVAL - 1;
+
+        let locators = sample_block_locators(height);
+        assert_eq!(locators.checkpoints.len(), max_checkpoints as usize, "not the largest acceptable locator set");
+
+        let ping = Ping {
+            version: Message::<CurrentNetwork>::latest_message_version(),
+            node_type: NodeType::Validator,
+            block_locators: Some(locators),
+        };
+
+        let mut codec = MessageCodec::<CurrentNetwork>::default();
+        let mut bytes = BytesMut::new();
+        codec.encode(Message::Ping(ping), &mut bytes).unwrap();
+
+        assert!(
+            bytes.len() - LENGTH_PREFIX_SIZE <= MessageId::Ping.max_size::<CurrentNetwork>(),
+            "a Ping at the maximum chain height is {} bytes, over the cap",
+            bytes.len() - LENGTH_PREFIX_SIZE
+        );
+        assert_eq!(codec.decode(&mut bytes).unwrap().unwrap().id(), MessageId::Ping);
+    }
+
+    /// Builds a bare frame header: a length prefix and a message ID, with no body behind it.
+    fn header(declared_len: usize, id: u16) -> BytesMut {
+        let mut bytes = BytesMut::new();
+        bytes.extend_from_slice(&(declared_len as FrameLength).to_le_bytes());
+        bytes.extend_from_slice(&id.to_le_bytes());
+        bytes
     }
 }

--- a/node/router/messages/src/helpers/mod.rs
+++ b/node/router/messages/src/helpers/mod.rs
@@ -14,8 +14,8 @@
 // limitations under the License.
 
 mod codec;
-pub use codec::MessageCodec;
 pub(crate) use codec::MAXIMUM_MESSAGE_SIZE;
+pub use codec::MessageCodec;
 
 mod disconnect;
 pub use disconnect::DisconnectReason;

--- a/node/router/messages/src/helpers/mod.rs
+++ b/node/router/messages/src/helpers/mod.rs
@@ -15,6 +15,7 @@
 
 mod codec;
 pub use codec::MessageCodec;
+pub(crate) use codec::MAXIMUM_MESSAGE_SIZE;
 
 mod disconnect;
 pub use disconnect::DisconnectReason;

--- a/node/router/messages/src/lib.rs
+++ b/node/router/messages/src/lib.rs
@@ -120,6 +120,19 @@ impl<N: Network> From<DisconnectReason> for Message<N> {
 }
 
 impl<N: Network> Message<N> {
+    // 8 KiB
+
+    /// The maximum size of a `Ping` message. Its `block_locators` can legitimately grow over the
+    /// life of the chain: up to `NUM_RECENT_BLOCKS` recent entries plus up to `MAX_CHECKPOINTS`
+    /// checkpoint entries (see `snarkos_node_sync_locators::block_locators`), each a `(u32,
+    /// BlockHash)` pair, i.e. 4 + 32 bytes. This is that bound with headroom, not a guess.
+    pub(crate) const MAX_PING_MESSAGE_SIZE: usize = 16 * 1024 * 1024;
+    /// The maximum size of the small, fixed-shape messages: `BlockRequest`, `ChallengeRequest`,
+    /// `ChallengeResponse`, `Disconnect`, `PeerRequest`, `PeerResponse`, `Pong`, `PuzzleRequest`,
+    /// `PuzzleResponse` and `UnconfirmedSolution`. None of these carry more than a handful of
+    /// fixed-size fields (or, for `PeerResponse`, a list bounded by `MAX_PEERS_TO_SEND`), so this
+    /// is generous relative to their real size while remaining far below the general frame limit.
+    pub(crate) const MAX_SMALL_MESSAGE_SIZE: usize = 8 * 1024;
     /// The version of the network protocol; this is incremented for breaking changes between migration versions.
     // Note. This should be incremented for each new `ConsensusVersion` that is added.
     pub const VERSIONS: [(ConsensusVersion, u32); 16] = [
@@ -213,18 +226,7 @@ impl<N: Network> Message<N> {
         }
     }
 
-    /// The maximum size of the small, fixed-shape messages: `BlockRequest`, `ChallengeRequest`,
-    /// `ChallengeResponse`, `Disconnect`, `PeerRequest`, `PeerResponse`, `Pong`, `PuzzleRequest`,
-    /// `PuzzleResponse` and `UnconfirmedSolution`. None of these carry more than a handful of
-    /// fixed-size fields (or, for `PeerResponse`, a list bounded by `MAX_PEERS_TO_SEND`), so this
-    /// is generous relative to their real size while remaining far below the general frame limit.
-    pub(crate) const MAX_SMALL_MESSAGE_SIZE: usize = 8 * 1024; // 8 KiB
-
-    /// The maximum size of a `Ping` message. Its `block_locators` can legitimately grow over the
-    /// life of the chain: up to `NUM_RECENT_BLOCKS` recent entries plus up to `MAX_CHECKPOINTS`
-    /// checkpoint entries (see `snarkos_node_sync_locators::block_locators`), each a `(u32,
-    /// BlockHash)` pair, i.e. 4 + 32 bytes. This is that bound with headroom, not a guess.
-    pub(crate) const MAX_PING_MESSAGE_SIZE: usize = 16 * 1024 * 1024; // 16 MiB
+    // 16 MiB
 
     /// Returns the maximum size, in bytes, that a message with the given ID may legitimately be -
     /// to be checked against the declared frame length before the frame body is read off the

--- a/node/router/messages/src/lib.rs
+++ b/node/router/messages/src/lib.rs
@@ -213,26 +213,41 @@ impl<N: Network> Message<N> {
         }
     }
 
-    /// Checks the message byte length. To be used before deserialization.
-    pub fn check_size(bytes: &[u8]) -> io::Result<()> {
-        // Store the length to be checked against the max message size for each variant.
-        let len = bytes.len();
-        if len < 2 {
-            return Err(io::Error::new(io::ErrorKind::InvalidData, "invalid message"));
+    /// The maximum size of the small, fixed-shape messages: `BlockRequest`, `ChallengeRequest`,
+    /// `ChallengeResponse`, `Disconnect`, `PeerRequest`, `PeerResponse`, `Pong`, `PuzzleRequest`,
+    /// `PuzzleResponse` and `UnconfirmedSolution`. None of these carry more than a handful of
+    /// fixed-size fields (or, for `PeerResponse`, a list bounded by `MAX_PEERS_TO_SEND`), so this
+    /// is generous relative to their real size while remaining far below the general frame limit.
+    pub(crate) const MAX_SMALL_MESSAGE_SIZE: usize = 8 * 1024; // 8 KiB
+
+    /// The maximum size of a `Ping` message. Its `block_locators` can legitimately grow over the
+    /// life of the chain: up to `NUM_RECENT_BLOCKS` recent entries plus up to `MAX_CHECKPOINTS`
+    /// checkpoint entries (see `snarkos_node_sync_locators::block_locators`), each a `(u32,
+    /// BlockHash)` pair, i.e. 4 + 32 bytes. This is that bound with headroom, not a guess.
+    pub(crate) const MAX_PING_MESSAGE_SIZE: usize = 16 * 1024 * 1024; // 16 MiB
+
+    /// Returns the maximum size, in bytes, that a message with the given ID may legitimately be -
+    /// to be checked against the declared frame length before the frame body is read off the
+    /// wire, not after. Every message ID this node understands must appear here explicitly: there
+    /// is no fallback arm, so adding a message variant without adding its entry is a compile
+    /// error, not a silent gap.
+    ///
+    /// Returns `None` for an ID this node doesn't recognize, which the caller should treat as a
+    /// rejection.
+    pub fn max_size_for_id(id: u16) -> Option<usize> {
+        match id {
+            // BlockResponse is the one message that is legitimately large - up to a handful of
+            // full blocks (bounded by block count, not by byte size). It is deliberately left at
+            // the general frame ceiling here; restricting it further needs the requester's own
+            // pending-request state, which this layer doesn't have.
+            1 => Some(MAXIMUM_MESSAGE_SIZE),
+            7 => Some(Self::MAX_PING_MESSAGE_SIZE),
+            // UnconfirmedTransaction is the one message type with its own network-defined,
+            // consensus-version-dependent cap.
+            12 => Some(N::LATEST_MAX_TRANSACTION_SIZE()),
+            0 | 2 | 3 | 4 | 5 | 6 | 8 | 9 | 10 | 11 => Some(Self::MAX_SMALL_MESSAGE_SIZE),
+            _ => None,
         }
-
-        // Check the first two bytes for the message ID.
-        let id_bytes: [u8; 2] = (&bytes[..2])
-            .try_into()
-            .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "id couldn't be deserialized"))?;
-        let id = u16::from_le_bytes(id_bytes);
-
-        // SPECIAL CASE: check the transaction message isn't too large.
-        if id == 12 && len > N::LATEST_MAX_TRANSACTION_SIZE() {
-            return Err(io::Error::new(io::ErrorKind::InvalidData, "transaction is too large"))?;
-        }
-
-        Ok(())
     }
 }
 

--- a/node/router/messages/src/lib.rs
+++ b/node/router/messages/src/lib.rs
@@ -36,6 +36,9 @@ pub use challenge_response::ChallengeResponse;
 mod disconnect;
 pub use disconnect::Disconnect;
 
+mod message_id;
+pub use message_id::{MAX_PING_MESSAGE_SIZE, MAX_SMALL_MESSAGE_SIZE, MessageId};
+
 mod peer_request;
 pub use peer_request::PeerRequest;
 
@@ -77,6 +80,9 @@ use snarkvm::prelude::{
 };
 
 use std::{borrow::Cow, io, net::SocketAddr};
+
+/// The width, in bytes, of the message ID that leads every message payload.
+pub const MESSAGE_ID_SIZE: usize = size_of::<u16>();
 
 // A compile-time compatibility check for the Message.
 const _: () = {
@@ -120,19 +126,6 @@ impl<N: Network> From<DisconnectReason> for Message<N> {
 }
 
 impl<N: Network> Message<N> {
-    // 8 KiB
-
-    /// The maximum size of a `Ping` message. Its `block_locators` can legitimately grow over the
-    /// life of the chain: up to `NUM_RECENT_BLOCKS` recent entries plus up to `MAX_CHECKPOINTS`
-    /// checkpoint entries (see `snarkos_node_sync_locators::block_locators`), each a `(u32,
-    /// BlockHash)` pair, i.e. 4 + 32 bytes. This is that bound with headroom, not a guess.
-    pub(crate) const MAX_PING_MESSAGE_SIZE: usize = 16 * 1024 * 1024;
-    /// The maximum size of the small, fixed-shape messages: `BlockRequest`, `ChallengeRequest`,
-    /// `ChallengeResponse`, `Disconnect`, `PeerRequest`, `PeerResponse`, `Pong`, `PuzzleRequest`,
-    /// `PuzzleResponse` and `UnconfirmedSolution`. None of these carry more than a handful of
-    /// fixed-size fields (or, for `PeerResponse`, a list bounded by `MAX_PEERS_TO_SEND`), so this
-    /// is generous relative to their real size while remaining far below the general frame limit.
-    pub(crate) const MAX_SMALL_MESSAGE_SIZE: usize = 8 * 1024;
     /// The version of the network protocol; this is incremented for breaking changes between migration versions.
     // Note. This should be incremented for each new `ConsensusVersion` that is added.
     pub const VERSIONS: [(ConsensusVersion, u32); 16] = [
@@ -207,55 +200,33 @@ impl<N: Network> Message<N> {
     }
 
     /// Returns the message ID.
-    #[inline]
-    pub fn id(&self) -> u16 {
-        match self {
-            Self::BlockRequest(..) => 0,
-            Self::BlockResponse(..) => 1,
-            Self::ChallengeRequest(..) => 2,
-            Self::ChallengeResponse(..) => 3,
-            Self::Disconnect(..) => 4,
-            Self::PeerRequest(..) => 5,
-            Self::PeerResponse(..) => 6,
-            Self::Ping(..) => 7,
-            Self::Pong(..) => 8,
-            Self::PuzzleRequest(..) => 9,
-            Self::PuzzleResponse(..) => 10,
-            Self::UnconfirmedSolution(..) => 11,
-            Self::UnconfirmedTransaction(..) => 12,
-        }
-    }
-
-    // 16 MiB
-
-    /// Returns the maximum size, in bytes, that a message with the given ID may legitimately be -
-    /// to be checked against the declared frame length before the frame body is read off the
-    /// wire, not after. Every message ID this node understands must appear here explicitly: there
-    /// is no fallback arm, so adding a message variant without adding its entry is a compile
-    /// error, not a silent gap.
     ///
-    /// Returns `None` for an ID this node doesn't recognize, which the caller should treat as a
-    /// rejection.
-    pub fn max_size_for_id(id: u16) -> Option<usize> {
-        match id {
-            // BlockResponse is the one message that is legitimately large - up to a handful of
-            // full blocks (bounded by block count, not by byte size). It is deliberately left at
-            // the general frame ceiling here; restricting it further needs the requester's own
-            // pending-request state, which this layer doesn't have.
-            1 => Some(MAXIMUM_MESSAGE_SIZE),
-            7 => Some(Self::MAX_PING_MESSAGE_SIZE),
-            // UnconfirmedTransaction is the one message type with its own network-defined,
-            // consensus-version-dependent cap.
-            12 => Some(N::LATEST_MAX_TRANSACTION_SIZE()),
-            0 | 2 | 3 | 4 | 5 | 6 | 8 | 9 | 10 | 11 => Some(Self::MAX_SMALL_MESSAGE_SIZE),
-            _ => None,
+    /// This is exhaustive over the variants and has no fallback arm, so a new variant has to be
+    /// given an ID here - and, in turn, a maximum size in [`MessageId::max_size`] - before the
+    /// crate will compile.
+    #[inline]
+    pub fn id(&self) -> MessageId {
+        match self {
+            Self::BlockRequest(..) => MessageId::BlockRequest,
+            Self::BlockResponse(..) => MessageId::BlockResponse,
+            Self::ChallengeRequest(..) => MessageId::ChallengeRequest,
+            Self::ChallengeResponse(..) => MessageId::ChallengeResponse,
+            Self::Disconnect(..) => MessageId::Disconnect,
+            Self::PeerRequest(..) => MessageId::PeerRequest,
+            Self::PeerResponse(..) => MessageId::PeerResponse,
+            Self::Ping(..) => MessageId::Ping,
+            Self::Pong(..) => MessageId::Pong,
+            Self::PuzzleRequest(..) => MessageId::PuzzleRequest,
+            Self::PuzzleResponse(..) => MessageId::PuzzleResponse,
+            Self::UnconfirmedSolution(..) => MessageId::UnconfirmedSolution,
+            Self::UnconfirmedTransaction(..) => MessageId::UnconfirmedTransaction,
         }
     }
 }
 
 impl<N: Network> ToBytes for Message<N> {
     fn write_le<W: io::Write>(&self, mut writer: W) -> io::Result<()> {
-        self.id().write_le(&mut writer)?;
+        self.id().as_u16().write_le(&mut writer)?;
 
         match self {
             Self::BlockRequest(message) => message.write_le(writer),
@@ -277,27 +248,31 @@ impl<N: Network> ToBytes for Message<N> {
 
 impl<N: Network> FromBytes for Message<N> {
     fn read_le<R: io::Read>(mut reader: R) -> io::Result<Self> {
-        // Read the event ID.
-        let mut id_bytes = [0u8; 2];
+        // Read the message ID.
+        let mut id_bytes = [0u8; MESSAGE_ID_SIZE];
         reader.read_exact(&mut id_bytes)?;
         let id = u16::from_le_bytes(id_bytes);
+        let Some(id) = MessageId::from_u16(id) else {
+            return Err(error(format!("Unknown message ID {id}")));
+        };
 
         // Deserialize the data field.
         let message = match id {
-            0 => Self::BlockRequest(BlockRequest::read_le(&mut reader)?),
-            1 => Self::BlockResponse(BlockResponse::read_le(&mut reader)?),
-            2 => Self::ChallengeRequest(ChallengeRequest::read_le(&mut reader)?),
-            3 => Self::ChallengeResponse(ChallengeResponse::read_le(&mut reader)?),
-            4 => Self::Disconnect(Disconnect::read_le(&mut reader)?),
-            5 => Self::PeerRequest(PeerRequest::read_le(&mut reader)?),
-            6 => Self::PeerResponse(PeerResponse::read_le(&mut reader)?),
-            7 => Self::Ping(Ping::read_le(&mut reader)?),
-            8 => Self::Pong(Pong::read_le(&mut reader)?),
-            9 => Self::PuzzleRequest(PuzzleRequest::read_le(&mut reader)?),
-            10 => Self::PuzzleResponse(PuzzleResponse::read_le(&mut reader)?),
-            11 => Self::UnconfirmedSolution(UnconfirmedSolution::read_le(&mut reader)?),
-            12 => Self::UnconfirmedTransaction(UnconfirmedTransaction::read_le(&mut reader)?),
-            13.. => return Err(error("Unknown message ID {id}")),
+            MessageId::BlockRequest => Self::BlockRequest(BlockRequest::read_le(&mut reader)?),
+            MessageId::BlockResponse => Self::BlockResponse(BlockResponse::read_le(&mut reader)?),
+            MessageId::ChallengeRequest => Self::ChallengeRequest(ChallengeRequest::read_le(&mut reader)?),
+            MessageId::ChallengeResponse => Self::ChallengeResponse(ChallengeResponse::read_le(&mut reader)?),
+            MessageId::Disconnect => Self::Disconnect(Disconnect::read_le(&mut reader)?),
+            MessageId::PeerRequest => Self::PeerRequest(PeerRequest::read_le(&mut reader)?),
+            MessageId::PeerResponse => Self::PeerResponse(PeerResponse::read_le(&mut reader)?),
+            MessageId::Ping => Self::Ping(Ping::read_le(&mut reader)?),
+            MessageId::Pong => Self::Pong(Pong::read_le(&mut reader)?),
+            MessageId::PuzzleRequest => Self::PuzzleRequest(PuzzleRequest::read_le(&mut reader)?),
+            MessageId::PuzzleResponse => Self::PuzzleResponse(PuzzleResponse::read_le(&mut reader)?),
+            MessageId::UnconfirmedSolution => Self::UnconfirmedSolution(UnconfirmedSolution::read_le(&mut reader)?),
+            MessageId::UnconfirmedTransaction => {
+                Self::UnconfirmedTransaction(UnconfirmedTransaction::read_le(&mut reader)?)
+            }
         };
 
         // Ensure that there are no "dangling" bytes.

--- a/node/router/messages/src/message_id.rs
+++ b/node/router/messages/src/message_id.rs
@@ -1,0 +1,234 @@
+// Copyright (c) 2019-2026 Provable Inc.
+// This file is part of the snarkOS library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{MAXIMUM_MESSAGE_SIZE, MESSAGE_ID_SIZE};
+
+use snarkos_node_sync_locators::{CHECKPOINT_INTERVAL, NUM_RECENT_BLOCKS};
+use snarkvm::prelude::Network;
+
+/// The wire ID of a [`crate::Message`] variant: the `u16` that leads every message payload.
+///
+/// This exists so that the codec can decide how large a message is allowed to be while holding
+/// nothing but the ID - i.e. before the body has been read off the socket. Keeping the IDs in a
+/// type rather than as bare integers is what makes that decision total: both
+/// [`crate::Message::id`] and [`MessageId::max_size`] are written as `match`es without a fallback
+/// arm, so a new `Message` variant that has no ID, or a new ID that has no size, does not compile.
+///
+/// The one direction that cannot be enforced by the compiler is [`MessageId::from_u16`], since a
+/// `u16` can hold values no variant claims; `message_id_round_trip` covers it instead.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[repr(u16)]
+pub enum MessageId {
+    BlockRequest = 0,
+    BlockResponse = 1,
+    ChallengeRequest = 2,
+    ChallengeResponse = 3,
+    Disconnect = 4,
+    PeerRequest = 5,
+    PeerResponse = 6,
+    Ping = 7,
+    Pong = 8,
+    PuzzleRequest = 9,
+    PuzzleResponse = 10,
+    UnconfirmedSolution = 11,
+    UnconfirmedTransaction = 12,
+}
+
+/// The maximum size of the small, fixed-shape messages - everything except `Ping`,
+/// `BlockResponse` and `UnconfirmedTransaction`. None of these carry more than a handful of
+/// fixed-size fields, or (for `PeerResponse`) a peer list bounded by the `u8` count that
+/// `PeerResponse::write_le` enforces. The `PEER_RESPONSE_WORST_CASE` assertion below pins the
+/// largest of them against this value.
+pub const MAX_SMALL_MESSAGE_SIZE: usize = 8 * 1024; // 8 KiB
+
+/// The maximum size of a `Ping` message.
+///
+/// Unlike the messages above, a `Ping` does not have a fixed shape: its `block_locators` grow
+/// with the height of the chain, up to `NUM_RECENT_BLOCKS` recent entries plus the
+/// `BlockLocators` deserializer's own ceiling of `u32::MAX / CHECKPOINT_INTERVAL` checkpoints.
+/// The `PING_WORST_CASE` assertion below is the arithmetic for that bound, so this constant
+/// cannot silently drift below the largest `Ping` the protocol permits.
+///
+/// Note this is far above what any realistic chain height produces (a few tens of KiB); it is the
+/// ceiling the wire format allows, not a target. It is not the memory an unfinished frame costs -
+/// the decoder no longer pre-allocates the declared length - so an attacker has to actually
+/// transmit these bytes to make a node hold them.
+pub const MAX_PING_MESSAGE_SIZE: usize = 16 * 1024 * 1024; // 16 MiB
+
+/// The bytes an `UnconfirmedTransaction` frame carries in addition to the transaction itself.
+///
+/// This has to be added to the transaction cap, rather than the cap being applied to the frame
+/// directly: a transaction of exactly `LATEST_MAX_TRANSACTION_SIZE` is valid - both the ledger
+/// service and the REST endpoint accept it - so the message carrying it has to fit on the wire,
+/// and that message is necessarily larger than the transaction it carries.
+///
+/// The figures below are what the encoder actually emits; `max_size_unconfirmed_transaction_is_accepted`
+/// pins them, so a change to any of these encodings fails the build rather than silently
+/// shrinking the transaction size the network will relay.
+pub const UNCONFIRMED_TRANSACTION_OVERHEAD: usize = MESSAGE_ID_SIZE
+    + 32 // the transaction ID preceding the transaction body
+    + 5; // `Data`'s own variant tag and length prefix
+
+// The caps above are only useful if they are above what an honest node actually sends. For the
+// two messages whose worst case is not obviously tiny, that arithmetic is written out here so the
+// build fails rather than the network quietly starting to disconnect honest peers. The
+// `largest_honest_peer_response_is_accepted` and `largest_possible_ping_is_accepted` tests check
+// the same bounds against what the serializer really produces.
+const _: () = {
+    // The largest `PeerResponse` that `PeerResponse::write_le` will emit: a peer count of
+    // `u8::MAX` - which that function enforces - with every peer an IPv6 address carrying a
+    // height.
+    let peer_response = MESSAGE_ID_SIZE
+        + 1 // the version indicator
+        + 1 // the peer count
+        + (u8::MAX as usize)
+            * (1     // the IPv6 tag
+                + 16 // the address
+                + 2  // the port
+                + 1  // the `Some` tag on the height
+                + 4); // the height
+    assert!(
+        peer_response <= MAX_SMALL_MESSAGE_SIZE,
+        "MAX_SMALL_MESSAGE_SIZE is below the largest PeerResponse an honest node will send"
+    );
+
+    // The largest `Ping` the wire format permits: a full recent-block window, plus the ceiling on
+    // checkpoints that `BlockLocators::read_le` enforces, each entry a `(u32, BlockHash)` pair.
+    let locator_entry = size_of::<u32>() + 32;
+    let ping = MESSAGE_ID_SIZE
+        + 4 // the version
+        + 1 // the node type
+        + 1 // the `Some` tag on the block locators
+        + 4 // the recents map length
+        + 4 // the checkpoints map length
+        + (NUM_RECENT_BLOCKS + (u32::MAX / CHECKPOINT_INTERVAL) as usize) * locator_entry;
+    assert!(ping <= MAX_PING_MESSAGE_SIZE, "MAX_PING_MESSAGE_SIZE is below the largest Ping the wire format permits");
+};
+
+impl MessageId {
+    /// Every message ID, for tests that need to enumerate them.
+    #[cfg(test)]
+    pub(crate) const ALL: [Self; 13] = [
+        Self::BlockRequest,
+        Self::BlockResponse,
+        Self::ChallengeRequest,
+        Self::ChallengeResponse,
+        Self::Disconnect,
+        Self::PeerRequest,
+        Self::PeerResponse,
+        Self::Ping,
+        Self::Pong,
+        Self::PuzzleRequest,
+        Self::PuzzleResponse,
+        Self::UnconfirmedSolution,
+        Self::UnconfirmedTransaction,
+    ];
+
+    /// Returns the ID as it appears on the wire.
+    pub const fn as_u16(self) -> u16 {
+        self as u16
+    }
+
+    /// Returns the ID for the given wire value, or `None` if no message this node understands
+    /// uses it. Callers are expected to treat `None` as a rejection: `Message::read_le` has never
+    /// been able to deserialize such a payload either.
+    pub const fn from_u16(id: u16) -> Option<Self> {
+        Some(match id {
+            0 => Self::BlockRequest,
+            1 => Self::BlockResponse,
+            2 => Self::ChallengeRequest,
+            3 => Self::ChallengeResponse,
+            4 => Self::Disconnect,
+            5 => Self::PeerRequest,
+            6 => Self::PeerResponse,
+            7 => Self::Ping,
+            8 => Self::Pong,
+            9 => Self::PuzzleRequest,
+            10 => Self::PuzzleResponse,
+            11 => Self::UnconfirmedSolution,
+            12 => Self::UnconfirmedTransaction,
+            13.. => return None,
+        })
+    }
+
+    /// Returns the largest frame, in bytes, that a message with this ID may legitimately be.
+    ///
+    /// This is checked against the declared frame length before the body is read off the wire,
+    /// so it bounds work the node does on behalf of a peer that has sent only six bytes. The size
+    /// is of the whole frame - the message ID included - because that is what the length prefix
+    /// counts.
+    pub fn max_size<N: Network>(self) -> usize {
+        match self {
+            // `BlockResponse` is the one message that is legitimately large - up to a handful of
+            // full blocks, bounded by block count rather than by byte size. It is deliberately
+            // left at the general frame ceiling; tightening it needs the requester's own
+            // pending-request state, which this framing layer does not have.
+            Self::BlockResponse => MAXIMUM_MESSAGE_SIZE,
+            Self::Ping => MAX_PING_MESSAGE_SIZE,
+            // `UnconfirmedTransaction` is the one message type with a network-defined,
+            // consensus-version-dependent cap. The envelope has to be added to it: a transaction
+            // of exactly `LATEST_MAX_TRANSACTION_SIZE` is valid, and the message carrying it is
+            // necessarily larger than the transaction itself.
+            Self::UnconfirmedTransaction => {
+                N::LATEST_MAX_TRANSACTION_SIZE().saturating_add(UNCONFIRMED_TRANSACTION_OVERHEAD)
+            }
+            Self::BlockRequest
+            | Self::ChallengeRequest
+            | Self::ChallengeResponse
+            | Self::Disconnect
+            | Self::PeerRequest
+            | Self::PeerResponse
+            | Self::Pong
+            | Self::PuzzleRequest
+            | Self::PuzzleResponse
+            | Self::UnconfirmedSolution => MAX_SMALL_MESSAGE_SIZE,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `from_u16` is the one mapping the compiler cannot check, so check it here.
+    #[test]
+    fn message_id_round_trip() {
+        for id in MessageId::ALL {
+            assert_eq!(MessageId::from_u16(id.as_u16()), Some(id), "{id:?} does not round-trip through its wire value");
+        }
+    }
+
+    /// Every ID is distinct, and they are the contiguous range the wire format assumes.
+    #[test]
+    fn message_ids_are_contiguous_from_zero() {
+        for (index, id) in MessageId::ALL.iter().enumerate() {
+            assert_eq!(id.as_u16() as usize, index, "{id:?} is not at its expected wire value");
+        }
+        assert_eq!(MessageId::from_u16(MessageId::ALL.len() as u16), None, "an unclaimed ID was accepted");
+    }
+
+    /// Every ID has a size that is at least large enough to hold the ID itself, and no capped
+    /// message may exceed the general frame ceiling.
+    #[test]
+    fn max_sizes_are_sane() {
+        type CurrentNetwork = snarkvm::prelude::MainnetV0;
+
+        for id in MessageId::ALL {
+            let max_size = id.max_size::<CurrentNetwork>();
+            assert!(max_size >= MESSAGE_ID_SIZE, "{id:?} cannot hold its own message ID");
+            assert!(max_size <= MAXIMUM_MESSAGE_SIZE, "{id:?} is allowed to exceed the general frame ceiling");
+        }
+    }
+}

--- a/node/router/messages/src/message_id.rs
+++ b/node/router/messages/src/message_id.rs
@@ -15,19 +15,28 @@
 
 use crate::{MAXIMUM_MESSAGE_SIZE, MESSAGE_ID_SIZE};
 
-use snarkos_node_sync_locators::{CHECKPOINT_INTERVAL, NUM_RECENT_BLOCKS};
+use snarkos_node_sync_locators::{MAX_CHECKPOINTS, NUM_RECENT_BLOCKS};
 use snarkvm::prelude::Network;
 
 /// The wire ID of a [`crate::Message`] variant: the `u16` that leads every message payload.
 ///
-/// This exists so that the codec can decide how large a message is allowed to be while holding
-/// nothing but the ID - i.e. before the body has been read off the socket. Keeping the IDs in a
-/// type rather than as bare integers is what makes that decision total: both
-/// [`crate::Message::id`] and [`MessageId::max_size`] are written as `match`es without a fallback
-/// arm, so a new `Message` variant that has no ID, or a new ID that has no size, does not compile.
+/// This exists so the codec can decide how large a message is allowed to be while holding nothing
+/// but the ID - i.e. before the body has been read off the socket.
 ///
-/// The one direction that cannot be enforced by the compiler is [`MessageId::from_u16`], since a
-/// `u16` can hold values no variant claims; `message_id_round_trip` covers it instead.
+/// # Adding a message
+///
+/// Two of the three mappings are checked by the compiler: [`crate::Message::id`] and
+/// [`MessageId::max_size`] are `match`es with no fallback arm, so a `Message` variant with no ID,
+/// or an ID with no size, does not compile.
+///
+/// [`MessageId::from_u16`] is **not** checked, and cannot be on stable Rust - enumerating an
+/// enum's variants needs a macro, a derive, or the unstable `variant_count`. So: **a variant added
+/// here must be added to `from_u16` by hand.** If it is not, everything still compiles and every
+/// test still passes, but the node will happily *encode* the new message while every decoder - its
+/// own included - rejects the frame as an unrecognized ID and drops the connection.
+///
+/// `message_ids_agree_with_their_discriminants` catches a `from_u16` arm that maps an ID to the
+/// *wrong* variant. Nothing catches one that is simply missing.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[repr(u16)]
 pub enum MessageId {
@@ -106,6 +115,8 @@ const _: () = {
 
     // The largest `Ping` the wire format permits: a full recent-block window, plus the ceiling on
     // checkpoints that `BlockLocators::read_le` enforces, each entry a `(u32, BlockHash)` pair.
+    // Both bounds come from the locators crate rather than being restated here, so that tightening
+    // either one there tightens this assertion with it.
     let locator_entry = size_of::<u32>() + 32;
     let ping = MESSAGE_ID_SIZE
         + 4 // the version
@@ -113,28 +124,19 @@ const _: () = {
         + 1 // the `Some` tag on the block locators
         + 4 // the recents map length
         + 4 // the checkpoints map length
-        + (NUM_RECENT_BLOCKS + (u32::MAX / CHECKPOINT_INTERVAL) as usize) * locator_entry;
+        + (NUM_RECENT_BLOCKS + MAX_CHECKPOINTS) * locator_entry;
     assert!(ping <= MAX_PING_MESSAGE_SIZE, "MAX_PING_MESSAGE_SIZE is below the largest Ping the wire format permits");
 };
 
 impl MessageId {
-    /// Every message ID, for tests that need to enumerate them.
-    #[cfg(test)]
-    pub(crate) const ALL: [Self; 13] = [
-        Self::BlockRequest,
-        Self::BlockResponse,
-        Self::ChallengeRequest,
-        Self::ChallengeResponse,
-        Self::Disconnect,
-        Self::PeerRequest,
-        Self::PeerResponse,
-        Self::Ping,
-        Self::Pong,
-        Self::PuzzleRequest,
-        Self::PuzzleResponse,
-        Self::UnconfirmedSolution,
-        Self::UnconfirmedTransaction,
-    ];
+    /// Every message ID, in wire order.
+    ///
+    /// Derived from `from_u16` rather than restated, so there is one hand-maintained list here
+    /// rather than two. Note this means an ID missing from `from_u16` is missing from here too -
+    /// see the type-level docs.
+    pub fn all() -> impl Iterator<Item = Self> {
+        (0..).map_while(Self::from_u16)
+    }
 
     /// Returns the ID as it appears on the wire.
     pub const fn as_u16(self) -> u16 {
@@ -144,6 +146,8 @@ impl MessageId {
     /// Returns the ID for the given wire value, or `None` if no message this node understands
     /// uses it. Callers are expected to treat `None` as a rejection: `Message::read_le` has never
     /// been able to deserialize such a payload either.
+    ///
+    /// Must be kept in step with the enum by hand - see the type-level docs.
     pub const fn from_u16(id: u16) -> Option<Self> {
         Some(match id {
             0 => Self::BlockRequest,
@@ -159,7 +163,7 @@ impl MessageId {
             10 => Self::PuzzleResponse,
             11 => Self::UnconfirmedSolution,
             12 => Self::UnconfirmedTransaction,
-            13.. => return None,
+            _ => return None,
         })
     }
 
@@ -202,21 +206,27 @@ impl MessageId {
 mod tests {
     use super::*;
 
-    /// `from_u16` is the one mapping the compiler cannot check, so check it here.
+    /// `from_u16` is hand-maintained, so check that each arm maps an ID to the variant whose
+    /// discriminant actually is that ID - a transposed or copy-pasted arm would otherwise decode
+    /// one message type as another. (A *missing* arm is not detectable here; see the type docs.)
     #[test]
-    fn message_id_round_trip() {
-        for id in MessageId::ALL {
-            assert_eq!(MessageId::from_u16(id.as_u16()), Some(id), "{id:?} does not round-trip through its wire value");
+    fn message_ids_agree_with_their_discriminants() {
+        for (index, id) in MessageId::all().enumerate() {
+            assert_eq!(
+                id.as_u16() as usize,
+                index,
+                "from_u16({index}) returned {id:?}, whose wire value is not {index}"
+            );
         }
     }
 
-    /// Every ID is distinct, and they are the contiguous range the wire format assumes.
+    /// The IDs `from_u16` accepts are a contiguous run from zero, which is what `all()` assumes
+    /// when it stops at the first gap.
     #[test]
     fn message_ids_are_contiguous_from_zero() {
-        for (index, id) in MessageId::ALL.iter().enumerate() {
-            assert_eq!(id.as_u16() as usize, index, "{id:?} is not at its expected wire value");
-        }
-        assert_eq!(MessageId::from_u16(MessageId::ALL.len() as u16), None, "an unclaimed ID was accepted");
+        let count = MessageId::all().count();
+        assert!(count > 0, "no message IDs are reachable from the wire");
+        assert_eq!(MessageId::from_u16(count as u16), None, "an ID past the end of the run was accepted");
     }
 
     /// Every ID has a size that is at least large enough to hold the ID itself, and no capped
@@ -225,7 +235,7 @@ mod tests {
     fn max_sizes_are_sane() {
         type CurrentNetwork = snarkvm::prelude::MainnetV0;
 
-        for id in MessageId::ALL {
+        for id in MessageId::all() {
             let max_size = id.max_size::<CurrentNetwork>();
             assert!(max_size >= MESSAGE_ID_SIZE, "{id:?} cannot hold its own message ID");
             assert!(max_size <= MAXIMUM_MESSAGE_SIZE, "{id:?} is allowed to exceed the general frame ceiling");

--- a/node/router/messages/src/puzzle_response.rs
+++ b/node/router/messages/src/puzzle_response.rs
@@ -83,8 +83,7 @@ pub mod prop_tests {
         (any_epoch_hash(), any::<u64>())
             .prop_map(|(epoch_hash, seed)| {
                 let mut rng = TestRng::fixed(seed);
-                let bytes: Vec<u8> =
-                    (0..crate::Message::<CurrentNetwork>::MAX_SMALL_MESSAGE_SIZE).map(|_| rng.random()).collect();
+                let bytes: Vec<u8> = (0..crate::MAX_SMALL_MESSAGE_SIZE).map(|_| rng.random()).collect();
                 PuzzleResponse { epoch_hash, block_header: Data::Buffer(bytes::Bytes::from(bytes)) }
             })
             .boxed()

--- a/node/router/messages/src/puzzle_response.rs
+++ b/node/router/messages/src/puzzle_response.rs
@@ -79,6 +79,17 @@ pub mod prop_tests {
             .boxed()
     }
 
+    pub fn any_large_puzzle_response() -> BoxedStrategy<PuzzleResponse<CurrentNetwork>> {
+        (any_epoch_hash(), any::<u64>())
+            .prop_map(|(epoch_hash, seed)| {
+                let mut rng = TestRng::fixed(seed);
+                let bytes: Vec<u8> =
+                    (0..crate::Message::<CurrentNetwork>::MAX_SMALL_MESSAGE_SIZE).map(|_| rng.random()).collect();
+                PuzzleResponse { epoch_hash, block_header: Data::Buffer(bytes::Bytes::from(bytes)) }
+            })
+            .boxed()
+    }
+
     #[proptest]
     fn puzzle_response_roundtrip(#[strategy(any_puzzle_response())] original: PuzzleResponse<CurrentNetwork>) {
         let mut buf = BytesMut::default().writer();

--- a/node/router/messages/src/unconfirmed_solution.rs
+++ b/node/router/messages/src/unconfirmed_solution.rs
@@ -89,8 +89,7 @@ pub mod prop_tests {
         (any_solution_id(), any::<u64>())
             .prop_map(|(solution_id, seed)| {
                 let mut rng = TestRng::fixed(seed);
-                let bytes: Vec<u8> =
-                    (0..crate::Message::<CurrentNetwork>::MAX_SMALL_MESSAGE_SIZE).map(|_| rng.random()).collect();
+                let bytes: Vec<u8> = (0..crate::MAX_SMALL_MESSAGE_SIZE).map(|_| rng.random()).collect();
                 UnconfirmedSolution { solution_id, solution: Data::Buffer(bytes::Bytes::from(bytes)) }
             })
             .boxed()

--- a/node/router/messages/src/unconfirmed_solution.rs
+++ b/node/router/messages/src/unconfirmed_solution.rs
@@ -85,6 +85,17 @@ pub mod prop_tests {
             .boxed()
     }
 
+    pub fn any_large_unconfirmed_solution() -> BoxedStrategy<UnconfirmedSolution<CurrentNetwork>> {
+        (any_solution_id(), any::<u64>())
+            .prop_map(|(solution_id, seed)| {
+                let mut rng = TestRng::fixed(seed);
+                let bytes: Vec<u8> =
+                    (0..crate::Message::<CurrentNetwork>::MAX_SMALL_MESSAGE_SIZE).map(|_| rng.random()).collect();
+                UnconfirmedSolution { solution_id, solution: Data::Buffer(bytes::Bytes::from(bytes)) }
+            })
+            .boxed()
+    }
+
     #[proptest]
     fn unconfirmed_solution_roundtrip(
         #[strategy(any_unconfirmed_solution())] original: UnconfirmedSolution<CurrentNetwork>,

--- a/node/router/messages/src/unconfirmed_transaction.rs
+++ b/node/router/messages/src/unconfirmed_transaction.rs
@@ -86,13 +86,25 @@ pub mod prop_tests {
             .boxed()
     }
 
-    pub fn any_large_unconfirmed_transaction() -> BoxedStrategy<UnconfirmedTransaction<CurrentNetwork>> {
+    /// An `UnconfirmedTransaction` carrying a transaction of exactly the maximum permitted size.
+    /// Such a transaction is valid - the ledger and the REST endpoint both accept it - so the
+    /// message carrying it has to be accepted on the wire too, even though the message is
+    /// necessarily larger than the transaction by the size of its envelope.
+    pub fn any_max_size_unconfirmed_transaction() -> BoxedStrategy<UnconfirmedTransaction<CurrentNetwork>> {
+        unconfirmed_transaction_of_size(CurrentNetwork::LATEST_MAX_TRANSACTION_SIZE())
+    }
+
+    /// An `UnconfirmedTransaction` carrying a transaction one byte over the maximum.
+    pub fn any_oversized_unconfirmed_transaction() -> BoxedStrategy<UnconfirmedTransaction<CurrentNetwork>> {
+        unconfirmed_transaction_of_size(CurrentNetwork::LATEST_MAX_TRANSACTION_SIZE() + 1)
+    }
+
+    fn unconfirmed_transaction_of_size(size: usize) -> BoxedStrategy<UnconfirmedTransaction<CurrentNetwork>> {
         any::<u64>()
-            .prop_map(|seed| {
+            .prop_map(move |seed| {
                 let mut rng = TestRng::fixed(seed);
                 let tx_id_field = Field::<CurrentNetwork>::rand(&mut rng);
-                let bytes: Vec<u8> =
-                    (0..CurrentNetwork::LATEST_MAX_TRANSACTION_SIZE()).map(|_| u8::rand(&mut rng)).collect();
+                let bytes: Vec<u8> = (0..size).map(|_| u8::rand(&mut rng)).collect();
                 UnconfirmedTransaction {
                     transaction_id: tx_id_field.into(),
                     transaction: Data::Buffer(Bytes::from(bytes)),

--- a/node/src/validator/router.rs
+++ b/node/src/validator/router.rs
@@ -22,6 +22,7 @@ use snarkos_node_router::messages::{
     DisconnectReason,
     Message,
     MessageCodec,
+    MessageId,
     Ping,
     Pong,
     UnconfirmedTransaction,
@@ -107,7 +108,14 @@ impl<N: Network, C: ConsensusStorage<N>> Reading for Validator<N, C> {
     /// Creates a [`Decoder`] used to interpret messages from the network.
     /// The `side` param indicates the connection side **from the node's perspective**.
     fn codec(&self, _peer_addr: SocketAddr, _side: ConnectionSide) -> Self::Codec {
-        Default::default()
+        // A validator syncs blocks exclusively over the committee-gated BFT gateway
+        // (`ConnectionMode::Gateway`); it never issues a `BlockRequest` over the router, so it
+        // never has a legitimate reason to accept a `BlockResponse` there either. Excluding it
+        // here means an untrusted router peer cannot force a large allocation by simply claiming
+        // to be answering a request that was never made. `BlockRequest` (id 0) stays permitted:
+        // other peers legitimately ask this validator for blocks over the router.
+        const EXCLUDED_MESSAGE_IDS: &[MessageId] = &[MessageId::BlockResponse];
+        MessageCodec::restricted(EXCLUDED_MESSAGE_IDS)
     }
 
     /// Processes a message received from the network.

--- a/node/sync/locators/src/block_locators.rs
+++ b/node/sync/locators/src/block_locators.rs
@@ -26,8 +26,9 @@ pub const NUM_RECENT_BLOCKS: usize = 100; // 100 blocks
 const RECENT_INTERVAL: u32 = 1; // 1 block intervals
 /// The interval between block checkpoints.
 pub const CHECKPOINT_INTERVAL: u32 = 10_000; // 10,000 block intervals
-// The maximum number of checkpoints that there can be
-const MAX_CHECKPOINTS: usize = (u32::MAX / CHECKPOINT_INTERVAL) as usize;
+/// The maximum number of checkpoints that there can be. `BlockLocators::read_le` rejects any
+/// locator set claiming more than this, so it also bounds how large a `Ping` can legitimately be.
+pub const MAX_CHECKPOINTS: usize = (u32::MAX / CHECKPOINT_INTERVAL) as usize;
 
 /// Block locator maps.
 ///


### PR DESCRIPTION
## Motivation

The purpose of this is node hardening (see also issue #4140), stacked on #4413. (note, i can't stack it properly because it's a PR from my fork, I guess I should have pushed the branch to upstream instead, or i'll just repoint when that merges)

There are several codecs used in the project:

```
┌──────────────────────────────────────────────┬─────────┬─────────────────┐
│                    codec                     │  limit  │ who can trigger │
├──────────────────────────────────────────────┼─────────┼─────────────────┤
│ node/router/messages/src/helpers/codec.rs:27 │ 128 MiB │ any P2P peer    │
├──────────────────────────────────────────────┼─────────┼─────────────────┤
│ node/bft/events/src/helpers/codec.rs:38      │ 256 MiB │ validator peers │
├──────────────────────────────────────────────┼─────────┼─────────────────┤
│ node/src/bootstrap_client/codec.rs:26        │ 2 MiB   │ bootstrap       │
└──────────────────────────────────────────────┴─────────┴─────────────────┘
```

Even after #4413's per-ID caps, `BlockResponse` stays at the general 128 MiB ceiling there, deliberately - it's the one message that's legitimately large, and tightening it needs the requester's own pending-request state, which that framing layer doesn't have.

A validator has that state, and it's simpler than it sounds: a validator syncs blocks exclusively over the committee-gated BFT gateway (`ConnectionMode::Gateway`) and never issues a `BlockRequest` over its router at all. So a validator's router connections have no legitimate reason to ever accept a `BlockResponse` - full stop, no per-peer tracking needed. Until now nothing enforced that: any router peer, with no stake and no committee membership, could send an unsolicited `BlockResponse` and force the 128 MiB frame-sized allocation.

This adds `MessageCodec::restricted(excluded_ids: &'static [MessageId])`, which rejects a listed message ID at the same early point #4413's size check runs - before the body is waited for or buffered - and wires it into the validator's `Reading::codec()` specifically, excluding only `BlockResponse`. `BlockRequest` stays permitted: a validator legitimately serves *other* peers' sync requests over the router, it just never issues one itself. `Client` and `Prover` are untouched - they legitimately use `BlockRequest`/`BlockResponse` over the router and keep the unrestricted codec.

After this change (and #4413), the largest message a P2P peer can send a validator over the router drops from 128 MiB to 16 MiB (`Ping`, per #4413's locator-size arithmetic). `Ping` can't be excluded the same way - it's universal P2P liveness traffic every node type sends and receives, and the router actually requires senders declaring themselves Client or Validator to include populated locators - so shrinking that further, if wanted, is a separate follow-up. The floor there is bounded by `UnconfirmedTransaction`'s cap (768 KB today), not by anything this PR does.

## Test Plan

Two new tests in `helpers/codec.rs` cover the restriction mechanism directly: `restricted_codec_rejects_an_excluded_id_even_when_well_formed` (a small, honestly-encoded, correctly-sized message is still rejected when its ID is excluded) and `restricted_codec_still_allows_a_permitted_message` (an unrelated exclusion doesn't affect a permitted message). The full existing `snarkos-node-router-messages` suite (32 tests) and a `snarkos-node` compile check both pass unchanged.

We will also deploy this to an ephemeral devnet

## Backwards compatibility

`Client` and `Prover` are not touched - they still use the unrestricted codec. For `Validator`, this is a behavior change only for peers sending an unsolicited `BlockResponse` over the router, which no honest peer does today: verified by tracing the actual call chain (`Validator` constructs its sync engine with `ConnectionMode::Gateway`, and `BFT::try_issuing_block_requests` drives it via the gateway, never the router), not by a runtime test - a validator's router-side outbound-request cache for `BlockResponse` is always empty by construction.