### PR TITLE
fix(router): account for the frame envelope in the transaction size cap

### DIFF
--- a/node/router/messages/src/helpers/codec.rs
+++ b/node/router/messages/src/helpers/codec.rs
@@ -96,7 +96,11 @@ mod tests {
 
     use crate::{
         UnconfirmedTransaction,
-        unconfirmed_transaction::prop_tests::{any_large_unconfirmed_transaction, any_unconfirmed_transaction},
+        unconfirmed_transaction::prop_tests::{
+            any_large_unconfirmed_transaction,
+            any_max_size_unconfirmed_transaction,
+            any_unconfirmed_transaction,
+        },
     };
 
     use proptest::prelude::ProptestConfig;
@@ -120,5 +124,18 @@ mod tests {
         let mut codec = MessageCodec::<CurrentNetwork>::default();
         assert!(codec.encode(Message::UnconfirmedTransaction(tx), &mut bytes).is_ok());
         assert!(matches!(codec.decode(&mut bytes), Err(err) if err.kind() == std::io::ErrorKind::InvalidData));
+    }
+
+    /// A transaction of exactly `LATEST_MAX_TRANSACTION_SIZE` is valid - both the ledger service
+    /// and the REST endpoint accept one - so the message carrying it must be accepted too, even
+    /// though the frame is 39 bytes larger than the transaction itself.
+    #[proptest(ProptestConfig { cases : 10, ..ProptestConfig::default() })]
+    fn max_size_unconfirmed_transaction_is_accepted(
+        #[strategy(any_max_size_unconfirmed_transaction())] tx: UnconfirmedTransaction<CurrentNetwork>,
+    ) {
+        let mut bytes = BytesMut::new();
+        let mut codec = MessageCodec::<CurrentNetwork>::default();
+        assert!(codec.encode(Message::UnconfirmedTransaction(tx), &mut bytes).is_ok());
+        assert!(codec.decode(&mut bytes).is_ok());
     }
 }

--- a/node/router/messages/src/lib.rs
+++ b/node/router/messages/src/lib.rs
@@ -58,7 +58,7 @@ mod unconfirmed_solution;
 pub use unconfirmed_solution::UnconfirmedSolution;
 
 mod unconfirmed_transaction;
-pub use unconfirmed_transaction::UnconfirmedTransaction;
+pub use unconfirmed_transaction::{UNCONFIRMED_TRANSACTION_OVERHEAD, UnconfirmedTransaction};
 
 pub use snarkos_node_bft_events::DataBlocks;
 
