### PR TITLE
fix(router): make Ping block locators optional for clients and validators

### DIFF
--- a/node/router/src/inbound.rs
+++ b/node/router/src/inbound.rs
@@ -191,13 +191,8 @@ pub trait Inbound<N: Network>: Reading + Outbound<N> {
                     bail!("Dropping '{peer_ip}' on message version {} (outdated)", message.version);
                 }
 
-                // If the peer is a client or validator, ensure there are block locators.
-                let is_client_or_validator = message.node_type.is_client() || message.node_type.is_validator();
-                if is_client_or_validator && message.block_locators.is_none() {
-                    bail!("Peer '{peer_ip}' is a {}, but no block locators were provided", message.node_type);
-                }
                 // If the peer is a prover, ensure there are no block locators.
-                else if message.node_type.is_prover() && message.block_locators.is_some() {
+                if message.node_type.is_prover() && message.block_locators.is_some() {
                     bail!("Peer '{peer_ip}' is a prover, but block locators were provided");
                 }
 


### PR DESCRIPTION
## Motivation

The inbound `Ping` handler disconnected a peer whose claimed `node_type` was client or validator if it did not carry block locators, and disconnected a claimed prover if it did. Drop the first rule: block locators are now simply optional for clients and validators. The prover rule is left in place.

This is followup from the analysis in #4424 

Three reasons this rule bought us nothing:

1. It is not enforceable. `node_type` is carried in `ChallengeRequest` but the handshake signature covers only `[peer_nonce, response_nonce]` - nothing binds a peer to the type it claims:

   https://github.com/ProvableHQ/snarkOS/blob/2a3b2c24ce366698b0fc4c73cd544bb6bd6f223a/node/router/src/handshake.rs#L230-L236

   A receiver-side rule keyed on a self-declared identity is bypassable by declaring a different identity, so it cannot serve a security purpose. It only forces honest peers to send bytes that dishonest peers need not.

2. The locators a validator receives on the router are discarded. Validators learn peer locators from other validators over the gateway via `PrimaryPing`; `Validator::ping` ignores its message entirely:

   https://github.com/ProvableHQ/snarkOS/blob/2a3b2c24ce366698b0fc4c73cd544bb6bd6f223a/node/src/validator/router.rs#L233-L240

   So for that direction, whether locators are present makes no difference to anything the receiver computes - it is ~73 KiB of eager `BlockLocators::from_le` parse work per peer per ping interval, thrown away.

3. Every handler that does use locators already treats them as optional, so nothing downstream needs to change. Client:

   https://github.com/ProvableHQ/snarkOS/blob/2a3b2c24ce366698b0fc4c73cd544bb6bd6f223a/node/src/client/router.rs#L268-L285

   Prover:

   https://github.com/ProvableHQ/snarkOS/blob/2a3b2c24ce366698b0fc4c73cd544bb6bd6f223a/node/src/prover/router.rs#L198-L210

This is purely a relaxation of inbound validation: no node changes what it sends, so validator -> client `Ping`s still carry locators and client sync is unaffected. Making the field optional first is what lets a later release stop sending locators to peers that ignore them without a flag day, since nodes on this release will already accept a locator-free `Ping`.


## Test Plan

The main test plan is performing a deployment to a dev network and seeing if everything still works. But since this change is backwards compatible, it should.

## Backwards compatibility

This only relaxes existing rules, so it is backwards compatible.