### PR TITLE
feat(router): cap each connection's frame length at its allowed types' max

### DIFF
--- a/node/router/messages/src/helpers/codec.rs
+++ b/node/router/messages/src/helpers/codec.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::Message;
+use crate::{MAX_SMALL_MESSAGE_SIZE, Message, MessageId};
 use snarkvm::prelude::{FromBytes, Network, ToBytes};
 
 use ::bytes::{Buf, BufMut, BytesMut};
@@ -22,9 +22,6 @@ use tokio_util::codec::{Decoder, Encoder, LengthDelimitedCodec};
 
 /// The maximum size of a message that can be transmitted during the handshake.
 const MAXIMUM_HANDSHAKE_MESSAGE_SIZE: usize = 1024 * 1024; // 1 MiB
-
-/// The maximum size of a message that can be transmitted in the network.
-pub(crate) const MAXIMUM_MESSAGE_SIZE: usize = 128 * 1024 * 1024; // 128 MiB
 
 /// The codec used to decode and encode network `Message`s.
 pub struct MessageCodec<N: Network> {
@@ -38,14 +35,38 @@ impl<N: Network> MessageCodec<N> {
         codec.codec.set_max_frame_length(MAXIMUM_HANDSHAKE_MESSAGE_SIZE);
         codec
     }
+
+    /// Builds a codec whose frame-length ceiling is the maximum over the sizes of the message
+    /// types in `allowed_ids` - not a per-message check at decode time, just the ceiling the
+    /// underlying length-delimited codec enforces before a frame is fully buffered.
+    ///
+    /// Restricting `allowed_ids` cannot hand an attacker any capability they don't already have:
+    /// whatever the resulting ceiling is, it is exactly the size of the largest type still
+    /// allowed on this connection, and an honest peer can already legitimately send that much of
+    /// that type. What it *does* buy is a smaller ceiling for a connection that structurally has
+    /// no legitimate reason to expect a large type at all - see [`Self::excluding`].
+    fn for_allowed_ids(allowed_ids: impl IntoIterator<Item = MessageId>) -> Self {
+        let max_frame_length =
+            allowed_ids.into_iter().map(|id| id.max_size::<N>()).max().unwrap_or(MAX_SMALL_MESSAGE_SIZE);
+        Self {
+            codec: LengthDelimitedCodec::builder().max_frame_length(max_frame_length).little_endian().new_codec(),
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Builds a codec for a connection that structurally has no legitimate reason to ever receive
+    /// any of `excluded_ids` - for instance, a validator's router connections, which never expect
+    /// a `BlockResponse` since validators sync blocks over the committee-gated BFT gateway
+    /// instead. See [`Self::for_allowed_ids`] for why this shrinks the connection's ceiling rather
+    /// than just relabeling it: the ceiling becomes the largest type *actually* expected here.
+    pub fn excluding(excluded_ids: &[MessageId]) -> Self {
+        Self::for_allowed_ids(MessageId::all().filter(|id| !excluded_ids.contains(id)))
+    }
 }
 
 impl<N: Network> Default for MessageCodec<N> {
     fn default() -> Self {
-        Self {
-            codec: LengthDelimitedCodec::builder().max_frame_length(MAXIMUM_MESSAGE_SIZE).little_endian().new_codec(),
-            _phantom: Default::default(),
-        }
+        Self::for_allowed_ids(MessageId::all())
     }
 }
 
@@ -95,10 +116,20 @@ mod tests {
     use super::*;
 
     use crate::{
-        MAX_PING_MESSAGE_SIZE,
+        BlockRequest,
+        BlockResponse,
+        DataBlocks,
+        MAX_SMALL_MESSAGE_SIZE,
+        MESSAGE_ID_SIZE,
+        MessageId,
+        PeerResponse,
+        PuzzleResponse,
         Transaction,
+        UnconfirmedSolution,
         UnconfirmedTransaction,
         ping::prop_tests::largest_possible_ping,
+        puzzle_response::prop_tests::{any_large_puzzle_response, any_puzzle_response},
+        unconfirmed_solution::prop_tests::{any_large_unconfirmed_solution, any_unconfirmed_solution},
         unconfirmed_transaction::prop_tests::{
             any_large_unconfirmed_transaction,
             any_max_size_unconfirmed_transaction,
@@ -108,6 +139,8 @@ mod tests {
     };
 
     use proptest::prelude::ProptestConfig;
+    use snarkvm::console::network::ConsensusVersion;
+    use std::net::{Ipv6Addr, SocketAddr};
     use test_strategy::proptest;
 
     type CurrentNetwork = snarkvm::prelude::MainnetV0;
@@ -153,7 +186,7 @@ mod tests {
 
     /// A transaction of exactly `LATEST_MAX_TRANSACTION_SIZE` is valid - both the ledger service
     /// and the REST endpoint accept one - so the message carrying it must be accepted too, even
-    /// though the frame is 39 bytes larger than the transaction itself.
+    /// though the frame is larger than the transaction itself by its envelope.
     #[proptest(ProptestConfig { cases : 10, ..ProptestConfig::default() })]
     fn max_size_unconfirmed_transaction_is_accepted(
         #[strategy(any_max_size_unconfirmed_transaction())] tx: UnconfirmedTransaction<CurrentNetwork>,
@@ -175,25 +208,152 @@ mod tests {
         assert!(matches!(codec.decode(&mut bytes), Ok(Some(Message::Ping(_)))));
     }
 
-    /// `check_size` is exercised directly here, rather than through a constructed `Ping`: nothing
-    /// past a `Ping`'s own wire-format ceiling (`MAX_CHECKPOINTS` checkpoints) can actually reach
-    /// `MAX_PING_MESSAGE_SIZE` - there's real headroom between the two - so a frame large enough
-    /// to violate the cap isn't representable as a legitimately-shaped `Ping` at all. The content
-    /// after the ID is irrelevant to `check_size`, which only inspects the ID and the length.
-    #[test]
-    fn oversized_ping_is_rejected() {
-        let id: u16 = 7; // Ping
-        let mut bytes = vec![0u8; MAX_PING_MESSAGE_SIZE + 1];
-        bytes[..2].copy_from_slice(&id.to_le_bytes());
-        assert!(Message::<CurrentNetwork>::check_size(&bytes).is_err());
+    /// The bug this whole cap exists to fix: before it, nothing stopped a `PuzzleResponse` or
+    /// `UnconfirmedSolution` from carrying an arbitrarily large payload, up to the general frame
+    /// ceiling. Both are now bounded like every other small, fixed-shape message.
+    #[proptest(ProptestConfig { cases : 5, ..ProptestConfig::default() })]
+    fn overly_large_puzzle_response(#[strategy(any_large_puzzle_response())] message: PuzzleResponse<CurrentNetwork>) {
+        let mut bytes = BytesMut::new();
+        let mut codec = MessageCodec::<CurrentNetwork>::default();
+        assert!(codec.encode(Message::PuzzleResponse(message), &mut bytes).is_ok());
+        assert!(matches!(codec.decode(&mut bytes), Err(err) if err.kind() == std::io::ErrorKind::InvalidData));
     }
 
-    /// The boundary itself: exactly `MAX_PING_MESSAGE_SIZE` must still be accepted by `check_size`.
+    #[proptest(ProptestConfig { cases : 5, ..ProptestConfig::default() })]
+    fn overly_large_unconfirmed_solution(
+        #[strategy(any_large_unconfirmed_solution())] solution: UnconfirmedSolution<CurrentNetwork>,
+    ) {
+        let mut bytes = BytesMut::new();
+        let mut codec = MessageCodec::<CurrentNetwork>::default();
+        assert!(codec.encode(Message::UnconfirmedSolution(solution), &mut bytes).is_ok());
+        assert!(matches!(codec.decode(&mut bytes), Err(err) if err.kind() == std::io::ErrorKind::InvalidData));
+    }
+
+    #[proptest]
+    fn puzzle_response_is_accepted(#[strategy(any_puzzle_response())] message: PuzzleResponse<CurrentNetwork>) {
+        let mut bytes = BytesMut::new();
+        let mut codec = MessageCodec::<CurrentNetwork>::default();
+        assert!(codec.encode(Message::PuzzleResponse(message), &mut bytes).is_ok());
+        assert!(matches!(codec.decode(&mut bytes), Ok(Some(Message::PuzzleResponse(_)))));
+    }
+
+    #[proptest]
+    fn unconfirmed_solution_is_accepted(
+        #[strategy(any_unconfirmed_solution())] solution: UnconfirmedSolution<CurrentNetwork>,
+    ) {
+        let mut bytes = BytesMut::new();
+        let mut codec = MessageCodec::<CurrentNetwork>::default();
+        assert!(codec.encode(Message::UnconfirmedSolution(solution), &mut bytes).is_ok());
+        assert!(matches!(codec.decode(&mut bytes), Ok(Some(Message::UnconfirmedSolution(_)))));
+    }
+
+    /// The caps have to admit the largest message an honest node will actually send, or peers
+    /// start disconnecting each other. `PeerResponse` is the tightest of the small messages: a
+    /// full peer list of IPv6 addresses, every one of them carrying a height - the encoding's
+    /// actual worst case, not just a plausible-looking sample of one.
     #[test]
-    fn max_size_ping_frame_is_accepted_by_check_size() {
-        let id: u16 = 7; // Ping
-        let mut bytes = vec![0u8; MAX_PING_MESSAGE_SIZE];
-        bytes[..2].copy_from_slice(&id.to_le_bytes());
+    fn largest_honest_peer_response_is_accepted() {
+        let peers = (0..u8::MAX as u16)
+            .map(|i| (SocketAddr::new(Ipv6Addr::new(0x2001, 0xdb8, i, i, i, i, i, i).into(), 4130), Some(u32::MAX)))
+            .collect::<Vec<_>>();
+
+        let mut bytes = BytesMut::new();
+        let mut codec = MessageCodec::<CurrentNetwork>::default();
+        assert!(codec.encode(Message::PeerResponse(PeerResponse { peers }), &mut bytes).is_ok());
+        assert!(matches!(codec.decode(&mut bytes), Ok(Some(Message::PeerResponse(_)))));
+    }
+
+    /// `check_size` bounds every message type it recognizes, not just `Ping` and
+    /// `UnconfirmedTransaction` - this sweeps every `MessageId` and pins its boundary exactly: a
+    /// frame declaring precisely the type's maximum is accepted, one byte more is rejected.
+    #[test]
+    fn size_gate_boundary_is_exact() {
+        for id in MessageId::all() {
+            let max_size = id.max_size::<CurrentNetwork>();
+
+            let mut bytes = vec![0u8; max_size];
+            bytes[..MESSAGE_ID_SIZE].copy_from_slice(&id.as_u16().to_le_bytes());
+            assert!(
+                Message::<CurrentNetwork>::check_size(&bytes).is_ok(),
+                "{id:?} rejected a frame of exactly its maximum size ({max_size})"
+            );
+
+            let mut bytes = vec![0u8; max_size + 1];
+            bytes[..MESSAGE_ID_SIZE].copy_from_slice(&id.as_u16().to_le_bytes());
+            assert!(
+                Message::<CurrentNetwork>::check_size(&bytes).is_err(),
+                "{id:?} admitted a frame one byte over its cap"
+            );
+        }
+    }
+
+    /// An ID this node doesn't recognize is left uncapped by `check_size` - `Message::read_le`
+    /// rejects it instead, and reports it as an unknown message rather than a size violation.
+    #[test]
+    fn unrecognized_message_id_is_not_size_capped() {
+        let unrecognized_id: u16 = MessageId::all().count() as u16;
+        let mut bytes = vec![0u8; MAX_SMALL_MESSAGE_SIZE + 1];
+        bytes[..MESSAGE_ID_SIZE].copy_from_slice(&unrecognized_id.to_le_bytes());
         assert!(Message::<CurrentNetwork>::check_size(&bytes).is_ok());
+    }
+
+    /// Builds a small, well-formed `BlockResponse` - an empty block list is a legitimate wire
+    /// encoding (nothing in `write_le`/`read_le` requires a non-empty one), so this never has to
+    /// construct a real block just to exercise the codec. The request range just has to be
+    /// well-formed by `BlockRequest`'s own rules (non-zero start, start < end) - it does not have
+    /// to match the (empty) block list for the codec to accept the frame.
+    fn small_block_response() -> Message<CurrentNetwork> {
+        let request = BlockRequest { start_height: 1, end_height: 2 };
+        Message::BlockResponse(BlockResponse::new(request, DataBlocks(vec![]), ConsensusVersion::V12))
+    }
+
+    /// The default codec's frame ceiling is `BlockResponse`'s own cap: it is the largest of every
+    /// message type this node might decode on a connection with no further restriction.
+    #[test]
+    fn default_codec_ceiling_is_the_largest_allowed_type() {
+        let codec = MessageCodec::<CurrentNetwork>::default();
+        let expected = MessageId::all().map(|id| id.max_size::<CurrentNetwork>()).max().unwrap();
+        assert_eq!(expected, MessageId::BlockResponse.max_size::<CurrentNetwork>());
+        assert_eq!(codec.codec.max_frame_length(), expected);
+    }
+
+    /// Excluding `BlockResponse` shrinks the ceiling to `Ping`'s - the largest of what remains -
+    /// rather than to some hardcoded number, so tightening `Ping`'s own cap in the future
+    /// automatically tightens this ceiling too.
+    #[test]
+    fn excluding_block_response_shrinks_the_ceiling_to_the_next_largest_type() {
+        let codec = MessageCodec::<CurrentNetwork>::excluding(&[MessageId::BlockResponse]);
+        assert_eq!(codec.codec.max_frame_length(), MessageId::Ping.max_size::<CurrentNetwork>());
+    }
+
+    /// Excluding a type from a codec's allowed IDs only shrinks the frame-length ceiling - it does
+    /// not add a decode-time rejection for that type's ID. A small, legitimately-shaped
+    /// `BlockResponse` still decodes: rejecting an unexpected one is `Validator::block_response`'s
+    /// job, a layer up, which has the connection's actual role to reason with.
+    #[test]
+    fn excluding_a_type_does_not_forbid_decoding_a_small_instance_of_it() {
+        let mut bytes = BytesMut::new();
+        let mut encoder = MessageCodec::<CurrentNetwork>::default();
+        encoder.encode(small_block_response(), &mut bytes).unwrap();
+
+        let mut restricted = MessageCodec::<CurrentNetwork>::excluding(&[MessageId::BlockResponse]);
+        assert!(matches!(restricted.decode(&mut bytes), Ok(Some(Message::BlockResponse(_)))));
+    }
+
+    /// The property that actually matters: a connection that excludes `BlockResponse` cannot be
+    /// forced to buffer anywhere near the general 128 MiB ceiling by a peer merely claiming to
+    /// send one - the frame is rejected the moment its length prefix is visible, before the rest
+    /// of a peer-declared, possibly enormous, body has to arrive or be held.
+    #[test]
+    fn excluding_block_response_rejects_an_oversized_frame_far_below_the_general_ceiling() {
+        let declared_len = MessageId::Ping.max_size::<CurrentNetwork>() + 1;
+        let mut bytes = BytesMut::new();
+        bytes.extend_from_slice(&(declared_len as u32).to_le_bytes());
+        bytes.extend_from_slice(&MessageId::BlockResponse.as_u16().to_le_bytes());
+        // Deliberately no further bytes: a real peer sending this much data would need to
+        // actually transmit `declared_len` bytes, which we never provide here.
+
+        let mut restricted = MessageCodec::<CurrentNetwork>::excluding(&[MessageId::BlockResponse]);
+        assert!(matches!(restricted.decode(&mut bytes), Err(err) if err.kind() == std::io::ErrorKind::InvalidData));
     }
 }

--- a/node/router/messages/src/helpers/codec.rs
+++ b/node/router/messages/src/helpers/codec.rs
@@ -26,6 +26,10 @@ const MAXIMUM_HANDSHAKE_MESSAGE_SIZE: usize = 1024 * 1024; // 1 MiB
 /// The codec used to decode and encode network `Message`s.
 pub struct MessageCodec<N: Network> {
     codec: LengthDelimitedCodec,
+    /// Message IDs this codec refuses to decode, rejected the moment the ID is visible - before
+    /// deserializing the message, regardless of whether it is otherwise well-formed and within
+    /// its own size cap. Empty by default; see [`Self::excluding`].
+    excluded_ids: &'static [MessageId],
     _phantom: PhantomData<N>,
 }
 
@@ -37,19 +41,13 @@ impl<N: Network> MessageCodec<N> {
     }
 
     /// Builds a codec whose frame-length ceiling is the maximum over the sizes of the message
-    /// types in `allowed_ids` - not a per-message check at decode time, just the ceiling the
-    /// underlying length-delimited codec enforces before a frame is fully buffered.
-    ///
-    /// Restricting `allowed_ids` cannot hand an attacker any capability they don't already have:
-    /// whatever the resulting ceiling is, it is exactly the size of the largest type still
-    /// allowed on this connection, and an honest peer can already legitimately send that much of
-    /// that type. What it *does* buy is a smaller ceiling for a connection that structurally has
-    /// no legitimate reason to expect a large type at all - see [`Self::excluding`].
+    /// types in `allowed_ids`.
     fn for_allowed_ids(allowed_ids: impl IntoIterator<Item = MessageId>) -> Self {
         let max_frame_length =
             allowed_ids.into_iter().map(|id| id.max_size::<N>()).max().unwrap_or(MAX_SMALL_MESSAGE_SIZE);
         Self {
             codec: LengthDelimitedCodec::builder().max_frame_length(max_frame_length).little_endian().new_codec(),
+            excluded_ids: &[],
             _phantom: PhantomData,
         }
     }
@@ -57,10 +55,15 @@ impl<N: Network> MessageCodec<N> {
     /// Builds a codec for a connection that structurally has no legitimate reason to ever receive
     /// any of `excluded_ids` - for instance, a validator's router connections, which never expect
     /// a `BlockResponse` since validators sync blocks over the committee-gated BFT gateway
-    /// instead. See [`Self::for_allowed_ids`] for why this shrinks the connection's ceiling rather
-    /// than just relabeling it: the ceiling becomes the largest type *actually* expected here.
-    pub fn excluding(excluded_ids: &[MessageId]) -> Self {
-        Self::for_allowed_ids(MessageId::all().filter(|id| !excluded_ids.contains(id)))
+    /// instead.
+    ///
+    /// This does two things: it rejects any frame with an excluded ID outright (see `decode`
+    /// below), and it shrinks the connection's frame-length ceiling to the largest type that
+    /// remains allowed - so an excluded type can no longer be used to force as large an
+    /// allocation as its own (possibly much bigger) cap would have permitted.
+    pub fn excluding(excluded_ids: &'static [MessageId]) -> Self {
+        let allowed_ids = MessageId::all().filter(|id| !excluded_ids.contains(id));
+        Self { excluded_ids, ..Self::for_allowed_ids(allowed_ids) }
     }
 }
 
@@ -97,6 +100,15 @@ impl<N: Network> Decoder for MessageCodec<N> {
             None => return Ok(None),
         };
 
+        // Reject a message type this connection has no legitimate reason to ever receive - before
+        // checking its size or deserializing it. An ID this node doesn't recognize at all isn't
+        // rejected here; `Message::read_le` below rejects it instead, and reports it as unknown.
+        if let Some(id) = MessageId::peek(&bytes)
+            && self.excluded_ids.contains(&id)
+        {
+            return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "message type is not permitted"));
+        }
+
         Self::Item::check_size(&bytes)?;
 
         // Convert the bytes to a message, or fail if it is not valid.
@@ -120,9 +132,9 @@ mod tests {
         BlockResponse,
         DataBlocks,
         MAX_SMALL_MESSAGE_SIZE,
-        MESSAGE_ID_SIZE,
         MessageId,
         PeerResponse,
+        Pong,
         PuzzleResponse,
         Transaction,
         UnconfirmedSolution,
@@ -272,14 +284,14 @@ mod tests {
             let max_size = id.max_size::<CurrentNetwork>();
 
             let mut bytes = vec![0u8; max_size];
-            bytes[..MESSAGE_ID_SIZE].copy_from_slice(&id.as_u16().to_le_bytes());
+            bytes[..MessageId::SIZE].copy_from_slice(&id.as_u16().to_le_bytes());
             assert!(
                 Message::<CurrentNetwork>::check_size(&bytes).is_ok(),
                 "{id:?} rejected a frame of exactly its maximum size ({max_size})"
             );
 
             let mut bytes = vec![0u8; max_size + 1];
-            bytes[..MESSAGE_ID_SIZE].copy_from_slice(&id.as_u16().to_le_bytes());
+            bytes[..MessageId::SIZE].copy_from_slice(&id.as_u16().to_le_bytes());
             assert!(
                 Message::<CurrentNetwork>::check_size(&bytes).is_err(),
                 "{id:?} admitted a frame one byte over its cap"
@@ -293,7 +305,7 @@ mod tests {
     fn unrecognized_message_id_is_not_size_capped() {
         let unrecognized_id: u16 = MessageId::all().count() as u16;
         let mut bytes = vec![0u8; MAX_SMALL_MESSAGE_SIZE + 1];
-        bytes[..MESSAGE_ID_SIZE].copy_from_slice(&unrecognized_id.to_le_bytes());
+        bytes[..MessageId::SIZE].copy_from_slice(&unrecognized_id.to_le_bytes());
         assert!(Message::<CurrentNetwork>::check_size(&bytes).is_ok());
     }
 
@@ -326,18 +338,31 @@ mod tests {
         assert_eq!(codec.codec.max_frame_length(), MessageId::Ping.max_size::<CurrentNetwork>());
     }
 
-    /// Excluding a type from a codec's allowed IDs only shrinks the frame-length ceiling - it does
-    /// not add a decode-time rejection for that type's ID. A small, legitimately-shaped
-    /// `BlockResponse` still decodes: rejecting an unexpected one is `Validator::block_response`'s
-    /// job, a layer up, which has the connection's actual role to reason with.
+    /// Excluding a type rejects it outright, even a small, well-formed, correctly-sized instance -
+    /// not just an oversized one. A connection that structurally never expects a type has no
+    /// legitimate reason to accept any instance of it, and rejecting it here, by ID, gives a
+    /// clearer signal for debugging than silently decoding it and relying on a much later,
+    /// semantic-level handler (e.g. `Validator::block_response`) to reject it instead.
     #[test]
-    fn excluding_a_type_does_not_forbid_decoding_a_small_instance_of_it() {
+    fn excluding_a_type_rejects_even_a_small_well_formed_instance_of_it() {
         let mut bytes = BytesMut::new();
         let mut encoder = MessageCodec::<CurrentNetwork>::default();
         encoder.encode(small_block_response(), &mut bytes).unwrap();
 
         let mut restricted = MessageCodec::<CurrentNetwork>::excluding(&[MessageId::BlockResponse]);
-        assert!(matches!(restricted.decode(&mut bytes), Ok(Some(Message::BlockResponse(_)))));
+        assert!(matches!(restricted.decode(&mut bytes), Err(err) if err.kind() == std::io::ErrorKind::InvalidData));
+    }
+
+    /// An exclusion is specific to the excluded ID - an unrelated, permitted message still decodes
+    /// normally on the same codec.
+    #[test]
+    fn excluding_a_type_still_allows_a_permitted_message() {
+        let mut bytes = BytesMut::new();
+        let mut encoder = MessageCodec::<CurrentNetwork>::default();
+        encoder.encode(Message::Pong(Pong { is_fork: Some(false) }), &mut bytes).unwrap();
+
+        let mut restricted = MessageCodec::<CurrentNetwork>::excluding(&[MessageId::BlockResponse]);
+        assert!(matches!(restricted.decode(&mut bytes), Ok(Some(Message::Pong(_)))));
     }
 
     /// The property that actually matters: a connection that excludes `BlockResponse` cannot be

--- a/node/router/messages/src/lib.rs
+++ b/node/router/messages/src/lib.rs
@@ -197,22 +197,27 @@ impl<N: Network> Message<N> {
     }
 
     /// Returns the message ID.
+    ///
+    /// This match is exhaustive over `Message`'s variants with no fallback arm, so a new variant
+    /// forces an ID here - and, since [`MessageId::max_size`] has no fallback arm either, a cap -
+    /// before the crate compiles. See the type-level docs on [`MessageId`] for the one part of
+    /// the ID mapping this still can't enforce.
     #[inline]
-    pub fn id(&self) -> u16 {
+    pub fn id(&self) -> MessageId {
         match self {
-            Self::BlockRequest(..) => 0,
-            Self::BlockResponse(..) => 1,
-            Self::ChallengeRequest(..) => 2,
-            Self::ChallengeResponse(..) => 3,
-            Self::Disconnect(..) => 4,
-            Self::PeerRequest(..) => 5,
-            Self::PeerResponse(..) => 6,
-            Self::Ping(..) => 7,
-            Self::Pong(..) => 8,
-            Self::PuzzleRequest(..) => 9,
-            Self::PuzzleResponse(..) => 10,
-            Self::UnconfirmedSolution(..) => 11,
-            Self::UnconfirmedTransaction(..) => 12,
+            Self::BlockRequest(..) => MessageId::BlockRequest,
+            Self::BlockResponse(..) => MessageId::BlockResponse,
+            Self::ChallengeRequest(..) => MessageId::ChallengeRequest,
+            Self::ChallengeResponse(..) => MessageId::ChallengeResponse,
+            Self::Disconnect(..) => MessageId::Disconnect,
+            Self::PeerRequest(..) => MessageId::PeerRequest,
+            Self::PeerResponse(..) => MessageId::PeerResponse,
+            Self::Ping(..) => MessageId::Ping,
+            Self::Pong(..) => MessageId::Pong,
+            Self::PuzzleRequest(..) => MessageId::PuzzleRequest,
+            Self::PuzzleResponse(..) => MessageId::PuzzleResponse,
+            Self::UnconfirmedSolution(..) => MessageId::UnconfirmedSolution,
+            Self::UnconfirmedTransaction(..) => MessageId::UnconfirmedTransaction,
         }
     }
 
@@ -222,18 +227,12 @@ impl<N: Network> Message<N> {
     /// An ID this node doesn't recognize at all is not rejected here - `Message::read_le` already
     /// rejects it, and reports it as an unknown message rather than a size violation.
     pub fn check_size(bytes: &[u8]) -> io::Result<()> {
-        let len = bytes.len();
-        if len < MessageId::SIZE {
+        if bytes.len() < MessageId::SIZE {
             return Err(io::Error::new(io::ErrorKind::InvalidData, "invalid message"));
         }
 
-        let id_bytes: [u8; MessageId::SIZE] = (&bytes[..MessageId::SIZE])
-            .try_into()
-            .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "id couldn't be deserialized"))?;
-        let id = u16::from_le_bytes(id_bytes);
-
-        if let Some(id) = MessageId::from_u16(id) {
-            if len > id.max_size::<N>() {
+        if let Some(id) = MessageId::peek(bytes) {
+            if bytes.len() > id.max_size::<N>() {
                 return Err(io::Error::new(io::ErrorKind::InvalidData, "message is too large for its type"));
             }
         }
@@ -244,7 +243,7 @@ impl<N: Network> Message<N> {
 
 impl<N: Network> ToBytes for Message<N> {
     fn write_le<W: io::Write>(&self, mut writer: W) -> io::Result<()> {
-        self.id().write_le(&mut writer)?;
+        self.id().as_u16().write_le(&mut writer)?;
 
         match self {
             Self::BlockRequest(message) => message.write_le(writer),
@@ -266,27 +265,31 @@ impl<N: Network> ToBytes for Message<N> {
 
 impl<N: Network> FromBytes for Message<N> {
     fn read_le<R: io::Read>(mut reader: R) -> io::Result<Self> {
-        // Read the event ID.
-        let mut id_bytes = [0u8; 2];
+        // Read the message ID.
+        let mut id_bytes = [0u8; MessageId::SIZE];
         reader.read_exact(&mut id_bytes)?;
         let id = u16::from_le_bytes(id_bytes);
+        let Some(id) = MessageId::from_u16(id) else {
+            return Err(error(format!("Unknown message ID {id}")));
+        };
 
         // Deserialize the data field.
         let message = match id {
-            0 => Self::BlockRequest(BlockRequest::read_le(&mut reader)?),
-            1 => Self::BlockResponse(BlockResponse::read_le(&mut reader)?),
-            2 => Self::ChallengeRequest(ChallengeRequest::read_le(&mut reader)?),
-            3 => Self::ChallengeResponse(ChallengeResponse::read_le(&mut reader)?),
-            4 => Self::Disconnect(Disconnect::read_le(&mut reader)?),
-            5 => Self::PeerRequest(PeerRequest::read_le(&mut reader)?),
-            6 => Self::PeerResponse(PeerResponse::read_le(&mut reader)?),
-            7 => Self::Ping(Ping::read_le(&mut reader)?),
-            8 => Self::Pong(Pong::read_le(&mut reader)?),
-            9 => Self::PuzzleRequest(PuzzleRequest::read_le(&mut reader)?),
-            10 => Self::PuzzleResponse(PuzzleResponse::read_le(&mut reader)?),
-            11 => Self::UnconfirmedSolution(UnconfirmedSolution::read_le(&mut reader)?),
-            12 => Self::UnconfirmedTransaction(UnconfirmedTransaction::read_le(&mut reader)?),
-            13.. => return Err(error("Unknown message ID {id}")),
+            MessageId::BlockRequest => Self::BlockRequest(BlockRequest::read_le(&mut reader)?),
+            MessageId::BlockResponse => Self::BlockResponse(BlockResponse::read_le(&mut reader)?),
+            MessageId::ChallengeRequest => Self::ChallengeRequest(ChallengeRequest::read_le(&mut reader)?),
+            MessageId::ChallengeResponse => Self::ChallengeResponse(ChallengeResponse::read_le(&mut reader)?),
+            MessageId::Disconnect => Self::Disconnect(Disconnect::read_le(&mut reader)?),
+            MessageId::PeerRequest => Self::PeerRequest(PeerRequest::read_le(&mut reader)?),
+            MessageId::PeerResponse => Self::PeerResponse(PeerResponse::read_le(&mut reader)?),
+            MessageId::Ping => Self::Ping(Ping::read_le(&mut reader)?),
+            MessageId::Pong => Self::Pong(Pong::read_le(&mut reader)?),
+            MessageId::PuzzleRequest => Self::PuzzleRequest(PuzzleRequest::read_le(&mut reader)?),
+            MessageId::PuzzleResponse => Self::PuzzleResponse(PuzzleResponse::read_le(&mut reader)?),
+            MessageId::UnconfirmedSolution => Self::UnconfirmedSolution(UnconfirmedSolution::read_le(&mut reader)?),
+            MessageId::UnconfirmedTransaction => {
+                Self::UnconfirmedTransaction(UnconfirmedTransaction::read_le(&mut reader)?)
+            }
         };
 
         // Ensure that there are no "dangling" bytes.

--- a/node/router/messages/src/lib.rs
+++ b/node/router/messages/src/lib.rs
@@ -81,9 +81,6 @@ use snarkvm::prelude::{
 
 use std::{borrow::Cow, io, net::SocketAddr};
 
-/// The width, in bytes, of the message ID that leads every message payload.
-pub const MESSAGE_ID_SIZE: usize = size_of::<u16>();
-
 // A compile-time compatibility check for the Message.
 const _: () = {
     let msg_versions = Message::<MainnetV0>::VERSIONS;
@@ -226,11 +223,11 @@ impl<N: Network> Message<N> {
     /// rejects it, and reports it as an unknown message rather than a size violation.
     pub fn check_size(bytes: &[u8]) -> io::Result<()> {
         let len = bytes.len();
-        if len < MESSAGE_ID_SIZE {
+        if len < MessageId::SIZE {
             return Err(io::Error::new(io::ErrorKind::InvalidData, "invalid message"));
         }
 
-        let id_bytes: [u8; MESSAGE_ID_SIZE] = (&bytes[..MESSAGE_ID_SIZE])
+        let id_bytes: [u8; MessageId::SIZE] = (&bytes[..MessageId::SIZE])
             .try_into()
             .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "id couldn't be deserialized"))?;
         let id = u16::from_le_bytes(id_bytes);

--- a/node/router/messages/src/lib.rs
+++ b/node/router/messages/src/lib.rs
@@ -36,6 +36,9 @@ pub use challenge_response::ChallengeResponse;
 mod disconnect;
 pub use disconnect::Disconnect;
 
+mod message_id;
+pub use message_id::{MAX_SMALL_MESSAGE_SIZE, MessageId};
+
 mod peer_request;
 pub use peer_request::PeerRequest;
 
@@ -77,6 +80,9 @@ use snarkvm::prelude::{
 };
 
 use std::{borrow::Cow, io, net::SocketAddr};
+
+/// The width, in bytes, of the message ID that leads every message payload.
+pub const MESSAGE_ID_SIZE: usize = size_of::<u16>();
 
 // A compile-time compatibility check for the Message.
 const _: () = {
@@ -213,36 +219,26 @@ impl<N: Network> Message<N> {
         }
     }
 
-    /// Checks the message byte length. To be used before deserialization.
+    /// Checks the message byte length against the cap for its type. To be used before
+    /// deserialization.
+    ///
+    /// An ID this node doesn't recognize at all is not rejected here - `Message::read_le` already
+    /// rejects it, and reports it as an unknown message rather than a size violation.
     pub fn check_size(bytes: &[u8]) -> io::Result<()> {
-        // Store the length to be checked against the max message size for each variant.
         let len = bytes.len();
-        if len < 2 {
+        if len < MESSAGE_ID_SIZE {
             return Err(io::Error::new(io::ErrorKind::InvalidData, "invalid message"));
         }
 
-        // Check the first two bytes for the message ID.
-        let id_bytes: [u8; 2] = (&bytes[..2])
+        let id_bytes: [u8; MESSAGE_ID_SIZE] = (&bytes[..MESSAGE_ID_SIZE])
             .try_into()
             .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "id couldn't be deserialized"))?;
         let id = u16::from_le_bytes(id_bytes);
 
-        // SPECIAL CASE: check the transaction message isn't too large.
-        //
-        // `len` is the whole frame, which is `UnconfirmedTransaction::OVERHEAD` bytes larger than
-        // the transaction it carries - so it has to be checked against the transaction cap plus
-        // that envelope, not the cap alone. A transaction of exactly `LATEST_MAX_TRANSACTION_SIZE`
-        // is valid (the ledger service and the REST endpoint both accept one), and the frame
-        // carrying it is necessarily larger than the transaction is.
-        if id == 12 && len > N::LATEST_MAX_TRANSACTION_SIZE().saturating_add(UnconfirmedTransaction::<N>::OVERHEAD) {
-            return Err(io::Error::new(io::ErrorKind::InvalidData, "transaction is too large"))?;
-        }
-
-        // SPECIAL CASE: check the ping message isn't too large. Unlike every other message type,
-        // Ping has no fixed shape - its block locators grow with chain height - so its cap is not
-        // a small constant; see MAX_PING_MESSAGE_SIZE for the derivation.
-        if id == 7 && len > MAX_PING_MESSAGE_SIZE {
-            return Err(io::Error::new(io::ErrorKind::InvalidData, "ping is too large"))?;
+        if let Some(id) = MessageId::from_u16(id) {
+            if len > id.max_size::<N>() {
+                return Err(io::Error::new(io::ErrorKind::InvalidData, "message is too large for its type"));
+            }
         }
 
         Ok(())

--- a/node/router/messages/src/message_id.rs
+++ b/node/router/messages/src/message_id.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{MAX_PING_MESSAGE_SIZE, MESSAGE_ID_SIZE, UnconfirmedTransaction};
+use crate::{MAX_PING_MESSAGE_SIZE, UnconfirmedTransaction};
 use snarkvm::prelude::Network;
 
 /// The wire ID of a [`crate::Message`] variant: the `u16` that leads every message payload.
@@ -70,7 +70,7 @@ pub(crate) const MAXIMUM_MESSAGE_SIZE: usize = 128 * 1024 * 1024; // 128 MiB
 // `largest_honest_peer_response_is_accepted` (in the codec's tests) checks this same bound
 // against what `PeerResponse::write_le` really produces.
 const _: () = {
-    let peer_response = MESSAGE_ID_SIZE
+    let peer_response = MessageId::SIZE
         + 1 // the version indicator
         + 1 // the peer count
         + (u8::MAX as usize)
@@ -86,6 +86,9 @@ const _: () = {
 };
 
 impl MessageId {
+    /// The width, in bytes, of the message ID that leads every message payload.
+    pub const SIZE: usize = size_of::<u16>();
+
     /// Every message ID, in wire order.
     ///
     /// Derived from `from_u16` rather than restated, so there is one hand-maintained list here
@@ -97,6 +100,13 @@ impl MessageId {
     /// Returns the ID as it appears on the wire.
     pub const fn as_u16(self) -> u16 {
         self as u16
+    }
+
+    /// Reads the ID leading `bytes` - the first two bytes of a message frame - or `None` if
+    /// `bytes` is too short to hold one, or the ID isn't one this node recognizes.
+    pub fn peek(bytes: &[u8]) -> Option<Self> {
+        let id_bytes: [u8; Self::SIZE] = bytes.get(..Self::SIZE)?.try_into().ok()?;
+        Self::from_u16(u16::from_le_bytes(id_bytes))
     }
 
     /// Returns the ID for the given wire value, or `None` if no message this node understands
@@ -194,7 +204,7 @@ mod tests {
 
         for id in MessageId::all() {
             let max_size = id.max_size::<CurrentNetwork>();
-            assert!(max_size >= MESSAGE_ID_SIZE, "{id:?} cannot hold its own message ID");
+            assert!(max_size >= MessageId::SIZE, "{id:?} cannot hold its own message ID");
             assert!(max_size <= MAXIMUM_MESSAGE_SIZE, "{id:?} is allowed to exceed the general frame ceiling");
         }
     }

--- a/node/router/messages/src/message_id.rs
+++ b/node/router/messages/src/message_id.rs
@@ -19,22 +19,20 @@ use snarkvm::prelude::Network;
 /// The wire ID of a [`crate::Message`] variant: the `u16` that leads every message payload.
 ///
 /// This exists to let a size cap be looked up for a message from its ID alone - before, or
-/// instead of, deserializing the message itself. It is deliberately independent of
-/// [`crate::Message::id`] (which keeps returning a plain `u16`, as every other part of the crate
-/// already expects): this type only needs to agree with that one at the numeric level, which
-/// `from_u16_agrees_with_discriminants` below checks.
+/// instead of, deserializing the message itself.
 ///
 /// # Adding a message
 ///
-/// This is intentionally not the type [`crate::Message::id`] returns (that stays a plain `u16`,
-/// as every existing caller expects) - it exists purely so a size cap can be looked up from an
-/// ID. That means adding a `Message` variant does not force a matching `MessageId` variant the
-/// way an exhaustive match would: a new message type that is never added here just never gets
-/// capped by `check_size`, which treats any ID `from_u16` doesn't recognize as "not this crate's
-/// business to cap" and leaves rejecting it to `Message::read_le`. So: **a new message needs a
-/// variant here, by hand, given the next ID in sequence** - `from_u16` and [`Self::max_size`] then
-/// enforce themselves (the latter has no fallback arm, so the crate does not compile until the new
-/// variant has a cap).
+/// [`crate::Message::id`] and [`Self::max_size`] are both exhaustive matches with no fallback arm,
+/// so a new `Message` variant forces a `MessageId` variant, which in turn forces a cap, before the
+/// crate compiles.
+///
+/// [`Self::from_u16`] is the one part of this **not** checked by the compiler, and cannot be on
+/// stable Rust - enumerating an enum's variants needs a macro, a derive, or the unstable
+/// `variant_count`. A variant missing there still compiles and every existing test still passes,
+/// but the node will happily *encode* the new message while every decoder - its own included -
+/// rejects the frame as an unrecognized ID and drops the connection. So: **a variant added to this
+/// enum must also be added to `from_u16` by hand.**
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[repr(u16)]
 pub enum MessageId {

--- a/node/router/messages/src/message_id.rs
+++ b/node/router/messages/src/message_id.rs
@@ -1,0 +1,201 @@
+// Copyright (c) 2019-2026 Provable Inc.
+// This file is part of the snarkOS library.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{MAX_PING_MESSAGE_SIZE, MESSAGE_ID_SIZE, UnconfirmedTransaction};
+use snarkvm::prelude::Network;
+
+/// The wire ID of a [`crate::Message`] variant: the `u16` that leads every message payload.
+///
+/// This exists to let a size cap be looked up for a message from its ID alone - before, or
+/// instead of, deserializing the message itself. It is deliberately independent of
+/// [`crate::Message::id`] (which keeps returning a plain `u16`, as every other part of the crate
+/// already expects): this type only needs to agree with that one at the numeric level, which
+/// `from_u16_agrees_with_discriminants` below checks.
+///
+/// # Adding a message
+///
+/// This is intentionally not the type [`crate::Message::id`] returns (that stays a plain `u16`,
+/// as every existing caller expects) - it exists purely so a size cap can be looked up from an
+/// ID. That means adding a `Message` variant does not force a matching `MessageId` variant the
+/// way an exhaustive match would: a new message type that is never added here just never gets
+/// capped by `check_size`, which treats any ID `from_u16` doesn't recognize as "not this crate's
+/// business to cap" and leaves rejecting it to `Message::read_le`. So: **a new message needs a
+/// variant here, by hand, given the next ID in sequence** - `from_u16` and [`Self::max_size`] then
+/// enforce themselves (the latter has no fallback arm, so the crate does not compile until the new
+/// variant has a cap).
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[repr(u16)]
+pub enum MessageId {
+    BlockRequest = 0,
+    BlockResponse = 1,
+    ChallengeRequest = 2,
+    ChallengeResponse = 3,
+    Disconnect = 4,
+    PeerRequest = 5,
+    PeerResponse = 6,
+    Ping = 7,
+    Pong = 8,
+    PuzzleRequest = 9,
+    PuzzleResponse = 10,
+    UnconfirmedSolution = 11,
+    UnconfirmedTransaction = 12,
+}
+
+/// The maximum size of the small, fixed-shape messages - everything except `Ping`,
+/// `BlockResponse`, and `UnconfirmedTransaction`. None of these carry more than a handful of
+/// fixed-size fields, or (for `PeerResponse`) a peer list bounded by the `u8` count that
+/// `PeerResponse::write_le` enforces - the compile-time assertion below pins the largest of them
+/// against this value, rather than trusting the "handful of fields" claim alone.
+pub const MAX_SMALL_MESSAGE_SIZE: usize = 8 * 1024; // 8 KiB
+
+/// The general frame ceiling: the maximum size of a message that can be transmitted in the
+/// network. Only `BlockResponse` is left at this ceiling - see [`MessageId::max_size`].
+pub(crate) const MAXIMUM_MESSAGE_SIZE: usize = 128 * 1024 * 1024; // 128 MiB
+
+// `MAX_SMALL_MESSAGE_SIZE` is only useful if it is actually above what an honest node sends.
+// `PeerResponse` is the one "small" message whose worst case isn't obviously tiny: a full peer
+// list of `u8::MAX` entries, every one an IPv6 address carrying a height.
+// `largest_honest_peer_response_is_accepted` (in the codec's tests) checks this same bound
+// against what `PeerResponse::write_le` really produces.
+const _: () = {
+    let peer_response = MESSAGE_ID_SIZE
+        + 1 // the version indicator
+        + 1 // the peer count
+        + (u8::MAX as usize)
+            * (1     // the IPv6 tag
+                + 16 // the address
+                + 2  // the port
+                + 1  // the `Some` tag on the height
+                + 4); // the height
+    assert!(
+        peer_response <= MAX_SMALL_MESSAGE_SIZE,
+        "MAX_SMALL_MESSAGE_SIZE is below the largest PeerResponse an honest node will send"
+    );
+};
+
+impl MessageId {
+    /// Every message ID, in wire order.
+    ///
+    /// Derived from `from_u16` rather than restated, so there is one hand-maintained list here
+    /// instead of two.
+    pub fn all() -> impl Iterator<Item = Self> {
+        (0..).map_while(Self::from_u16)
+    }
+
+    /// Returns the ID as it appears on the wire.
+    pub const fn as_u16(self) -> u16 {
+        self as u16
+    }
+
+    /// Returns the ID for the given wire value, or `None` if no message this node understands
+    /// uses it.
+    ///
+    /// Must be kept in step with the enum by hand - see the type-level docs.
+    pub const fn from_u16(id: u16) -> Option<Self> {
+        Some(match id {
+            0 => Self::BlockRequest,
+            1 => Self::BlockResponse,
+            2 => Self::ChallengeRequest,
+            3 => Self::ChallengeResponse,
+            4 => Self::Disconnect,
+            5 => Self::PeerRequest,
+            6 => Self::PeerResponse,
+            7 => Self::Ping,
+            8 => Self::Pong,
+            9 => Self::PuzzleRequest,
+            10 => Self::PuzzleResponse,
+            11 => Self::UnconfirmedSolution,
+            12 => Self::UnconfirmedTransaction,
+            _ => return None,
+        })
+    }
+
+    /// Returns the largest frame, in bytes, that a message with this ID may legitimately be. The
+    /// size is of the whole frame - the message ID included - because that is what the length
+    /// prefix on the wire counts.
+    ///
+    /// A connection's frame-length ceiling is the maximum of this over whatever subset of IDs
+    /// that connection actually expects to receive - see `MessageCodec::for_allowed_ids`. Letting
+    /// a smaller-capped type ride along under a bigger type's ceiling cannot hand an attacker any
+    /// capability they don't already have: they could send the bigger type instead, and this
+    /// check still rejects a smaller type's frame once it is over its own cap.
+    pub fn max_size<N: Network>(self) -> usize {
+        match self {
+            // The one message that is legitimately large - up to a handful of full blocks,
+            // bounded by block count rather than by byte size - so it is left at the general
+            // frame ceiling rather than a type-specific one.
+            Self::BlockResponse => MAXIMUM_MESSAGE_SIZE,
+            Self::Ping => MAX_PING_MESSAGE_SIZE,
+            // The one message with a network-defined, consensus-version-dependent cap. The
+            // envelope has to be added to it: a transaction of exactly `LATEST_MAX_TRANSACTION_SIZE`
+            // is valid (both the ledger service and the REST endpoint accept one), and the message
+            // carrying it is necessarily larger than the transaction itself.
+            Self::UnconfirmedTransaction => {
+                N::LATEST_MAX_TRANSACTION_SIZE().saturating_add(UnconfirmedTransaction::<N>::OVERHEAD)
+            }
+            Self::BlockRequest
+            | Self::ChallengeRequest
+            | Self::ChallengeResponse
+            | Self::Disconnect
+            | Self::PeerRequest
+            | Self::PeerResponse
+            | Self::Pong
+            | Self::PuzzleRequest
+            | Self::PuzzleResponse
+            | Self::UnconfirmedSolution => MAX_SMALL_MESSAGE_SIZE,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `from_u16` is hand-maintained, so check that each arm maps an ID to the variant whose
+    /// discriminant actually is that ID - a transposed or copy-pasted arm would otherwise treat
+    /// one message type's frames as if they were another's.
+    #[test]
+    fn from_u16_agrees_with_discriminants() {
+        for (index, id) in MessageId::all().enumerate() {
+            assert_eq!(
+                id.as_u16() as usize,
+                index,
+                "from_u16({index}) returned {id:?}, whose wire value is not {index}"
+            );
+        }
+    }
+
+    /// The IDs `from_u16` accepts have to be a contiguous run from zero, which is what `all()`
+    /// assumes when it stops at the first gap.
+    #[test]
+    fn message_ids_are_contiguous() {
+        let count = MessageId::all().count();
+        assert!(count > 0, "no message IDs are reachable from the wire");
+        assert_eq!(MessageId::from_u16(count as u16), None, "an ID past the end of the run was accepted");
+    }
+
+    /// Every ID has a size that is at least large enough to hold the ID itself, and no capped
+    /// message may exceed the general frame ceiling.
+    #[test]
+    fn max_sizes_are_sane() {
+        type CurrentNetwork = snarkvm::prelude::MainnetV0;
+
+        for id in MessageId::all() {
+            let max_size = id.max_size::<CurrentNetwork>();
+            assert!(max_size >= MESSAGE_ID_SIZE, "{id:?} cannot hold its own message ID");
+            assert!(max_size <= MAXIMUM_MESSAGE_SIZE, "{id:?} is allowed to exceed the general frame ceiling");
+        }
+    }
+}

--- a/node/router/messages/src/puzzle_response.rs
+++ b/node/router/messages/src/puzzle_response.rs
@@ -51,14 +51,14 @@ impl<N: Network> FromBytes for PuzzleResponse<N> {
 
 #[cfg(test)]
 pub mod prop_tests {
-    use crate::{PuzzleResponse, challenge_response::prop_tests::any_genesis_header};
+    use crate::{MAX_SMALL_MESSAGE_SIZE, PuzzleResponse, challenge_response::prop_tests::any_genesis_header};
     use snarkvm::{
         console::prelude::{FromBytes, ToBytes},
         ledger::narwhal::Data,
         prelude::{Network, Rng, TestRng},
     };
 
-    use bytes::{Buf, BufMut, BytesMut};
+    use bytes::{Buf, BufMut, Bytes, BytesMut};
     use proptest::prelude::{BoxedStrategy, Strategy, any};
     use test_strategy::proptest;
 
@@ -76,6 +76,20 @@ pub mod prop_tests {
     pub fn any_puzzle_response() -> BoxedStrategy<PuzzleResponse<CurrentNetwork>> {
         (any_epoch_hash(), any_genesis_header())
             .prop_map(|(epoch_hash, bh)| PuzzleResponse { epoch_hash, block_header: Data::Object(bh) })
+            .boxed()
+    }
+
+    /// A `PuzzleResponse` whose `block_header` is a raw, undeserializable buffer of junk bytes
+    /// exactly `MAX_SMALL_MESSAGE_SIZE` long - already over the cap once the surrounding envelope
+    /// (message ID, `epoch_hash`, `Data`'s own tag and length prefix) is added. `Data::Buffer`
+    /// means this never has to construct a real, absurdly large `Header`.
+    pub fn any_large_puzzle_response() -> BoxedStrategy<PuzzleResponse<CurrentNetwork>> {
+        (any_epoch_hash(), any::<u64>())
+            .prop_map(|(epoch_hash, seed)| {
+                let mut rng = TestRng::fixed(seed);
+                let junk: Vec<u8> = (0..MAX_SMALL_MESSAGE_SIZE).map(|_| rng.random()).collect();
+                PuzzleResponse { epoch_hash, block_header: Data::Buffer(Bytes::from(junk)) }
+            })
             .boxed()
     }
 

--- a/node/router/messages/src/unconfirmed_solution.rs
+++ b/node/router/messages/src/unconfirmed_solution.rs
@@ -51,13 +51,13 @@ impl<N: Network> FromBytes for UnconfirmedSolution<N> {
 
 #[cfg(test)]
 pub mod prop_tests {
-    use crate::{Solution, SolutionID, UnconfirmedSolution};
+    use crate::{MAX_SMALL_MESSAGE_SIZE, Solution, SolutionID, UnconfirmedSolution};
     use snarkvm::{
         ledger::{narwhal::Data, puzzle::PartialSolution},
         prelude::{Address, FromBytes, PrivateKey, Rng, TestRng, ToBytes},
     };
 
-    use bytes::{Buf, BufMut, BytesMut};
+    use bytes::{Buf, BufMut, Bytes, BytesMut};
     use proptest::prelude::{BoxedStrategy, Strategy, any};
     use test_strategy::proptest;
 
@@ -82,6 +82,20 @@ pub mod prop_tests {
     pub fn any_unconfirmed_solution() -> BoxedStrategy<UnconfirmedSolution<CurrentNetwork>> {
         (any_solution_id(), any_solution())
             .prop_map(|(solution_id, ps)| UnconfirmedSolution { solution_id, solution: Data::Object(ps) })
+            .boxed()
+    }
+
+    /// An `UnconfirmedSolution` whose `solution` is a raw, undeserializable buffer of junk bytes
+    /// exactly `MAX_SMALL_MESSAGE_SIZE` long - already over the cap once the surrounding envelope
+    /// (message ID, `solution_id`, `Data`'s own tag and length prefix) is added. `Data::Buffer`
+    /// means this never has to construct a real, absurdly large `Solution`.
+    pub fn any_large_unconfirmed_solution() -> BoxedStrategy<UnconfirmedSolution<CurrentNetwork>> {
+        (any_solution_id(), any::<u64>())
+            .prop_map(|(solution_id, seed)| {
+                let mut rng = TestRng::fixed(seed);
+                let junk: Vec<u8> = (0..MAX_SMALL_MESSAGE_SIZE).map(|_| rng.random()).collect();
+                UnconfirmedSolution { solution_id, solution: Data::Buffer(Bytes::from(junk)) }
+            })
             .boxed()
     }
 

--- a/node/src/validator/router.rs
+++ b/node/src/validator/router.rs
@@ -110,13 +110,12 @@ impl<N: Network, C: ConsensusStorage<N>> Reading for Validator<N, C> {
     fn codec(&self, _peer_addr: SocketAddr, _side: ConnectionSide) -> Self::Codec {
         // A validator syncs blocks exclusively over the committee-gated BFT gateway
         // (`ConnectionMode::Gateway`); it never issues a `BlockRequest` over the router, so it
-        // never has a legitimate reason to expect a `BlockResponse` there either. Excluding it
-        // from this connection's ceiling means an untrusted router peer cannot use a claimed
-        // `BlockResponse` to force as large an allocation as the general 128 MiB frame ceiling -
-        // the ceiling shrinks to `Ping`'s, the largest type actually expected here. This changes
-        // nothing about which messages decode successfully: a `BlockResponse` that fits under the
-        // new, smaller ceiling still decodes, and is rejected below, in `block_response`, exactly
-        // as before.
+        // never has a legitimate reason to accept a `BlockResponse` there either. Excluding it
+        // rejects one outright the moment its ID is visible, and shrinks this connection's frame
+        // ceiling from the general 128 MiB down to `Ping`'s (the largest type still allowed) - so
+        // an untrusted router peer can no longer use a claimed `BlockResponse` to force either a
+        // 128 MiB allocation or a successful decode that `block_response` below only rejects
+        // afterward.
         MessageCodec::excluding(&[MessageId::BlockResponse])
     }
 

--- a/node/src/validator/router.rs
+++ b/node/src/validator/router.rs
@@ -22,6 +22,7 @@ use snarkos_node_router::messages::{
     DisconnectReason,
     Message,
     MessageCodec,
+    MessageId,
     Ping,
     Pong,
     UnconfirmedTransaction,
@@ -107,7 +108,16 @@ impl<N: Network, C: ConsensusStorage<N>> Reading for Validator<N, C> {
     /// Creates a [`Decoder`] used to interpret messages from the network.
     /// The `side` param indicates the connection side **from the node's perspective**.
     fn codec(&self, _peer_addr: SocketAddr, _side: ConnectionSide) -> Self::Codec {
-        Default::default()
+        // A validator syncs blocks exclusively over the committee-gated BFT gateway
+        // (`ConnectionMode::Gateway`); it never issues a `BlockRequest` over the router, so it
+        // never has a legitimate reason to expect a `BlockResponse` there either. Excluding it
+        // from this connection's ceiling means an untrusted router peer cannot use a claimed
+        // `BlockResponse` to force as large an allocation as the general 128 MiB frame ceiling -
+        // the ceiling shrinks to `Ping`'s, the largest type actually expected here. This changes
+        // nothing about which messages decode successfully: a `BlockResponse` that fits under the
+        // new, smaller ceiling still decodes, and is rejected below, in `block_response`, exactly
+        // as before.
+        MessageCodec::excluding(&[MessageId::BlockResponse])
     }
 
     /// Processes a message received from the network.


### PR DESCRIPTION
## Summary

Redevelops #4414 around a simpler idea after review:

1. A codec may permit only a subset of the possible message IDs to be decoded - the router codec knows it's only supposed to get certain messages, the gateway codec a different set, and so on.
2. The codec's maximum supported length is computed from that set of allowed messages, so excluding the largest messages reduces the memory the codec needs when handling untrusted input.
3. The codec itself also rejects message types that aren't allowed, rather than only bounding their size.

With this redevelop, we continue using `LengthDelimitedCodec` as requested - so it should stay compatible with either of the two PRs Lukasz pointed to in review (#4055, #4232).

For a validator's router connections specifically:

```
┌────────────────────┬─────────┬─────────────────┐
│                    │  limit  │ who can trigger │
├────────────────────┼─────────┼─────────────────┤
│ before this stack  │ 128 MiB │ any P2P peer    │
├────────────────────┼─────────┼─────────────────┤
│ after this PR      │  16 MiB │ any P2P peer    │
└────────────────────┴─────────┴─────────────────┘
```

`Client` and `Prover` router connections are unchanged (they legitimately expect `BlockResponse`, so they keep the general 128 MiB ceiling); `node/bft/events` and `node/src/bootstrap_client` are separate codecs, also unchanged - out of scope here.

The 16 MiB here is `Ping`'s own cap (the largest of what remains once `BlockResponse` is excluded) - if that can be tightened without breaking compatibility, this ceiling would shrink further, to roughly 1 MiB (max size of unconfirmed transaction). That's follow-up work, not part of this PR.

## What changed

- **`MessageId`**: a new enum mirroring `Message`'s wire IDs, with `max_size::<N>()` giving each type's worst-case frame size. `BlockResponse` stays at the general 128 MiB ceiling (legitimately large, bounded by block count rather than byte size); `Ping` and `UnconfirmedTransaction` keep their existing dedicated caps from the earlier PRs in this stack; everything else gets a new `MAX_SMALL_MESSAGE_SIZE` (8 KiB) cap.
- **`Message::check_size`** now looks up `MessageId::max_size` instead of special-casing two IDs by hand - so `PuzzleResponse` and `UnconfirmedSolution` are finally capped too (previously unbounded up to the general 128 MiB ceiling - this was one of the independently-reported findings this whole stack traces back to).
- **`MessageCodec::for_allowed_ids` / `excluding`**: build a codec whose `max_frame_length` is the max over a given set of allowed IDs, rather than always the general ceiling. `excluding` also rejects any frame whose ID is excluded outright, the moment the ID is visible - not just an oversized one. A validator's router connections now use `excluding(&[MessageId::BlockResponse])` (validators sync blocks exclusively over the committee-gated BFT gateway, never issuing a `BlockRequest` over the router, so a `BlockResponse` there is never legitimate). This closes the 128 MiB allocation an unsolicited `BlockResponse` could previously force, and gives a clearer rejection than relying on the later, semantic-level `Validator::block_response` handler alone.
- **`Message::id()`** now returns `MessageId` instead of a raw `u16`. Combined with `MessageId::max_size`, both matches are now exhaustive with no fallback arm, so a new `Message` variant forces a `MessageId` variant - and, in turn, a cap - before the crate compiles.

## Test plan
- [x] `cargo test -p snarkos-node-router-messages --all-targets` - 33 tests, including a full sweep of `MessageId::all()` pinning every type's size-gate boundary exactly, and dedicated tests for `excluding` (ceiling shrinks; an excluded type is rejected even when small and well-formed; an unrelated type still decodes normally).
- [x] `cargo +nightly-2026-04-02 fmt --check` on the touched crates.
- [x] Full workspace build (`cargo build -p snarkos`) and `cargo clippy -p snarkos-node-router-messages -p snarkos --all-targets -- -D warnings`.

Based on #4417 (Ping cap), which is based on #4416 (transaction frame overhead) and #4418 (an unrelated clippy hotfix it needed to build on).

## Backwards compatibility

Excluding `BlockResponse` from a validator's router codec is not a behavior change for any honest peer: [`Validator::block_response`](https://github.com/ProvableHQ/snarkOS/blob/126536511b390eb48d11dfe8041552fe09bbff60/node/src/validator/router.rs#L222-L230) already unconditionally rejects a `BlockResponse` received over the router today, regardless of this PR:

```rust
fn block_response(
    &self,
    peer_ip: SocketAddr,
    _blocks: Vec<Block<N>>,
    _latest_consensus_version: Option<ConsensusVersion>,
) -> bool {
    warn!("Received a block response through P2P, not BFT, from {peer_ip}");
    false
}
```

No honest peer sends a validator a `BlockResponse` over the router in the first place - a validator never issues a `BlockRequest` there (it syncs blocks exclusively over the committee-gated BFT gateway), so nothing it receives is ever a solicited response. This PR just moves the rejection earlier - by ID, before the frame is even sized or deserialized - rather than changing what ultimately gets accepted.