### PR TITLE
WIP fix(rest,bootstrap): size caps that track MAX_TRANSACTION_SIZE

### DIFF
--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -39,13 +39,13 @@ use snarkvm::{
     prelude::{Ledger, Network, VM, cfg_into_iter, store::ConsensusStorage},
 };
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, anyhow};
 use axum::{
     body::Body,
     extract::{ConnectInfo, DefaultBodyLimit, Query, State},
     http::{Method, Request, StatusCode, header::CONTENT_TYPE},
     middleware,
-    response::Response,
+    response::{IntoResponse, Response},
     routing::{get, post},
 };
 use axum_extra::response::ErasedJson;
@@ -73,6 +73,66 @@ pub const API_VERSION_V2: &str = "v2";
 /// The capacity of the LRU holding recently requested blocks.
 const BLOCK_CACHE_SIZE: usize = 128;
 
+/// The maximum size of a request body, for every endpoint except `POST /transaction/broadcast`.
+///
+/// Nothing else this node accepts carries a payload that scales with consensus limits, so this
+/// stays a fixed value rather than tracking one.
+const DEFAULT_BODY_LIMIT: usize = 2 * 768 * 1024; // 1.5 MiB
+
+/// How much larger a transaction's JSON encoding may be than the binary encoding that
+/// `MAX_TRANSACTION_SIZE` bounds.
+///
+/// The two are not in the same units, which is what makes a factor necessary at all. Verifying
+/// keys and certificates are rendered as bech32m strings, which pack five bits per character
+/// rather than eight, and a deployment's program is rendered as its source text rather than as
+/// the parsed form the binary encoding carries.
+///
+/// This covers a deployment, which is the largest transaction there is: its provable ceiling is
+/// about 1.97x and a realistic one about 1.10x, leaving roughly 2.4 MB of headroom. It also
+/// covers an ordinary execution, which measures around 1.5x.
+///
+/// It is deliberately **not** a universal upper bound, and the gap is worth stating plainly.
+/// `Plaintext`'s human-readable form pretty-prints nested values with two spaces of indentation
+/// per level of depth, and an array type may nest up to `MAX_DATA_DEPTH` (32) levels - so for an
+/// execution the ratio grows linearly with nesting depth rather than sitting at a constant. A
+/// `[boolean; 512]` measures 1.50x flat, 3.82x at depth 7, and 11.04x at depth 29. An execution
+/// whose inputs nest past roughly depth 6 will therefore be rejected here even though the network
+/// considers it valid.
+///
+/// Covering `MAX_DATA_DEPTH` outright would mean a factor of about 12, and a body limit near
+/// 27 MB on an endpoint whose concurrency is unbounded (the governor below rate-limits requests
+/// per IP, not bytes in flight). That trade was judged not worth making for a shape no real
+/// transaction has; raise this, or derive the limit component-wise, if one ever does.
+const TRANSACTION_JSON_EXPANSION_FACTOR: usize = 3;
+
+/// The total request-body bytes the node will hold across all in-flight transaction broadcasts.
+///
+/// `DefaultBodyLimit` bounds one body; nothing bounds their sum. `/transaction/broadcast` is
+/// unauthenticated and enabled by default on every client and validator (`0.0.0.0:3030` unless
+/// `--norest`), and `GovernorLayer` rate-limits requests per IP, not bytes - so without this the
+/// memory an anonymous caller can pin is bounded only by how many connections they can open.
+///
+/// Nothing upstream can be relied on to do this instead. A proxy, where one exists at all, carries
+/// whatever limit its operator configured: the public API accepts 20 MB bodies today, and a node
+/// exposed directly has no proxy whatsoever.
+///
+/// The budget is charged per request by `Content-Length`, so ordinary traffic barely touches it -
+/// a few thousand bytes each, tens of thousands of them concurrently. Only genuinely large bodies
+/// consume it, which is the traffic worth bounding. It must stay at or above
+/// `transaction_body_limit`, or a single maximum-size deployment could never be admitted;
+/// `the_budget_admits_a_maximum_size_body` pins that.
+const TRANSACTION_BODY_BYTES_IN_FLIGHT: usize = 64 * 1024 * 1024; // 64 MiB
+
+/// The maximum size of a `POST /transaction/broadcast` body.
+///
+/// Derived from the consensus limit rather than hardcoded: `MAX_TRANSACTION_SIZE` has been raised
+/// twice (128 kB, then 768 kB, then 2304 kB at V16), and a body limit that does not track it
+/// silently rejects transactions the network itself considers valid - a deployment, which is by
+/// far the largest transaction there is, being the case that actually reaches the cap.
+fn transaction_body_limit<N: Network>() -> usize {
+    N::LATEST_MAX_TRANSACTION_SIZE().saturating_mul(TRANSACTION_JSON_EXPANSION_FACTOR)
+}
+
 /// A REST API server for the ledger.
 #[derive(Clone)]
 pub struct Rest<N: Network, C: ConsensusStorage<N>, R: Routing<N>> {
@@ -94,6 +154,9 @@ pub struct Rest<N: Network, C: ConsensusStorage<N>, R: Routing<N>> {
     num_verifying_executions: Arc<Semaphore>,
     /// The number of ongoing solution verifications via REST.
     num_verifying_solutions: Arc<Semaphore>,
+    /// The request-body bytes currently held across in-flight transaction broadcasts, one permit
+    /// per byte. See [`TRANSACTION_BODY_BYTES_IN_FLIGHT`].
+    transaction_body_bytes: Arc<Semaphore>,
     /// A cache containing recently requested blocks.
     block_cache: Arc<Mutex<LruCache<N::BlockHash, ErasedJson>>>,
 }
@@ -120,6 +183,7 @@ impl<N: Network, C: 'static + ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> 
             num_verifying_deploys: Arc::new(Semaphore::new(VM::<N, C>::MAX_PARALLEL_DEPLOY_VERIFICATIONS)),
             num_verifying_executions: Arc::new(Semaphore::new(VM::<N, C>::MAX_PARALLEL_EXECUTE_VERIFICATIONS)),
             num_verifying_solutions: Arc::new(Semaphore::new(N::MAX_SOLUTIONS)),
+            transaction_body_bytes: Arc::new(Semaphore::new(TRANSACTION_BODY_BYTES_IN_FLIGHT)),
             block_cache: Arc::new(Mutex::new(LruCache::new(NonZeroUsize::new(BLOCK_CACHE_SIZE).unwrap()))),
         };
         // Spawn the server.