@@ -229,14 +229,11 @@ impl<N: Network> Message<N> {
 
         // SPECIAL CASE: check the transaction message isn't too large.
         //
-        // `len` is the whole frame - message ID, transaction ID, and `Data`'s own tag and length
-        // prefix, in addition to the transaction itself - so it has to be checked against the
-        // transaction cap plus that envelope, not the cap alone. A transaction of exactly
-        // `LATEST_MAX_TRANSACTION_SIZE` is valid (the ledger service and the REST endpoint both
-        // accept one), and the frame carrying it is necessarily larger than the transaction is.
-        const UNCONFIRMED_TRANSACTION_OVERHEAD: usize = 2 // the message ID
-            + 32 // the transaction ID preceding the transaction body
-            + 5; // `Data`'s own version byte and length prefix
+        // `len` is the whole frame, which is `UNCONFIRMED_TRANSACTION_OVERHEAD` bytes larger than
+        // the transaction it carries - so it has to be checked against the transaction cap plus
+        // that envelope, not the cap alone. A transaction of exactly `LATEST_MAX_TRANSACTION_SIZE`
+        // is valid (the ledger service and the REST endpoint both accept one), and the frame
+        // carrying it is necessarily larger than the transaction is.
         if id == 12 && len > N::LATEST_MAX_TRANSACTION_SIZE().saturating_add(UNCONFIRMED_TRANSACTION_OVERHEAD) {
             return Err(io::Error::new(io::ErrorKind::InvalidData, "transaction is too large"))?;
         }

--- a/node/router/messages/src/lib.rs
+++ b/node/router/messages/src/lib.rs
@@ -228,7 +228,16 @@ impl<N: Network> Message<N> {
         let id = u16::from_le_bytes(id_bytes);
 
         // SPECIAL CASE: check the transaction message isn't too large.
-        if id == 12 && len > N::LATEST_MAX_TRANSACTION_SIZE() {
+        //
+        // `len` is the whole frame - message ID, transaction ID, and `Data`'s own tag and length
+        // prefix, in addition to the transaction itself - so it has to be checked against the
+        // transaction cap plus that envelope, not the cap alone. A transaction of exactly
+        // `LATEST_MAX_TRANSACTION_SIZE` is valid (the ledger service and the REST endpoint both
+        // accept one), and the frame carrying it is necessarily larger than the transaction is.
+        const UNCONFIRMED_TRANSACTION_OVERHEAD: usize = 2 // the message ID
+            + 32 // the transaction ID preceding the transaction body
+            + 5; // `Data`'s own version byte and length prefix
+        if id == 12 && len > N::LATEST_MAX_TRANSACTION_SIZE().saturating_add(UNCONFIRMED_TRANSACTION_OVERHEAD) {
             return Err(io::Error::new(io::ErrorKind::InvalidData, "transaction is too large"))?;
         }
 

--- a/node/router/messages/src/unconfirmed_transaction.rs
+++ b/node/router/messages/src/unconfirmed_transaction.rs
@@ -86,7 +86,28 @@ pub mod prop_tests {
             .boxed()
     }
 
+    /// A transaction body one byte larger than the cap allows - genuinely too large, since the
+    /// frame carrying it exceeds `LATEST_MAX_TRANSACTION_SIZE` plus its envelope either way.
     pub fn any_large_unconfirmed_transaction() -> BoxedStrategy<UnconfirmedTransaction<CurrentNetwork>> {
+        any::<u64>()
+            .prop_map(|seed| {
+                let mut rng = TestRng::fixed(seed);
+                let tx_id_field = Field::<CurrentNetwork>::rand(&mut rng);
+                let bytes: Vec<u8> =
+                    (0..CurrentNetwork::LATEST_MAX_TRANSACTION_SIZE() + 1).map(|_| u8::rand(&mut rng)).collect();
+                UnconfirmedTransaction {
+                    transaction_id: tx_id_field.into(),
+                    transaction: Data::Buffer(Bytes::from(bytes)),
+                }
+            })
+            .boxed()
+    }
+
+    /// A transaction body of exactly `LATEST_MAX_TRANSACTION_SIZE` - the largest a transaction is
+    /// actually allowed to be, per the ledger service and the REST endpoint. The frame carrying
+    /// it is necessarily larger than the transaction itself (message ID, transaction ID, and
+    /// `Data`'s own tag and length prefix), so this is the case `check_size` must still accept.
+    pub fn any_max_size_unconfirmed_transaction() -> BoxedStrategy<UnconfirmedTransaction<CurrentNetwork>> {
         any::<u64>()
             .prop_map(|seed| {
                 let mut rng = TestRng::fixed(seed);

--- a/node/router/messages/src/unconfirmed_transaction.rs
+++ b/node/router/messages/src/unconfirmed_transaction.rs
@@ -28,6 +28,15 @@ pub struct UnconfirmedTransaction<N: Network> {
     pub transaction: Data<Transaction<N>>,
 }
 
+/// The bytes an `UnconfirmedTransaction` frame carries in addition to the transaction itself:
+/// the message ID that precedes every message payload, `transaction_id`, and `Data`'s own
+/// version byte and length prefix around `transaction`. Kept next to `write_le` below, which is
+/// what actually defines these three numbers - changing that encoding without updating this
+/// would silently reintroduce the mismatch `check_size` was fixed to avoid.
+pub const UNCONFIRMED_TRANSACTION_OVERHEAD: usize = 2 // the message ID
+    + 32 // `transaction_id`
+    + 5; // `Data`'s own version byte and length prefix, around `transaction`
+
 impl<N: Network> From<Transaction<N>> for UnconfirmedTransaction<N> {
     /// Initializes a new `UnconfirmedTransaction` message.
     fn from(transaction: Transaction<N>) -> Self {


### PR DESCRIPTION
## Motivation

Split out from #4413 per review - this piece doesn't depend on that PR's per-ID mechanism at all, so it stands on its own.

`check_size`'s special case for `UnconfirmedTransaction` (id 12) rejects the message if the whole frame exceeds `LATEST_MAX_TRANSACTION_SIZE`. But the frame is larger than the transaction it carries - message ID, transaction ID, and `Data`'s own version byte and length prefix - 39 bytes in total (2 + 32 + 5). A transaction of exactly the maximum size is valid (`ledger-service` and the REST endpoint both accept one), so on `staging` today the peer relaying it gets disconnected for relaying a transaction the network itself considers acceptable.

Fix: check the frame length against `LATEST_MAX_TRANSACTION_SIZE` plus that 39-byte envelope, not the cap alone.

## Test Plan

- `overly_large_unconfirmed_transaction`'s strategy generated exactly `LATEST_MAX_TRANSACTION_SIZE` junk bytes, which after this fix is a legitimate frame size, not an oversized one - bumped it to `+1` so it still tests a genuinely-too-large frame.
- Added `max_size_unconfirmed_transaction_is_accepted`, which is the actual regression test: a transaction body of exactly `LATEST_MAX_TRANSACTION_SIZE` now round-trips through the codec instead of being rejected.
- Full `snarkos-node-router-messages` suite (16 tests) and a `snarkos-node` compile check both pass.

## Backwards compatibility

Strictly more permissive: the only behavior change is that a previously-rejected, legitimately-sized transaction is now accepted.