### PR TITLE
fix(router): account for the frame envelope in the transaction size cap

### DIFF
--- a/node/router/messages/src/helpers/codec.rs
+++ b/node/router/messages/src/helpers/codec.rs
@@ -96,7 +96,11 @@ mod tests {
 
     use crate::{
         UnconfirmedTransaction,
-        unconfirmed_transaction::prop_tests::{any_large_unconfirmed_transaction, any_unconfirmed_transaction},
+        unconfirmed_transaction::prop_tests::{
+            any_large_unconfirmed_transaction,
+            any_max_size_unconfirmed_transaction,
+            any_unconfirmed_transaction,
+        },
     };
 
     use proptest::prelude::ProptestConfig;
@@ -120,5 +124,18 @@ mod tests {
         let mut codec = MessageCodec::<CurrentNetwork>::default();
         assert!(codec.encode(Message::UnconfirmedTransaction(tx), &mut bytes).is_ok());
         assert!(matches!(codec.decode(&mut bytes), Err(err) if err.kind() == std::io::ErrorKind::InvalidData));
+    }
+
+    /// A transaction of exactly `LATEST_MAX_TRANSACTION_SIZE` is valid - both the ledger service
+    /// and the REST endpoint accept one - so the message carrying it must be accepted too, even
+    /// though the frame is 39 bytes larger than the transaction itself.
+    #[proptest(ProptestConfig { cases : 10, ..ProptestConfig::default() })]
+    fn max_size_unconfirmed_transaction_is_accepted(
+        #[strategy(any_max_size_unconfirmed_transaction())] tx: UnconfirmedTransaction<CurrentNetwork>,
+    ) {
+        let mut bytes = BytesMut::new();
+        let mut codec = MessageCodec::<CurrentNetwork>::default();
+        assert!(codec.encode(Message::UnconfirmedTransaction(tx), &mut bytes).is_ok());
+        assert!(codec.decode(&mut bytes).is_ok());
     }
 }

--- a/node/router/messages/src/helpers/codec.rs
+++ b/node/router/messages/src/helpers/codec.rs
@@ -95,10 +95,13 @@ mod tests {
     use super::*;
 
     use crate::{
+        Transaction,
+        UNCONFIRMED_TRANSACTION_OVERHEAD,
         UnconfirmedTransaction,
         unconfirmed_transaction::prop_tests::{
             any_large_unconfirmed_transaction,
             any_max_size_unconfirmed_transaction,
+            any_transaction,
             any_unconfirmed_transaction,
         },
     };
@@ -113,7 +116,28 @@ mod tests {
         let mut bytes = BytesMut::new();
         let mut codec = MessageCodec::<CurrentNetwork>::default();
         assert!(codec.encode(Message::UnconfirmedTransaction(tx), &mut bytes).is_ok());
-        assert!(codec.decode(&mut bytes).is_ok());
+        // `Ok(None)` ("frame incomplete") would also pass a bare `.is_ok()` check, so this must
+        // pin down that a message was actually decoded, not merely that decoding didn't error.
+        assert!(matches!(codec.decode(&mut bytes), Ok(Some(Message::UnconfirmedTransaction(_)))));
+    }
+
+    /// Pins `UNCONFIRMED_TRANSACTION_OVERHEAD` against what `Message::write_le` actually emits,
+    /// rather than trusting the arithmetic in its doc comment: encodes a real transaction inside
+    /// an `UnconfirmedTransaction` frame and checks the frame is exactly that much larger than
+    /// the transaction's own serialized size, for every size a transaction actually takes.
+    #[proptest]
+    fn unconfirmed_transaction_overhead_matches_the_real_encoding(
+        #[strategy(any_transaction())] transaction: Transaction<CurrentNetwork>,
+    ) {
+        let mut transaction_bytes = BytesMut::default().writer();
+        transaction.write_le(&mut transaction_bytes).unwrap();
+        let transaction_len = transaction_bytes.into_inner().len();
+
+        let mut frame = BytesMut::default().writer();
+        Message::UnconfirmedTransaction(transaction.into()).write_le(&mut frame).unwrap();
+        let frame_len = frame.into_inner().len();
+
+        assert_eq!(frame_len, transaction_len + UNCONFIRMED_TRANSACTION_OVERHEAD);
     }
 
     #[proptest(ProptestConfig { cases : 10, ..ProptestConfig::default() })]
@@ -136,6 +160,6 @@ mod tests {
         let mut bytes = BytesMut::new();
         let mut codec = MessageCodec::<CurrentNetwork>::default();
         assert!(codec.encode(Message::UnconfirmedTransaction(tx), &mut bytes).is_ok());
-        assert!(codec.decode(&mut bytes).is_ok());
+        assert!(matches!(codec.decode(&mut bytes), Ok(Some(Message::UnconfirmedTransaction(_)))));
     }
 }

