### PR TITLE
fix(router): cap the size of a Ping message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5444,6 +5444,7 @@ name = "snarkos-node-router-messages"
 version = "4.9.0"
 dependencies = [
  "bytes",
+ "indexmap 2.14.0",
  "proptest",
  "snarkos-node-bft-events",
  "snarkos-node-network",

--- a/node/router/messages/Cargo.toml
+++ b/node/router/messages/Cargo.toml
@@ -45,6 +45,9 @@ features = [ "codec" ]
 [dependencies.tracing]
 workspace = true
 
+[dev-dependencies.indexmap]
+workspace = true
+
 [dev-dependencies.snarkos-node-sync-locators]
 workspace = true
 features = [ "test" ]

--- a/node/router/messages/src/helpers/codec.rs
+++ b/node/router/messages/src/helpers/codec.rs
@@ -95,8 +95,10 @@ mod tests {
     use super::*;
 
     use crate::{
+        MAX_PING_MESSAGE_SIZE,
         Transaction,
         UnconfirmedTransaction,
+        ping::prop_tests::largest_possible_ping,
         unconfirmed_transaction::prop_tests::{
             any_large_unconfirmed_transaction,
             any_max_size_unconfirmed_transaction,
@@ -160,5 +162,38 @@ mod tests {
         let mut codec = MessageCodec::<CurrentNetwork>::default();
         assert!(codec.encode(Message::UnconfirmedTransaction(tx), &mut bytes).is_ok());
         assert!(matches!(codec.decode(&mut bytes), Ok(Some(Message::UnconfirmedTransaction(_)))));
+    }
+
+    /// The largest `Ping` the wire format permits must still be accepted - the failure mode a too
+    /// tight cap causes is disconnecting honest peers, which is worse than the DoS this exists to
+    /// prevent.
+    #[test]
+    fn largest_possible_ping_is_accepted() {
+        let mut bytes = BytesMut::new();
+        let mut codec = MessageCodec::<CurrentNetwork>::default();
+        assert!(codec.encode(Message::Ping(largest_possible_ping()), &mut bytes).is_ok());
+        assert!(matches!(codec.decode(&mut bytes), Ok(Some(Message::Ping(_)))));
+    }
+
+    /// `check_size` is exercised directly here, rather than through a constructed `Ping`: nothing
+    /// past a `Ping`'s own wire-format ceiling (`MAX_CHECKPOINTS` checkpoints) can actually reach
+    /// `MAX_PING_MESSAGE_SIZE` - there's real headroom between the two - so a frame large enough
+    /// to violate the cap isn't representable as a legitimately-shaped `Ping` at all. The content
+    /// after the ID is irrelevant to `check_size`, which only inspects the ID and the length.
+    #[test]
+    fn oversized_ping_is_rejected() {
+        let id: u16 = 7; // Ping
+        let mut bytes = vec![0u8; MAX_PING_MESSAGE_SIZE + 1];
+        bytes[..2].copy_from_slice(&id.to_le_bytes());
+        assert!(Message::<CurrentNetwork>::check_size(&bytes).is_err());
+    }
+
+    /// The boundary itself: exactly `MAX_PING_MESSAGE_SIZE` must still be accepted by `check_size`.
+    #[test]
+    fn max_size_ping_frame_is_accepted_by_check_size() {
+        let id: u16 = 7; // Ping
+        let mut bytes = vec![0u8; MAX_PING_MESSAGE_SIZE];
+        bytes[..2].copy_from_slice(&id.to_le_bytes());
+        assert!(Message::<CurrentNetwork>::check_size(&bytes).is_ok());
     }
 }

--- a/node/router/messages/src/lib.rs
+++ b/node/router/messages/src/lib.rs
@@ -43,7 +43,7 @@ mod peer_response;
 pub use peer_response::PeerResponse;
 
 mod ping;
-pub use ping::Ping;
+pub use ping::{MAX_PING_MESSAGE_SIZE, Ping};
 
 mod pong;
 pub use pong::Pong;
@@ -236,6 +236,13 @@ impl<N: Network> Message<N> {
         // carrying it is necessarily larger than the transaction is.
         if id == 12 && len > N::LATEST_MAX_TRANSACTION_SIZE().saturating_add(UnconfirmedTransaction::<N>::OVERHEAD) {
             return Err(io::Error::new(io::ErrorKind::InvalidData, "transaction is too large"))?;
+        }
+
+        // SPECIAL CASE: check the ping message isn't too large. Unlike every other message type,
+        // Ping has no fixed shape - its block locators grow with chain height - so its cap is not
+        // a small constant; see MAX_PING_MESSAGE_SIZE for the derivation.
+        if id == 7 && len > MAX_PING_MESSAGE_SIZE {
+            return Err(io::Error::new(io::ErrorKind::InvalidData, "ping is too large"))?;
         }
 
         Ok(())

--- a/node/router/messages/src/ping.rs
+++ b/node/router/messages/src/ping.rs
@@ -16,6 +16,7 @@
 use super::*;
 
 use snarkos_node_network::NodeType;
+use snarkos_node_sync_locators::{MAX_CHECKPOINTS, NUM_RECENT_BLOCKS};
 use snarkvm::prelude::{FromBytes, ToBytes};
 
 use std::borrow::Cow;
@@ -26,6 +27,32 @@ pub struct Ping<N: Network> {
     pub node_type: NodeType,
     pub block_locators: Option<BlockLocators<N>>,
 }
+
+/// The maximum size of a `Ping` frame, kept next to `write_le` below since that is what actually
+/// defines the fixed part of this layout (4 + 1 + 1 bytes, plus the message ID that
+/// `Message::write_le` prepends). Unlike every other message type, `Ping` has no fixed shape:
+/// `block_locators` grows with the height of the chain, up to `NUM_RECENT_BLOCKS` recent entries
+/// plus `MAX_CHECKPOINTS` checkpoints (see `snarkos_node_sync_locators::block_locators`), each a
+/// `(u32, BlockHash)` pair - 4 bytes plus a 32-byte field element.
+///
+/// This is `u32::MAX / CHECKPOINT_INTERVAL` checkpoints' worth - the wire format's own ceiling,
+/// derived rather than measured, and asserted below against the real locator-entry size so it
+/// can't silently drift from what `BlockLocators` actually enforces. It is far above anything a
+/// realistic chain height produces today; see the PR that introduced this cap for the case that
+/// a tighter, revisitable number might be preferable instead.
+pub const MAX_PING_MESSAGE_SIZE: usize = 16 * 1024 * 1024; // 16 MiB
+
+const _: () = {
+    let locator_entry = size_of::<u32>() + 32; // a block height, plus a `BlockHash` field element
+    let ping = 2 // the message ID
+        + 4 // `version`
+        + 1 // `node_type`
+        + 1 // the `Some`/`None` marker on `block_locators`
+        + 4 // the `recents` map's length prefix
+        + 4 // the `checkpoints` map's length prefix
+        + (NUM_RECENT_BLOCKS + MAX_CHECKPOINTS) * locator_entry;
+    assert!(ping <= MAX_PING_MESSAGE_SIZE, "MAX_PING_MESSAGE_SIZE is below the largest Ping the wire format permits");
+};
 
 impl<N: Network> MessageTrait for Ping<N> {
     /// Returns the message name.
@@ -75,10 +102,20 @@ impl<N: Network> Ping<N> {
 #[cfg(test)]
 pub mod prop_tests {
     use crate::{Ping, challenge_request::prop_tests::any_node_type};
-    use snarkos_node_sync_locators::{BlockLocators, test_helpers::sample_block_locators};
-    use snarkvm::utilities::{FromBytes, ToBytes};
+    use snarkos_node_sync_locators::{
+        BlockLocators,
+        CHECKPOINT_INTERVAL,
+        MAX_CHECKPOINTS,
+        NUM_RECENT_BLOCKS,
+        test_helpers::sample_block_locators,
+    };
+    use snarkvm::{
+        prelude::Field,
+        utilities::{FromBytes, ToBytes},
+    };
 
     use bytes::{Buf, BufMut, BytesMut};
+    use indexmap::IndexMap;
     use proptest::prelude::{BoxedStrategy, Strategy, any};
     use test_strategy::proptest;
 
@@ -100,5 +137,47 @@ pub mod prop_tests {
         ping.write_le(&mut bytes).unwrap();
         let decoded = Ping::<CurrentNetwork>::read_le(&mut bytes.into_inner().reader()).unwrap();
         assert_eq!(ping, decoded);
+    }
+
+    /// The largest `Ping` the wire format permits: a full recent-block window, plus the
+    /// checkpoint ceiling `BlockLocators::read_le` itself enforces - not just the largest number
+    /// of entries `write_le` will emit, but one that actually satisfies `BlockLocators::new`'s own
+    /// validity rules, since `read_le` calls it and this needs to round-trip through the codec.
+    /// That means checkpoints genuinely spaced `CHECKPOINT_INTERVAL` apart (not just sequential
+    /// heights), with `recents` ending within one interval of the last checkpoint - so this is
+    /// only reachable at a chain height near `u32::MAX`, which is exactly the point.
+    ///
+    /// Content doesn't matter here beyond satisfying `BlockLocators::new`'s uniqueness
+    /// requirement (`recents` and, separately, `checkpoints` may not contain a repeated hash) -
+    /// so each entry's hash is just its own height embedded as a field element, which is cheap
+    /// and trivially unique within each map, rather than paying for hundreds of thousands of
+    /// fresh random field elements. Uniqueness is not required *across* the two maps, only
+    /// within each, and this construction never gives them an overlapping height anyway.
+    ///
+    /// Note this is `MAX_CHECKPOINTS`, not `MAX_CHECKPOINTS + 1`: the latter isn't a way to get a
+    /// frame that's too large for `MAX_PING_MESSAGE_SIZE` (there's real headroom between the two;
+    /// `MAX_PING_MESSAGE_SIZE`'s own doc comment has the arithmetic), it's a way to get a frame
+    /// that `BlockLocators::read_le` rejects for an unrelated reason - a different mechanism than
+    /// the one this cap is testing.
+    pub fn largest_possible_ping() -> Ping<CurrentNetwork> {
+        let hash_for = |height: u32| Field::<CurrentNetwork>::from_u64(height as u64).into();
+
+        let last_checkpoint_height = (MAX_CHECKPOINTS as u32 - 1) * CHECKPOINT_INTERVAL;
+        let checkpoints = (0..MAX_CHECKPOINTS as u32)
+            .map(|i| (i * CHECKPOINT_INTERVAL, hash_for(i)))
+            .collect::<IndexMap<_, _>>();
+
+        // `recents` must end within [last_checkpoint_height, last_checkpoint_height +
+        // CHECKPOINT_INTERVAL) - put its window at the very top of that range.
+        let last_recent_height = last_checkpoint_height + CHECKPOINT_INTERVAL - 1;
+        let recents = ((last_recent_height + 1 - NUM_RECENT_BLOCKS as u32)..=last_recent_height)
+            .map(|h| (h, hash_for(h)))
+            .collect::<IndexMap<_, _>>();
+
+        Ping {
+            version: 0,
+            node_type: snarkos_node_network::NodeType::Client,
+            block_locators: Some(BlockLocators { recents, checkpoints }),
+        }
     }
 }

--- a/node/router/messages/src/ping.rs
+++ b/node/router/messages/src/ping.rs
@@ -163,9 +163,8 @@ pub mod prop_tests {
         let hash_for = |height: u32| Field::<CurrentNetwork>::from_u64(height as u64).into();
 
         let last_checkpoint_height = (MAX_CHECKPOINTS as u32 - 1) * CHECKPOINT_INTERVAL;
-        let checkpoints = (0..MAX_CHECKPOINTS as u32)
-            .map(|i| (i * CHECKPOINT_INTERVAL, hash_for(i)))
-            .collect::<IndexMap<_, _>>();
+        let checkpoints =
+            (0..MAX_CHECKPOINTS as u32).map(|i| (i * CHECKPOINT_INTERVAL, hash_for(i))).collect::<IndexMap<_, _>>();
 
         // `recents` must end within [last_checkpoint_height, last_checkpoint_height +
         // CHECKPOINT_INTERVAL) - put its window at the very top of that range.

--- a/node/sync/locators/src/block_locators.rs
+++ b/node/sync/locators/src/block_locators.rs
@@ -27,7 +27,11 @@ const RECENT_INTERVAL: u32 = 1; // 1 block intervals
 /// The interval between block checkpoints.
 pub const CHECKPOINT_INTERVAL: u32 = 10_000; // 10,000 block intervals
 // The maximum number of checkpoints that there can be
-const MAX_CHECKPOINTS: usize = (u32::MAX / CHECKPOINT_INTERVAL) as usize;
+/// The maximum number of checkpoints a valid `BlockLocators` can ever contain: one checkpoint
+/// every `CHECKPOINT_INTERVAL` blocks, up to the largest height the wire format can express.
+/// `pub` so callers outside this crate - e.g. a message-size cap on whatever carries block
+/// locators - can size themselves against this bound instead of restating it.
+pub const MAX_CHECKPOINTS: usize = (u32::MAX / CHECKPOINT_INTERVAL) as usize;
 
 /// Block locator maps.
 ///


### PR DESCRIPTION
## Motivation

Ping had no message-specific size check at all, unlike UnconfirmedTransaction - it fell through to the general 128 MiB frame ceiling. Unlike every other message type, Ping has no fixed shape: its block_locators grow with chain height, up to NUM_RECENT_BLOCKS recent entries plus MAX_CHECKPOINTS checkpoints (BlockLocators::read_le's own ceiling), each a (u32, BlockHash) pair.

* Add a Ping-specific cap of 16 MiB, derived from that arithmetic (the "real" worst case is ~14.75 MiB)
* Use it in `fn check_size`

Exports MAX_CHECKPOINTS from the locators crate, which was private, so this cap can be derived from it instead of restating the bound.

## Test Plan

Pinned by a compile-time assertion so it can't silently drift below what the wire format actually permits. This is the theoretical ceiling, not a tight number.

It might be that there's a better bound we can justify using the maximum ping size, which would give better node hardening. Getting it down to 768kb would match the maximum size of an unconfirmed transaction.

## Documentation

N/A

## Backwards compatibility

This is backwards compatible.