### PR TITLE
fix clippy & cargo audit failing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -681,9 +681,9 @@ dependencies = [
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -4020,7 +4020,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "chacha20 0.10.1",
+ "chacha20 0.10.2",
  "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]

--- a/node/bft/src/helpers/telemetry.rs
+++ b/node/bft/src/helpers/telemetry.rs
@@ -182,6 +182,10 @@ enum TelemetryUpdate<N: Network> {
     /// anything about the subdag itself.
     Subdag { gc_round: u64, metadata: Vec<CertificateMetadata<N>> },
     /// Insert the metadata of a single certificate.
+    ///
+    /// Only ever sent by the `#[cfg(test)]`-only `insert_certificate`, so a non-test build
+    /// never constructs it - hence the `allow` below.
+    #[cfg_attr(not(test), allow(dead_code))]
     Certificate(Box<CertificateMetadata<N>>),
     /// Acknowledge once every previously enqueued update has been applied and published.
     Flush(oneshot::Sender<()>),


### PR DESCRIPTION
## Summary

`check-clippy` has been failing on `staging`'s own tip since #4406 landed
```
error: variant `Certificate` is never constructed
   --> node/bft/src/helpers/telemetry.rs:185:5
    |
178 | enum TelemetryUpdate<N: Network> {
    |      --------------- variant in this enum
...
185 |     Certificate(Box<CertificateMetadata<N>>),
    |     ^^^^^^^^^^^
```

This is because the variant is only used by tests now, so we mark it allow ignored.

---

Also, chacha20 0.10.1 was yanked, and we need to bump to 0.10.2.

## Fix

Add `#[cfg_attr(not(test), allow(dead_code))]` directly on the variant, scoped to exactly the case that's a false positive.

## Test plan
- [x] `cargo clippy -p snarkos-node-bft --lib -- -D warnings` passes (previously failed with the error above)