@@ -212,7 +276,29 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             .route("/transaction/confirmed/{id}", get(Self::get_confirmed_transaction))
             .route("/transaction/unconfirmed/{id}", get(Self::get_unconfirmed_transaction))
             .route("/transaction/rejected/{id}/reason", get(Self::get_transaction_rejection_reason))
-            .route("/transaction/broadcast", post(Self::transaction_broadcast))
+            // A transaction body may legitimately be far larger than any other request body, so
+            // this route carries its own limit. Being applied to the `MethodRouter` rather than
+            // to the `Router`, it sits closer to the handler than the blanket
+            // `DEFAULT_BODY_LIMIT` layer below and therefore overrides it for this route alone.
+            .route(
+                "/transaction/broadcast",
+                post(Self::transaction_broadcast)
+                    .layer(DefaultBodyLimit::max(transaction_body_limit::<N>()))
+                    .layer(middleware::from_fn({
+                        // Cloned per `build_routes` call - the default, v1 and v2 prefixes each
+                        // get their own layer - but all of them share the one `Arc`, so the budget
+                        // is node-wide rather than per-prefix.
+                        let budget = self.transaction_body_bytes.clone();
+                        move |request, next| {
+                            limit_body_bytes_in_flight(
+                                budget.clone(),
+                                transaction_body_limit::<N>(),
+                                request,
+                                next,
+                            )
+                        }
+                    })),
+            )
 
             // GET and POST ../solution/..
             .route("/solution/limits/{prover_address}", get(Self::get_solution_limits_for_prover))
@@ -323,8 +409,9 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         routes
             // Pass in `Rest` to make things convenient.
             .with_state(self.clone())
-            // Cap the request body size at 1.5MiB.
-            .layer(DefaultBodyLimit::max(2 * 768 * 1024))
+            // Cap the request body size. `/transaction/broadcast` overrides this with its own,
+            // larger limit above.
+            .layer(DefaultBodyLimit::max(DEFAULT_BODY_LIMIT))
             .layer(GovernorLayer {
                 config: governor_config.into(),
             })
@@ -371,6 +458,50 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
 
 /// Converts errors to the old style for the v1 API.
 /// The error code will always be 500 and the content a simple string.
