### PR TITLE
chore(deps): use snarkVM's DATA_ENCODING_OVERHEAD, closing the TODO

### DIFF
--- a/node/router/messages/src/lib.rs
+++ b/node/router/messages/src/lib.rs
@@ -61,7 +61,7 @@ mod unconfirmed_solution;
 pub use unconfirmed_solution::UnconfirmedSolution;
 
 mod unconfirmed_transaction;
-pub use unconfirmed_transaction::{DATA_ENCODING_OVERHEAD, UnconfirmedTransaction};
+pub use unconfirmed_transaction::UnconfirmedTransaction;
 
 pub use snarkos_node_bft_events::DataBlocks;
 

--- a/node/router/messages/src/unconfirmed_transaction.rs
+++ b/node/router/messages/src/unconfirmed_transaction.rs
@@ -16,7 +16,7 @@
 use super::*;
 
 use snarkvm::{
-    ledger::narwhal::Data,
+    ledger::narwhal::{DATA_ENCODING_OVERHEAD, Data},
     prelude::{Field, FromBytes, ToBytes},
 };
 
@@ -27,15 +27,6 @@ pub struct UnconfirmedTransaction<N: Network> {
     pub transaction_id: N::TransactionID,
     pub transaction: Data<Transaction<N>>,
 }
-
-/// The bytes `Data`'s own encoding wraps around the object it carries: a version byte and a `u32`
-/// length prefix, both emitted by `Data::write_le` and expected back by `Data::read_le`.
-///
-/// TODO: this belongs in snarkVM, beside the encoding it describes (`ledger/narwhal/data/src`),
-/// so that changing `Data::write_le` forces this to be changed with it. Restating it here is a
-/// stopgap - replace it with the snarkVM constant once one is exported.
-pub const DATA_ENCODING_OVERHEAD: usize = size_of::<u8>() // the version byte
-    + size_of::<u32>(); // the length prefix
 
 impl<N: Network> UnconfirmedTransaction<N> {
     /// The bytes an `UnconfirmedTransaction` frame carries in addition to the transaction itself:


### PR DESCRIPTION
WIP this needs to wait for snarkVM bump in this repo

---

#4416 introduced `UnconfirmedTransaction::OVERHEAD` (formerly `UNCONFIRMED_TRANSACTION_OVERHEAD`), which needed the byte overhead `Data`'s encoding adds (a version byte + a `u32` length prefix).

Reviewer feedback there (@ljedrz) asked for that number to come from the code that actually defines it, but it wasn't exported from snarkVM at the time, so a local stopgap constant of the same name and value was declared instead, with a TODO to replace it once snarkVM exported one:

```rust
/// TODO: this belongs in snarkVM, beside the encoding it describes (`ledger/narwhal/data/src`),
/// so that changing `Data::write_le` forces this to be changed with it. Restating it here is a
/// stopgap - replace it with the snarkVM constant once one is exported.
pub const DATA_ENCODING_OVERHEAD: usize = size_of::<u8>() // the version byte
    + size_of::<u32>(); // the length prefix
```

ProvableHQ/snarkVM#3396 has since merged, exporting `DATA_ENCODING_OVERHEAD` next to `Data`'s own `ToBytes`/`FromBytes` impls (`ledger/narwhal/data/src/lib.rs`), pinned there against what `write_le` actually emits.