--- a/node/router/messages/src/helpers/codec.rs
+++ b/node/router/messages/src/helpers/codec.rs
@@ -96,7 +96,6 @@ mod tests {
 
     use crate::{
         Transaction,
-        UNCONFIRMED_TRANSACTION_OVERHEAD,
         UnconfirmedTransaction,
         unconfirmed_transaction::prop_tests::{
             any_large_unconfirmed_transaction,
@@ -121,7 +120,7 @@ mod tests {
         assert!(matches!(codec.decode(&mut bytes), Ok(Some(Message::UnconfirmedTransaction(_)))));
     }
 
-    /// Pins `UNCONFIRMED_TRANSACTION_OVERHEAD` against what `Message::write_le` actually emits,
+    /// Pins `UnconfirmedTransaction::OVERHEAD` against what `Message::write_le` actually emits,
     /// rather than trusting the arithmetic in its doc comment: encodes a real transaction inside
     /// an `UnconfirmedTransaction` frame and checks the frame is exactly that much larger than
     /// the transaction's own serialized size, for every size a transaction actually takes.
@@ -137,7 +136,7 @@ mod tests {
         Message::UnconfirmedTransaction(transaction.into()).write_le(&mut frame).unwrap();
         let frame_len = frame.into_inner().len();
 
-        assert_eq!(frame_len, transaction_len + UNCONFIRMED_TRANSACTION_OVERHEAD);
+        assert_eq!(frame_len, transaction_len + UnconfirmedTransaction::<CurrentNetwork>::OVERHEAD);
     }
 
     #[proptest(ProptestConfig { cases : 10, ..ProptestConfig::default() })]

--- a/node/router/messages/src/lib.rs
+++ b/node/router/messages/src/lib.rs
@@ -58,7 +58,7 @@ mod unconfirmed_solution;
 pub use unconfirmed_solution::UnconfirmedSolution;
 
 mod unconfirmed_transaction;
-pub use unconfirmed_transaction::UnconfirmedTransaction;
+pub use unconfirmed_transaction::{UNCONFIRMED_TRANSACTION_OVERHEAD, UnconfirmedTransaction};
 
 pub use snarkos_node_bft_events::DataBlocks;
 
@@ -229,14 +229,11 @@ impl<N: Network> Message<N> {
 
         // SPECIAL CASE: check the transaction message isn't too large.
         //
-        // `len` is the whole frame - message ID, transaction ID, and `Data`'s own tag and length
-        // prefix, in addition to the transaction itself - so it has to be checked against the
-        // transaction cap plus that envelope, not the cap alone. A transaction of exactly
-        // `LATEST_MAX_TRANSACTION_SIZE` is valid (the ledger service and the REST endpoint both
-        // accept one), and the frame carrying it is necessarily larger than the transaction is.
-        const UNCONFIRMED_TRANSACTION_OVERHEAD: usize = 2 // the message ID
-            + 32 // the transaction ID preceding the transaction body
-            + 5; // `Data`'s own version byte and length prefix
+        // `len` is the whole frame, which is `UNCONFIRMED_TRANSACTION_OVERHEAD` bytes larger than
+        // the transaction it carries - so it has to be checked against the transaction cap plus
+        // that envelope, not the cap alone. A transaction of exactly `LATEST_MAX_TRANSACTION_SIZE`
+        // is valid (the ledger service and the REST endpoint both accept one), and the frame
+        // carrying it is necessarily larger than the transaction is.
         if id == 12 && len > N::LATEST_MAX_TRANSACTION_SIZE().saturating_add(UNCONFIRMED_TRANSACTION_OVERHEAD) {
             return Err(io::Error::new(io::ErrorKind::InvalidData, "transaction is too large"))?;
         }

--- a/node/router/messages/src/lib.rs
+++ b/node/router/messages/src/lib.rs
@@ -58,7 +58,7 @@ mod unconfirmed_solution;
 pub use unconfirmed_solution::UnconfirmedSolution;
 
 mod unconfirmed_transaction;
-pub use unconfirmed_transaction::{UNCONFIRMED_TRANSACTION_OVERHEAD, UnconfirmedTransaction};
+pub use unconfirmed_transaction::{DATA_ENCODING_OVERHEAD, UnconfirmedTransaction};
 
 pub use snarkos_node_bft_events::DataBlocks;
 
@@ -229,12 +229,12 @@ impl<N: Network> Message<N> {
 
         // SPECIAL CASE: check the transaction message isn't too large.
         //
-        // `len` is the whole frame, which is `UNCONFIRMED_TRANSACTION_OVERHEAD` bytes larger than
+        // `len` is the whole frame, which is `UnconfirmedTransaction::OVERHEAD` bytes larger than
         // the transaction it carries - so it has to be checked against the transaction cap plus
         // that envelope, not the cap alone. A transaction of exactly `LATEST_MAX_TRANSACTION_SIZE`
         // is valid (the ledger service and the REST endpoint both accept one), and the frame
         // carrying it is necessarily larger than the transaction is.
-        if id == 12 && len > N::LATEST_MAX_TRANSACTION_SIZE().saturating_add(UNCONFIRMED_TRANSACTION_OVERHEAD) {
+        if id == 12 && len > N::LATEST_MAX_TRANSACTION_SIZE().saturating_add(UnconfirmedTransaction::<N>::OVERHEAD) {
             return Err(io::Error::new(io::ErrorKind::InvalidData, "transaction is too large"))?;
         }
 

--- a/node/router/messages/src/lib.rs
+++ b/node/router/messages/src/lib.rs
@@ -228,7 +228,16 @@ impl<N: Network> Message<N> {
         let id = u16::from_le_bytes(id_bytes);
 
         // SPECIAL CASE: check the transaction message isn't too large.
-        if id == 12 && len > N::LATEST_MAX_TRANSACTION_SIZE() {
+        //
+        // `len` is the whole frame - message ID, transaction ID, and `Data`'s own tag and length
+        // prefix, in addition to the transaction itself - so it has to be checked against the
+        // transaction cap plus that envelope, not the cap alone. A transaction of exactly
+        // `LATEST_MAX_TRANSACTION_SIZE` is valid (the ledger service and the REST endpoint both
+        // accept one), and the frame carrying it is necessarily larger than the transaction is.
+        const UNCONFIRMED_TRANSACTION_OVERHEAD: usize = 2 // the message ID
+            + 32 // the transaction ID preceding the transaction body
+            + 5; // `Data`'s own version byte and length prefix
+        if id == 12 && len > N::LATEST_MAX_TRANSACTION_SIZE().saturating_add(UNCONFIRMED_TRANSACTION_OVERHEAD) {
             return Err(io::Error::new(io::ErrorKind::InvalidData, "transaction is too large"))?;
         }
 

--- a/node/router/messages/src/unconfirmed_transaction.rs
+++ b/node/router/messages/src/unconfirmed_transaction.rs
@@ -29,10 +29,12 @@ pub struct UnconfirmedTransaction<N: Network> {
 }
 
 /// The bytes an `UnconfirmedTransaction` frame carries in addition to the transaction itself:
-/// the message ID that precedes every message payload, `transaction_id`, and `Data`'s own
-/// version byte and length prefix around `transaction`. Kept next to `write_le` below, which is
-/// what actually defines these three numbers - changing that encoding without updating this
-/// would silently reintroduce the mismatch `check_size` was fixed to avoid.
+/// the message ID that precedes every message payload (written by `Message::write_le` in
+/// lib.rs, not here), `transaction_id`, and `Data`'s own version byte and length prefix around
+/// `transaction` - the latter two defined by `write_le` below. Changing either encoding without
+/// updating this would silently reintroduce the mismatch `check_size` was fixed to avoid; the
+/// `unconfirmed_transaction_overhead_matches_the_real_encoding` test pins it against the actual
+/// serializer rather than trusting this arithmetic on its own.
 pub const UNCONFIRMED_TRANSACTION_OVERHEAD: usize = 2 // the message ID
     + 32 // `transaction_id`
     + 5; // `Data`'s own version byte and length prefix, around `transaction`
@@ -95,20 +97,33 @@ pub mod prop_tests {
             .boxed()
     }
 
+    /// Fills a `Vec<u8>` of the given length, eight bytes per RNG call rather than one, since the
+    /// callers below need this at up to `LATEST_MAX_TRANSACTION_SIZE` (hundreds of KB).
+    fn random_bytes(rng: &mut TestRng, len: usize) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(len);
+        while bytes.len() < len {
+            bytes.extend_from_slice(&u64::rand(rng).to_le_bytes());
+        }
+        bytes.truncate(len);
+        bytes
+    }
+
+    /// Builds an `UnconfirmedTransaction` whose `Data::Buffer` is exactly `len` bytes of junk -
+    /// content doesn't matter for a pure frame-size test.
+    fn unconfirmed_transaction_of_size(seed: u64, len: usize) -> UnconfirmedTransaction<CurrentNetwork> {
+        let mut rng = TestRng::fixed(seed);
+        let tx_id_field = Field::<CurrentNetwork>::rand(&mut rng);
+        UnconfirmedTransaction {
+            transaction_id: tx_id_field.into(),
+            transaction: Data::Buffer(Bytes::from(random_bytes(&mut rng, len))),
+        }
+    }
+
     /// A transaction body one byte larger than the cap allows - genuinely too large, since the
     /// frame carrying it exceeds `LATEST_MAX_TRANSACTION_SIZE` plus its envelope either way.
     pub fn any_large_unconfirmed_transaction() -> BoxedStrategy<UnconfirmedTransaction<CurrentNetwork>> {
         any::<u64>()
-            .prop_map(|seed| {
-                let mut rng = TestRng::fixed(seed);
-                let tx_id_field = Field::<CurrentNetwork>::rand(&mut rng);
-                let bytes: Vec<u8> =
-                    (0..CurrentNetwork::LATEST_MAX_TRANSACTION_SIZE() + 1).map(|_| u8::rand(&mut rng)).collect();
-                UnconfirmedTransaction {
-                    transaction_id: tx_id_field.into(),
-                    transaction: Data::Buffer(Bytes::from(bytes)),
-                }
-            })
+            .prop_map(|seed| unconfirmed_transaction_of_size(seed, CurrentNetwork::LATEST_MAX_TRANSACTION_SIZE() + 1))
             .boxed()
     }
 
@@ -118,16 +133,7 @@ pub mod prop_tests {
     /// `Data`'s own tag and length prefix), so this is the case `check_size` must still accept.
     pub fn any_max_size_unconfirmed_transaction() -> BoxedStrategy<UnconfirmedTransaction<CurrentNetwork>> {
         any::<u64>()
-            .prop_map(|seed| {
-                let mut rng = TestRng::fixed(seed);
-                let tx_id_field = Field::<CurrentNetwork>::rand(&mut rng);
-                let bytes: Vec<u8> =
-                    (0..CurrentNetwork::LATEST_MAX_TRANSACTION_SIZE()).map(|_| u8::rand(&mut rng)).collect();
-                UnconfirmedTransaction {
-                    transaction_id: tx_id_field.into(),
-                    transaction: Data::Buffer(Bytes::from(bytes)),
-                }
-            })
+            .prop_map(|seed| unconfirmed_transaction_of_size(seed, CurrentNetwork::LATEST_MAX_TRANSACTION_SIZE()))
             .boxed()
     }
 

--- a/node/router/messages/src/unconfirmed_transaction.rs
+++ b/node/router/messages/src/unconfirmed_transaction.rs
@@ -86,7 +86,28 @@ pub mod prop_tests {
             .boxed()
     }
 
+    /// A transaction body one byte larger than the cap allows - genuinely too large, since the
+    /// frame carrying it exceeds `LATEST_MAX_TRANSACTION_SIZE` plus its envelope either way.
     pub fn any_large_unconfirmed_transaction() -> BoxedStrategy<UnconfirmedTransaction<CurrentNetwork>> {
+        any::<u64>()
+            .prop_map(|seed| {
+                let mut rng = TestRng::fixed(seed);
+                let tx_id_field = Field::<CurrentNetwork>::rand(&mut rng);
+                let bytes: Vec<u8> =
+                    (0..CurrentNetwork::LATEST_MAX_TRANSACTION_SIZE() + 1).map(|_| u8::rand(&mut rng)).collect();
+                UnconfirmedTransaction {
+                    transaction_id: tx_id_field.into(),
+                    transaction: Data::Buffer(Bytes::from(bytes)),
+                }
+            })
+            .boxed()
+    }
+
+    /// A transaction body of exactly `LATEST_MAX_TRANSACTION_SIZE` - the largest a transaction is
+    /// actually allowed to be, per the ledger service and the REST endpoint. The frame carrying
+    /// it is necessarily larger than the transaction itself (message ID, transaction ID, and
+    /// `Data`'s own tag and length prefix), so this is the case `check_size` must still accept.
+    pub fn any_max_size_unconfirmed_transaction() -> BoxedStrategy<UnconfirmedTransaction<CurrentNetwork>> {
         any::<u64>()
             .prop_map(|seed| {
                 let mut rng = TestRng::fixed(seed);

--- a/node/router/messages/src/unconfirmed_transaction.rs
+++ b/node/router/messages/src/unconfirmed_transaction.rs
@@ -28,6 +28,15 @@ pub struct UnconfirmedTransaction<N: Network> {
     pub transaction: Data<Transaction<N>>,
 }
 
+/// The bytes an `UnconfirmedTransaction` frame carries in addition to the transaction itself:
+/// the message ID that precedes every message payload, `transaction_id`, and `Data`'s own
+/// version byte and length prefix around `transaction`. Kept next to `write_le` below, which is
+/// what actually defines these three numbers - changing that encoding without updating this
+/// would silently reintroduce the mismatch `check_size` was fixed to avoid.
+pub const UNCONFIRMED_TRANSACTION_OVERHEAD: usize = 2 // the message ID
+    + 32 // `transaction_id`
+    + 5; // `Data`'s own version byte and length prefix, around `transaction`
+
 impl<N: Network> From<Transaction<N>> for UnconfirmedTransaction<N> {
     /// Initializes a new `UnconfirmedTransaction` message.
     fn from(transaction: Transaction<N>) -> Self {

--- a/node/router/messages/src/unconfirmed_transaction.rs
+++ b/node/router/messages/src/unconfirmed_transaction.rs
@@ -17,7 +17,7 @@ use super::*;
 
 use snarkvm::{
     ledger::narwhal::Data,
-    prelude::{FromBytes, ToBytes},
+    prelude::{Field, FromBytes, ToBytes},
 };
 
 use std::borrow::Cow;
@@ -28,16 +28,30 @@ pub struct UnconfirmedTransaction<N: Network> {
     pub transaction: Data<Transaction<N>>,
 }
 
-/// The bytes an `UnconfirmedTransaction` frame carries in addition to the transaction itself:
-/// the message ID that precedes every message payload (written by `Message::write_le` in
-/// lib.rs, not here), `transaction_id`, and `Data`'s own version byte and length prefix around
-/// `transaction` - the latter two defined by `write_le` below. Changing either encoding without
-/// updating this would silently reintroduce the mismatch `check_size` was fixed to avoid; the
-/// `unconfirmed_transaction_overhead_matches_the_real_encoding` test pins it against the actual
-/// serializer rather than trusting this arithmetic on its own.
-pub const UNCONFIRMED_TRANSACTION_OVERHEAD: usize = 2 // the message ID
-    + 32 // `transaction_id`
-    + 5; // `Data`'s own version byte and length prefix, around `transaction`
+/// The bytes `Data`'s own encoding wraps around the object it carries: a version byte and a `u32`
+/// length prefix, both emitted by `Data::write_le` and expected back by `Data::read_le`.
+///
+/// TODO: this belongs in snarkVM, beside the encoding it describes (`ledger/narwhal/data/src`),
+/// so that changing `Data::write_le` forces this to be changed with it. Restating it here is a
+/// stopgap - replace it with the snarkVM constant once one is exported.
+pub const DATA_ENCODING_OVERHEAD: usize = size_of::<u8>() // the version byte
+    + size_of::<u32>(); // the length prefix
+
+impl<N: Network> UnconfirmedTransaction<N> {
+    /// The bytes an `UnconfirmedTransaction` frame carries in addition to the transaction itself:
+    /// the message ID that precedes every message payload (written by `Message::write_le` in
+    /// lib.rs, not here), `transaction_id`, and the `Data` envelope around `transaction` that
+    /// `write_le` below emits.
+    ///
+    /// Each term names what defines it rather than a literal, so widening any of them is a
+    /// compile-time change here too. Adding or removing a *field* still isn't, which is why
+    /// `unconfirmed_transaction_overhead_matches_the_real_encoding` pins the total against the
+    /// actual serializer rather than trusting this arithmetic on its own - getting it wrong would
+    /// silently reintroduce the mismatch `check_size` was fixed to avoid.
+    pub const OVERHEAD: usize = size_of::<u16>() // the message ID
+        + Field::<N>::SIZE_IN_BYTES // `transaction_id`, an `AleoID` wrapping one field element
+        + DATA_ENCODING_OVERHEAD; // `Data`'s envelope around `transaction`
+}
 
 impl<N: Network> From<Transaction<N>> for UnconfirmedTransaction<N> {
     /// Initializes a new `UnconfirmedTransaction` message.


### PR DESCRIPTION
## Motivation

Split out from #4413 per review

`check_size`'s special case for `UnconfirmedTransaction` (id 12) rejects the message if the whole frame exceeds `LATEST_MAX_TRANSACTION_SIZE`. But the frame is larger than the transaction it carries - message ID, transaction ID, and `Data`'s own version byte and length prefix - 39 bytes in total (2 + 32 + 5). A transaction of exactly the maximum size is valid (`ledger-service` and the REST endpoint both accept one), so on `staging` today the peer relaying it gets disconnected for relaying a transaction the network itself considers acceptable.

Fix: check the frame length against `LATEST_MAX_TRANSACTION_SIZE` plus that 39-byte envelope, not the cap alone.

## Test Plan

- `overly_large_unconfirmed_transaction`'s strategy generated exactly `LATEST_MAX_TRANSACTION_SIZE` junk bytes, which after this fix is a legitimate frame size, not an oversized one - bumped it to `+1` so it still tests a genuinely-too-large frame.
- Added `max_size_unconfirmed_transaction_is_accepted`, which is the actual regression test: a transaction body of exactly `LATEST_MAX_TRANSACTION_SIZE` now round-trips through the codec instead of being rejected.
- Full `snarkos-node-router-messages` suite (16 tests) and a `snarkos-node` compile check both pass.

## Backwards compatibility

Strictly more permissive: the only behavior change is that a previously-rejected, legitimately-sized transaction is now accepted.