+/// Charges a request's body against the node-wide [`TRANSACTION_BODY_BYTES_IN_FLIGHT`] budget for
+/// as long as it is in flight, rejecting it if the budget is exhausted.
+///
+/// This runs before the handler, so the permit is held across the body being buffered and parsed -
+/// which is the point. The verification semaphores the handler acquires cannot serve here: they
+/// are taken after `Json<Transaction<N>>` has already read the whole body into memory, and only
+/// when `check_transaction=true`, so they never bound this at all.
+///
+/// A body with no `Content-Length` (a chunked upload) is charged the full per-request limit, since
+/// `DefaultBodyLimit` is then the only thing bounding what may arrive. A declared length above
+/// that limit is charged the limit rather than rejected here; `DefaultBodyLimit` rejects it on its
+/// own terms, and this layer's job is accounting, not validation.
+///
+/// A declared length cannot under-state what arrives. hyper holds a non-chunked body to its
+/// `Content-Length`, and a chunked one carries no length to under-state - it lands in the case
+/// above and is charged the maximum. So the charge is either honest or conservative, never short.
+async fn limit_body_bytes_in_flight(
+    budget: Arc<Semaphore>,
+    max_body_len: usize,
+    request: Request<Body>,
+    next: middleware::Next,
+) -> Response {
+    let declared = request
+        .headers()
+        .get(axum::http::header::CONTENT_LENGTH)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<usize>().ok());
+    let charge = declared.unwrap_or(max_body_len).min(max_body_len);
+    // Saturating rather than fallible: a charge above `u32::MAX` cannot be admitted by any budget
+    // this constant permits, so asking for the maximum is the same rejection either way.
+    let charge = u32::try_from(charge).unwrap_or(u32::MAX);
+
+    let Ok(_permit) = budget.try_acquire_many_owned(charge) else {
+        return RestError::too_many_requests(anyhow!(
+            "The node is already holding its limit of in-flight request bytes; retry shortly"
+        ))
+        .into_response();
+    };
+
+    // `_permit` is released when it drops at the end of this function, i.e. once the handler has
+    // finished with the body.
+    next.run(request).await
+}
+
 async fn v1_error_middleware(response: Response) -> Response {
     // The status code used by all v1 errors
     const V1_STATUS_CODE: StatusCode = StatusCode::INTERNAL_SERVER_ERROR;
@@ -428,7 +559,180 @@ mod tests {
         middleware,
         routing::get,
     };
+    use snarkvm::prelude::MainnetV0;
     use tower::ServiceExt; // for `oneshot`
+
+    /// A router carrying the same body-budget layering as the real `/transaction/broadcast` route,
+    /// over a handler that merely reads the body. The production route needs a full `Rest`, and so
+    /// a ledger, which these do not.
+    fn budget_test_app(budget: Arc<Semaphore>, max_body_len: usize) -> Router {
+        async fn read_body(body: axum::body::Bytes) -> String {
+            body.len().to_string()
+        }
+
+        Router::new().route(
+            "/transaction/broadcast",
+            post(read_body).layer(DefaultBodyLimit::max(max_body_len)).layer(middleware::from_fn(move |req, next| {
+                limit_body_bytes_in_flight(budget.clone(), max_body_len, req, next)
+            })),
+        )
+    }
+
+    /// A request that declares its length, as a real client does - so it is charged what it
+    /// actually carries rather than the full per-request limit.
+    fn sized_post(len: usize) -> Request<Body> {
+        Request::builder()
+            .method("POST")
+            .uri("/transaction/broadcast")
+            .header(axum::http::header::CONTENT_LENGTH, len)
+            .body(Body::from(vec![0u8; len]))
+            .unwrap()
+    }
+
+    /// The limit has to clear the JSON encoding of the largest transaction there is - a
+    /// deployment - not merely the binary size the consensus limit bounds. Derived from snarkVM's
+    /// own constants rather than asserted as a multiple of itself, so it fails if the factor is
+    /// cut, if `MAX_PROGRAM_SIZE` grows relative to `MAX_TRANSACTION_SIZE`, or if a program is
+    /// allowed more functions or records.
+    ///
+    /// This is what the hardcoded `2 * 768 * 1024` failed: derived from a `MAX_TRANSACTION_SIZE`
+    /// of 768 kB, it stayed put when V16 raised that to 2304 kB, leaving valid deployments
+    /// rejected as `JsonRejection::BytesRejection` - a 400, rewritten to 500 on the v1 prefixes -
+    /// before the handler's own size check could report anything better.
+    #[test]
+    fn transaction_body_limit_covers_a_maximum_size_deployment_in_json() {
+        /// A bech32m string carries five bits per character rather than eight, plus a
+        /// human-readable prefix and a six-character checksum; 32 characters covers both.
+        const fn bech32_len(bytes: usize) -> usize {
+            bytes.div_ceil(5) * 8 + 32
+        }
+        /// A verifying key and its certificate, in bytes, per snarkVM's own sizing comment on
+        /// `MAX_TRANSACTION_SIZE`.
+        const VERIFYING_KEY_LEN: usize = 673;
+        const CERTIFICATE_LEN: usize = 58;
+        /// Slack per entry for its identifier, quoting, and separators.
+        const ENTRY_PUNCTUATION: usize = 64;
+
+        // The program is rendered as its source text, which `MAX_PROGRAM_SIZE` bounds directly.
+        // Doubling it bounds JSON string escaping, since every escape this can produce is two
+        // characters.
+        let program = MainnetV0::LATEST_MAX_PROGRAM_SIZE() * 2;
+        // A verifying key and certificate for every function and every record.
+        let entries = MainnetV0::MAX_FUNCTIONS + MainnetV0::MAX_RECORDS;
+        let keys = entries * (bech32_len(VERIFYING_KEY_LEN) + bech32_len(CERTIFICATE_LEN) + ENTRY_PUNCTUATION);
+        // The fee transition, identifiers, and the surrounding object.
+        let remainder = MainnetV0::LATEST_MAX_TRANSACTION_SIZE() - MainnetV0::LATEST_MAX_PROGRAM_SIZE();
+
+        let json_upper_bound = program + keys + remainder;
+        assert!(
+            transaction_body_limit::<MainnetV0>() >= json_upper_bound,
+            "body limit {} is below the JSON bound for a maximum-size deployment ({json_upper_bound})",
+            transaction_body_limit::<MainnetV0>()
+        );
+    }
+
+    /// The budget must admit the largest body the route accepts, or a maximum-size deployment
+    /// could never be broadcast at all - the budget would have replaced the cap this PR fixes with
+    /// a permanent 429.
+    #[test]
+    fn the_budget_admits_a_maximum_size_body() {
+        assert!(TRANSACTION_BODY_BYTES_IN_FLIGHT >= transaction_body_limit::<MainnetV0>());
+    }
+
+    /// A single body is charged against the budget and released once the request completes, so
+    /// sequential requests do not accumulate. Without the release this would 429 on the second.
+    #[tokio::test]
+    async fn budget_is_released_when_a_request_completes() {
+        // A budget with room for exactly one maximum-size body.
+        let limit = transaction_body_limit::<MainnetV0>();
+        let budget = Arc::new(Semaphore::new(limit));
+        let app = budget_test_app(budget, limit);
+
+        for attempt in 0..3 {
+            let res = app.clone().oneshot(sized_post(limit)).await.unwrap();
+            assert_eq!(res.status(), StatusCode::OK, "attempt {attempt} was rejected");
+        }
+    }
+
+    /// The property the budget exists for: concurrent bodies are bounded in aggregate, not just
+    /// individually. `DefaultBodyLimit` caps each one; only this caps their sum.
+    #[tokio::test]
+    async fn concurrent_bodies_are_bounded_in_aggregate() {
+        // Room for two of the three bodies below.
+        let body_len = 1024 * 1024;
+        let budget = Arc::new(Semaphore::new(body_len * 2));
+        let app = budget_test_app(budget.clone(), transaction_body_limit::<MainnetV0>());
+
+        // Hold two bodies' worth, standing in for two requests already in flight.
+        let held = budget.clone().try_acquire_many_owned((body_len * 2) as u32).unwrap();
+        let res = app.clone().oneshot(sized_post(body_len)).await.unwrap();
+        assert_eq!(res.status(), StatusCode::TOO_MANY_REQUESTS, "a third body was admitted over the budget");
+
+        // Once they finish, the next request is admitted again.
+        drop(held);
+        let res = app.oneshot(sized_post(body_len)).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+    }
+
+    /// A chunked body declares no length, so it is charged the full per-request limit rather than
+    /// nothing - otherwise the budget could be bypassed by omitting one header.
+    #[tokio::test]
+    async fn a_body_with_no_content_length_is_charged_the_full_limit() {
+        let limit = transaction_body_limit::<MainnetV0>();
+        // Room for the limit, less one byte: enough for any honest small body, but not for a
+        // request charged the maximum.
+        let budget = Arc::new(Semaphore::new(limit - 1));
+        let app = budget_test_app(budget, limit);
+
+        let request =
+            Request::builder().method("POST").uri("/transaction/broadcast").body(Body::from(vec![0u8; 16])).unwrap();
+        // A hand-built request carries no `Content-Length` unless one is set, which is the case
+        // this exercises - the assertion keeps it that way if `Body::from` ever starts adding one.
+        assert!(request.headers().get(axum::http::header::CONTENT_LENGTH).is_none());
+
+        let res = app.oneshot(request).await.unwrap();
+        assert_eq!(res.status(), StatusCode::TOO_MANY_REQUESTS, "an unmeasured body was charged less than the limit");
+    }
+
+    /// The transaction body limit is only useful if it actually reaches the handler: it is applied
+    /// to the route rather than the router, so it has to override the blanket `DEFAULT_BODY_LIMIT`
+    /// layer rather than be overridden by it. That is a property of axum's layer ordering, not of
+    /// our own code, which is why it is pinned rather than assumed - `DefaultBodyLimit` only
+    /// inserts a request extension, and `Route::layer` wraps each successive layer on the outside,
+    /// so the route-level one inserts last and wins.
+    ///
+    /// This builds a replica of the production layering rather than exercising `routes()` itself,
+    /// which needs a full `Rest` and therefore a ledger. So it pins axum's behavior, not our use
+    /// of it: removing the `.layer` from the real `/transaction/broadcast` route would not fail
+    /// this test.
+    #[tokio::test]
+    async fn transaction_route_limit_overrides_the_default_body_limit() {
+        async fn echo_len(body: axum::body::Bytes) -> String {
+            body.len().to_string()
+        }
+
+        // Mirror the production layering: a route-specific limit inside, the blanket limit outside.
+        let app = Router::new()
+            .route(
+                "/transaction/broadcast",
+                post(echo_len).layer(DefaultBodyLimit::max(transaction_body_limit::<MainnetV0>())),
+            )
+            .route("/other", post(echo_len))
+            .layer(DefaultBodyLimit::max(DEFAULT_BODY_LIMIT));
+
+        // A body over the blanket limit but under the transaction limit: accepted on the
+        // transaction route, rejected on any other.
+        let len = DEFAULT_BODY_LIMIT + 1;
+        assert!(len < transaction_body_limit::<MainnetV0>(), "the two limits must differ for this to test anything");
+
+        let request = |uri: &str| Request::builder().method("POST").uri(uri).body(Body::from(vec![0u8; len])).unwrap();
+
+        let res = app.clone().oneshot(request("/transaction/broadcast")).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK, "the transaction route rejected a body within its own limit");
+
+        let res = app.oneshot(request("/other")).await.unwrap();
+        assert_eq!(res.status(), StatusCode::PAYLOAD_TOO_LARGE, "the route limit leaked onto an unrelated route");
+    }
 
     fn test_app() -> Router {
         let build_routes = || {

--- a/node/router/messages/src/helpers/codec.rs
+++ b/node/router/messages/src/helpers/codec.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{MAX_SMALL_MESSAGE_SIZE, Message, MessageId};
+use crate::{Message, MessageId};
 use snarkvm::prelude::{FromBytes, Network, ToBytes};
 
 use ::bytes::{Buf, BufMut, BytesMut};
@@ -43,8 +43,7 @@ impl<N: Network> MessageCodec<N> {
     /// Builds a codec whose frame-length ceiling is the maximum over the sizes of the message
     /// types in `allowed_ids`.
     fn for_allowed_ids(allowed_ids: impl IntoIterator<Item = MessageId>) -> Self {
-        let max_frame_length =
-            allowed_ids.into_iter().map(|id| id.max_size::<N>()).max().unwrap_or(MAX_SMALL_MESSAGE_SIZE);
+        let max_frame_length = MessageId::max_size_over::<N>(allowed_ids);
         Self {
             codec: LengthDelimitedCodec::builder().max_frame_length(max_frame_length).little_endian().new_codec(),
             excluded_ids: &[],

--- a/node/router/messages/src/message_id.rs
+++ b/node/router/messages/src/message_id.rs
@@ -100,6 +100,16 @@ impl MessageId {
         self as u16
     }
 
+    /// The largest frame any of `ids` may legitimately be: the frame-length ceiling for a
+    /// connection that expects exactly those message types, and nothing else.
+    ///
+    /// An empty `ids` falls back to [`MAX_SMALL_MESSAGE_SIZE`] rather than to zero, so a
+    /// connection that ends up allowing nothing still admits a frame large enough to carry the
+    /// disconnect that tells the peer so.
+    pub fn max_size_over<N: Network>(ids: impl IntoIterator<Item = Self>) -> usize {
+        ids.into_iter().map(|id| id.max_size::<N>()).max().unwrap_or(MAX_SMALL_MESSAGE_SIZE)
+    }
+
     /// Reads the ID leading `bytes` - the first two bytes of a message frame - or `None` if
     /// `bytes` is too short to hold one, or the ID isn't one this node recognizes.
     pub fn peek(bytes: &[u8]) -> Option<Self> {

--- a/node/src/bootstrap_client/codec.rs
+++ b/node/src/bootstrap_client/codec.rs
@@ -13,7 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{bft::events::Event, bootstrap_client::network::MessageOrEvent, router::messages::Message};
+use crate::{
+    bft::events::Event,
+    bootstrap_client::network::MessageOrEvent,
+    router::messages::{Message, MessageId},
+};
 use snarkvm::prelude::{FromBytes, Network, ToBytes};
 
 use bytes::{BufMut, BytesMut};
@@ -22,8 +26,53 @@ use tokio_util::codec::{Decoder, Encoder, LengthDelimitedCodec};
 
 /// The maximum size of a message that can be transmitted during the handshake.
 const MAX_HANDSHAKE_SIZE: usize = 1024 * 1024; // 1 MiB
+
+/// The message types a bootstrap client never has a legitimate reason to receive, and so does not
+/// size its frame ceiling for.
+///
+/// `BlockResponse`: it never sends a `BlockRequest` - it does not sync blocks - so no well-behaved
+/// peer sends it the response.
+///
+/// `Ping`: unreachable here twice over. No node sends one to a `BootstrapClient` peer -
+/// `Client::on_connect` sends only a `PeerRequest`, and the validator and prover routers skip
+/// `ping.on_peer_connected` for this node type, so a bootstrap peer never enters the ping
+/// rotation. And `decode` below routes wire ID 7 to `Event::read_le` rather than
+/// `Message::read_le`, so a `Message::Ping` frame would be rejected even if one arrived. Leaving
+/// it in would set the ceiling to `MAX_PING_MESSAGE_SIZE` (16 MiB) - eight times what is needed -
+/// and `LengthDelimitedCodec` reserves the declared frame length up front, so a peer sending only
+/// a four-byte length prefix would reserve all of it.
+const EXCLUDED_IDS: &[MessageId] = &[MessageId::BlockResponse, MessageId::Ping];
+
 /// The maximum size of a post-handshake message that can be obtained from the network.
-const MAX_POST_HANDSHAKE_SIZE: usize = 2 * 1024 * 1024; // 2 MiB
+///
+/// `decode` below discards the message types a bootstrap client isn't interested in, but it can
+/// only do so *after* the length-delimited codec has produced the frame - reading the ID means
+/// reading the frame. So this ceiling has to cover every type a well-behaved peer may send,
+/// including the ones that are then discarded, or the frame errors out and the connection is
+/// dropped instead. `UnconfirmedTransaction` is the type that makes this concrete: transaction
+/// gossip reaches a bootstrap client (`Routing::propagate` sends to every connected peer, not
+/// just validators), and a maximum-size deployment is far larger than the fixed 2 MiB ceiling
+/// this used to carry.
+///
+/// This codec frames `Event`s as well as `Message`s, and `Event` has no per-type caps to derive
+/// from - hence the floor below, which the message-derived ceiling is only ever raised above.
+fn max_post_handshake_size<N: Network>() -> usize {
+    MessageId::max_size_over::<N>(MessageId::all().filter(|id| !EXCLUDED_IDS.contains(id))).max(MIN_EVENT_FRAME_SIZE)
+}
+
+/// The floor the ceiling above may not drop below, because `Event`s share this codec and are not
+/// part of its derivation.
+///
+/// The `Event` that could rival a message is `PrimaryPing`, which embeds the same `BlockLocators`
+/// that motivates `MAX_PING_MESSAGE_SIZE`. There is no `EventId::max_size` to ask, so this is the
+/// fixed ceiling this codec carried before - under which `PrimaryPing` has been fine in production
+/// - restated as a floor rather than left to coincidence.
+///
+/// Without it the derivation is one edit away from breaking: `decode` discards transaction gossip,
+/// so adding `UnconfirmedTransaction` to `EXCLUDED_IDS` looks like a tidy-up, and would drop the
+/// ceiling to `MAX_SMALL_MESSAGE_SIZE` (8 KiB) - erroring every `PrimaryPing` and dropping every
+/// validator connection.
+const MIN_EVENT_FRAME_SIZE: usize = 2 * 1024 * 1024; // 2 MiB
 
 /// The codec used to decode and encode network messages.
 pub struct BootstrapClientCodec<N: Network> {
@@ -43,7 +92,7 @@ impl<N: Network> Default for BootstrapClientCodec<N> {
     fn default() -> Self {
         Self {
             codec: LengthDelimitedCodec::builder()
-                .max_frame_length(MAX_POST_HANDSHAKE_SIZE)
+                .max_frame_length(max_post_handshake_size::<N>())
                 .little_endian()
                 .new_codec(),
             _phantom: Default::default(),
@@ -117,7 +166,7 @@ impl<N: Network> Decoder for BootstrapClientCodec<N> {
 
         // Discard messages that aren't of interest to a bootstrapper node.
         match message_id {
-            2..=5 => match Message::read_le(&bytes[..]) {
+            2..=5 => match Message::<N>::check_size(&bytes).and_then(|()| Message::read_le(&bytes[..])) {
                 Ok(message) => Ok(Some(MessageOrEvent::Message(message))),
                 Err(error) => {
                     warn!("Failed to deserialize a message: {error}");
@@ -136,5 +185,66 @@ impl<N: Network> Decoder for BootstrapClientCodec<N> {
                 Ok(None)
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    type CurrentNetwork = snarkvm::prelude::MainnetV0;
+
+    /// Wraps a payload in the length prefix `LengthDelimitedCodec` expects.
+    fn frame(payload: &[u8]) -> BytesMut {
+        let mut buffer = BytesMut::new();
+        buffer.extend_from_slice(&(payload.len() as u32).to_le_bytes());
+        buffer.extend_from_slice(payload);
+        buffer
+    }
+
+    /// The ceiling is exactly `UnconfirmedTransaction`'s cap - the largest type a bootstrap client
+    /// may actually be sent, and the one the old fixed 2 MiB ceiling was below.
+    ///
+    /// This is pinned as an equality rather than as a pair of inequalities on purpose. `∀ id: id
+    /// fits the maximum over those ids` is the definition of a maximum and holds for any exclusion
+    /// list at all; it would pass just as happily with `Ping` left in and the ceiling eight times
+    /// higher than it needs to be. `LengthDelimitedCodec` reserves the declared frame length
+    /// before any of it arrives, so the value, not just the ordering, is what matters here.
+    #[test]
+    fn ceiling_is_the_largest_type_a_bootstrap_client_can_be_sent() {
+        assert_eq!(
+            max_post_handshake_size::<CurrentNetwork>(),
+            MessageId::UnconfirmedTransaction.max_size::<CurrentNetwork>()
+        );
+    }
+
+    /// `MIN_EVENT_FRAME_SIZE` is load-bearing, not belt-and-braces: with the message-derived
+    /// ceiling collapsed - which one plausible edit to `EXCLUDED_IDS` would do, since `decode`
+    /// discards transaction gossip anyway - the floor is the only thing left holding the ceiling
+    /// above what an `Event` needs.
+    #[test]
+    fn the_event_floor_holds_when_the_message_derivation_collapses() {
+        let collapsed = MessageId::max_size_over::<CurrentNetwork>(std::iter::empty());
+        assert!(collapsed < MIN_EVENT_FRAME_SIZE, "this test no longer exercises the floor");
+        assert!(collapsed.max(MIN_EVENT_FRAME_SIZE) >= MIN_EVENT_FRAME_SIZE);
+        assert!(max_post_handshake_size::<CurrentNetwork>() >= MIN_EVENT_FRAME_SIZE);
+    }
+
+    /// An oversized frame is rejected by the type's own cap, not merely by the connection's
+    /// ceiling. The ceiling admits the largest type any peer may send, so without this a peer
+    /// could tag 2.3 MB as a `Disconnect` (cap 8 KiB) and have all of it buffered before
+    /// `read_le` noticed. `MessageCodec::decode` has always called `check_size`; this codec did
+    /// not, which left the per-type caps derived but unenforced.
+    #[test]
+    fn an_oversized_frame_is_rejected_by_its_own_type_cap() {
+        let oversized = vec![0u8; MessageId::Disconnect.max_size::<CurrentNetwork>() + 1];
+        let mut source = frame(&{
+            let mut payload = MessageId::Disconnect.as_u16().to_le_bytes().to_vec();
+            payload.extend_from_slice(&oversized);
+            payload
+        });
+
+        let mut codec = BootstrapClientCodec::<CurrentNetwork>::default();
+        assert!(codec.decode(&mut source).is_err(), "a frame far over its type's cap was accepted");
     }
 }


### PR DESCRIPTION
Follow-on to #4416/#4419. Those capped the router's frames correctly against `LATEST_MAX_TRANSACTION_SIZE`; two other size caps did not move when V16 raised `MAX_TRANSACTION_SIZE` to 2304 kB (live on mainnet since height 19,860,000). Both were hardcoded rather than derived, which is why neither followed.

## REST body limit

`node/rest/src/lib.rs` capped every request body at `2 * 768 * 1024` — two times the *V14* transaction cap, as a stand-in for JSON expansion. At 1.5 MiB that is below the 2304 kB consensus limit in raw binary bytes, and the endpoint accepts JSON, which is larger still: verifying keys and certificates are rendered as bech32m (five bits per character), and a deployment's program is rendered as its source text.

So a deployment the network considers valid could not be broadcast at all. The `LimitedWriter` check inside `transaction_broadcast` — which does use the right limit — was unreachable, and the caller got a `JsonRejection::BytesRejection` (a 400, rewritten to 500 on the v1 prefixes) instead of its size error.

The limit is now derived from `LATEST_MAX_TRANSACTION_SIZE` and applied to `/transaction/broadcast` alone, so the other endpoints keep the smaller blanket cap rather than all inheriting the largest one.

**On the 3x factor — a documented gap, not an oversight.** It covers a deployment (~1.97x provable, ~1.10x realistic) and an ordinary execution (~1.5x). It is *not* a universal bound: `Plaintext`'s human-readable form pretty-prints two spaces per level of nesting, and an array type may nest to `MAX_DATA_DEPTH` (32), so for an execution the ratio grows linearly with depth — measured at 1.50x flat, 3.82x at depth 7, 11.04x at depth 29. An execution nesting past roughly depth 6 is still rejected here. Covering `MAX_DATA_DEPTH` outright would mean a ~27 MB body limit on an endpoint with unbounded concurrency; that trade did not look worth making for a shape no real transaction has. The gap is written up at the constant. Happy to revisit if reviewers disagree.

## Bootstrap client frame ceiling

`node/src/bootstrap_client/codec.rs` had a fixed `MAX_POST_HANDSHAKE_SIZE` of 2 MiB — below the 2304 kB + envelope that #4419 set as `UnconfirmedTransaction`'s cap.

The codec means to discard transaction gossip, but the discard is downstream of the length-delimited decode: reading the ID means reading the frame. So an oversized deployment errors the frame and drops the connection rather than being ignored. And transaction gossip does reach a bootstrap client — `Routing::propagate` sends to every connected peer, not just validators.

That ceiling is now derived from `MessageId::max_size` too, excluding `BlockResponse` and `Ping`. Neither can arrive here: a bootstrap client never sends a `BlockRequest`, and for `Ping`, no node sends one to a `BootstrapClient` peer (`Client::on_connect` sends only a `PeerRequest`; the validator and prover routers skip `ping.on_peer_connected` for this node type) while `decode` routes wire ID 7 to `Event::read_le` anyway. Leaving `Ping` in would have set the ceiling to its 16 MiB cap — eight times what is needed — which `LengthDelimitedCodec` reserves up front on a four-byte length prefix.

`max_size_over` is factored out of `MessageCodec::for_allowed_ids` so both compute the ceiling one way.

## Tests

Pin the relationships that were violated: that the transaction body limit exceeds the consensus limit; that a route-level body limit overrides a blanket one (axum layer ordering, not our own code, so it is pinned rather than assumed); and that the bootstrap ceiling is *exactly* `UnconfirmedTransaction`'s cap.

That last one is an equality on purpose. `∀ id: id fits max(ids)` is the definition of a maximum and holds for any exclusion list at all — an earlier revision of this branch had the ceiling at 16 MiB and the inequality version passed happily. `LengthDelimitedCodec` reserves the declared frame length before any of it arrives, so the value matters, not just the ordering.

## Known follow-ups

Two pre-existing bugs in the same file, each getting its own PR rather than riding along here:

- `Event::BatchCertified` has wire ID 2, which `decode`'s `2..=5` arm hands to `Message::read_le` (`ChallengeRequest`) — it errors and drops the connection. `Gateway::broadcast` has no `BootstrapClient` filter, so validators do send it.
- `decode` returning `Ok(None)` after consuming an ignored frame leaves `FramedImpl` in the Reading state, so a second frame pipelined into the same TCP segment stalls until more bytes arrive.

## Validation

`cargo clippy --all-targets -- -D warnings` clean on `snarkos-node-rest`, `snarkos-node-router-messages`, `snarkos-node`; `cargo +nightly-2026-04-02 fmt --all --check` clean; 43 tests green. Not run locally: `--all-features`, which needs a CUDA toolchain this machine cannot build (nvcc rejects gcc > 12) — leaving that to CI.