### PR TITLE
fix(router): tighten MAX_PING_MESSAGE_SIZE from 16 MiB to 2 MiB

### DIFF
--- a/node/router/messages/src/helpers/codec.rs
+++ b/node/router/messages/src/helpers/codec.rs
@@ -139,7 +139,7 @@ mod tests {
         Transaction,
         UnconfirmedSolution,
         UnconfirmedTransaction,
-        ping::prop_tests::largest_possible_ping,
+        ping::prop_tests::largest_supported_ping,
         puzzle_response::prop_tests::{any_large_puzzle_response, any_puzzle_response},
         unconfirmed_solution::prop_tests::{any_large_unconfirmed_solution, any_unconfirmed_solution},
         unconfirmed_transaction::prop_tests::{
@@ -209,14 +209,14 @@ mod tests {
         assert!(matches!(codec.decode(&mut bytes), Ok(Some(Message::UnconfirmedTransaction(_)))));
     }
 
-    /// The largest `Ping` the wire format permits must still be accepted - the failure mode a too
+    /// The largest `Ping` the cap is sized for must still be accepted - the failure mode a too
     /// tight cap causes is disconnecting honest peers, which is worse than the DoS this exists to
     /// prevent.
     #[test]
-    fn largest_possible_ping_is_accepted() {
+    fn largest_supported_ping_is_accepted() {
         let mut bytes = BytesMut::new();
         let mut codec = MessageCodec::<CurrentNetwork>::default();
-        assert!(codec.encode(Message::Ping(largest_possible_ping()), &mut bytes).is_ok());
+        assert!(codec.encode(Message::Ping(largest_supported_ping()), &mut bytes).is_ok());
         assert!(matches!(codec.decode(&mut bytes), Ok(Some(Message::Ping(_)))));
     }
 
@@ -329,13 +329,14 @@ mod tests {
         assert_eq!(codec.codec.max_frame_length(), expected);
     }
 
-    /// Excluding `BlockResponse` shrinks the ceiling to `Ping`'s - the largest of what remains -
-    /// rather than to some hardcoded number, so tightening `Ping`'s own cap in the future
-    /// automatically tightens this ceiling too.
+    /// Excluding `BlockResponse` shrinks the ceiling to `UnconfirmedTransaction`'s - the largest
+    /// of what remains - rather than to some hardcoded number, so tightening any one type's cap in
+    /// the future automatically tightens this ceiling too. A validator must accept those, so this
+    /// is also the floor the router ceiling can reach by capping other message types alone.
     #[test]
     fn excluding_block_response_shrinks_the_ceiling_to_the_next_largest_type() {
         let codec = MessageCodec::<CurrentNetwork>::excluding(&[MessageId::BlockResponse]);
-        assert_eq!(codec.codec.max_frame_length(), MessageId::Ping.max_size::<CurrentNetwork>());
+        assert_eq!(codec.codec.max_frame_length(), MessageId::UnconfirmedTransaction.max_size::<CurrentNetwork>());
     }
 
     /// Excluding a type rejects it outright, even a small, well-formed, correctly-sized instance -
@@ -371,7 +372,7 @@ mod tests {
     /// of a peer-declared, possibly enormous, body has to arrive or be held.
     #[test]
     fn excluding_block_response_rejects_an_oversized_frame_far_below_the_general_ceiling() {
-        let declared_len = MessageId::Ping.max_size::<CurrentNetwork>() + 1;
+        let declared_len = MessageId::UnconfirmedTransaction.max_size::<CurrentNetwork>() + 1;
         let mut bytes = BytesMut::new();
         bytes.extend_from_slice(&(declared_len as u32).to_le_bytes());
         bytes.extend_from_slice(&MessageId::BlockResponse.as_u16().to_le_bytes());

--- a/node/router/messages/src/lib.rs
+++ b/node/router/messages/src/lib.rs
@@ -46,7 +46,7 @@ mod peer_response;
 pub use peer_response::PeerResponse;
 
 mod ping;
-pub use ping::{MAX_PING_MESSAGE_SIZE, Ping};
+pub use ping::{MAX_PING_LOCATOR_HEIGHT, MAX_PING_MESSAGE_SIZE, Ping};
 
 mod pong;
 pub use pong::Pong;

--- a/node/router/messages/src/ping.rs
+++ b/node/router/messages/src/ping.rs
@@ -16,7 +16,7 @@
 use super::*;
 
 use snarkos_node_network::NodeType;
-use snarkos_node_sync_locators::{MAX_CHECKPOINTS, NUM_RECENT_BLOCKS};
+use snarkos_node_sync_locators::{CHECKPOINT_INTERVAL, NUM_RECENT_BLOCKS};
 use snarkvm::prelude::{FromBytes, ToBytes};
 
 use std::borrow::Cow;
@@ -28,30 +28,41 @@ pub struct Ping<N: Network> {
     pub block_locators: Option<BlockLocators<N>>,
 }
 
+/// The chain height [`MAX_PING_MESSAGE_SIZE`] is sized for: mainnet is at ~19.9M blocks and grows
+/// ~10.4M a year, so 500M is 40+ years of headroom. Whoever gets near it raises the cap, or - the
+/// real fix - makes the locator scheme logarithmic in height rather than linear.
+pub const MAX_PING_LOCATOR_HEIGHT: u32 = 500_000_000;
+
 /// The maximum size of a `Ping` frame, kept next to `write_le` below since that is what actually
 /// defines the fixed part of this layout (4 + 1 + 1 bytes, plus the message ID that
 /// `Message::write_le` prepends). Unlike every other message type, `Ping` has no fixed shape:
-/// `block_locators` grows with the height of the chain, up to `NUM_RECENT_BLOCKS` recent entries
-/// plus `MAX_CHECKPOINTS` checkpoints (see `snarkos_node_sync_locators::block_locators`), each a
-/// `(u32, BlockHash)` pair - 4 bytes plus a 32-byte field element.
+/// `block_locators` grows with the height of the chain, carrying up to `NUM_RECENT_BLOCKS` recent
+/// entries plus one checkpoint per `CHECKPOINT_INTERVAL` blocks (see
+/// `snarkos_node_sync_locators::block_locators`), each a `(u32, BlockHash)` pair - 4 bytes plus a
+/// 32-byte field element.
 ///
-/// This is `u32::MAX / CHECKPOINT_INTERVAL` checkpoints' worth - the wire format's own ceiling,
-/// derived rather than measured, and asserted below against the real locator-entry size so it
-/// can't silently drift from what `BlockLocators` actually enforces. It is far above anything a
-/// realistic chain height produces today; see the PR that introduced this cap for the case that
-/// a tighter, revisitable number might be preferable instead.
-pub const MAX_PING_MESSAGE_SIZE: usize = 16 * 1024 * 1024; // 16 MiB
+/// This is a policy cap rather than the wire format's own ceiling: the format can express
+/// `MAX_CHECKPOINTS` checkpoints, a chain of 4.29 billion blocks and ~14.75 MiB, but locator size
+/// is linear in chain height, so what an honest peer actually sends is set by the height the
+/// chain has reached. Since this cap is what bounds the memory an untrusted router peer can pin
+/// (see `MessageId::max_size` and `MessageCodec::for_allowed_ids`), it is sized from
+/// `MAX_PING_LOCATOR_HEIGHT` instead, which the assert below holds it to.
+pub const MAX_PING_MESSAGE_SIZE: usize = 2 * 1024 * 1024; // 2 MiB
 
 const _: () = {
     let locator_entry = size_of::<u32>() + 32; // a block height, plus a `BlockHash` field element
+    let checkpoints = (MAX_PING_LOCATOR_HEIGHT / CHECKPOINT_INTERVAL) as usize + 1; // one at height 0
     let ping = 2 // the message ID
         + 4 // `version`
         + 1 // `node_type`
         + 1 // the `Some`/`None` marker on `block_locators`
         + 4 // the `recents` map's length prefix
         + 4 // the `checkpoints` map's length prefix
-        + (NUM_RECENT_BLOCKS + MAX_CHECKPOINTS) * locator_entry;
-    assert!(ping <= MAX_PING_MESSAGE_SIZE, "MAX_PING_MESSAGE_SIZE is below the largest Ping the wire format permits");
+        + (NUM_RECENT_BLOCKS + checkpoints) * locator_entry;
+    assert!(
+        ping <= MAX_PING_MESSAGE_SIZE,
+        "MAX_PING_MESSAGE_SIZE is below the Ping a chain at MAX_PING_LOCATOR_HEIGHT sends"
+    );
 };
 
 impl<N: Network> MessageTrait for Ping<N> {
@@ -101,21 +112,11 @@ impl<N: Network> Ping<N> {
 
 #[cfg(test)]
 pub mod prop_tests {
-    use crate::{Ping, challenge_request::prop_tests::any_node_type};
-    use snarkos_node_sync_locators::{
-        BlockLocators,
-        CHECKPOINT_INTERVAL,
-        MAX_CHECKPOINTS,
-        NUM_RECENT_BLOCKS,
-        test_helpers::sample_block_locators,
-    };
-    use snarkvm::{
-        prelude::Field,
-        utilities::{FromBytes, ToBytes},
-    };
+    use crate::{MAX_PING_LOCATOR_HEIGHT, Ping, challenge_request::prop_tests::any_node_type};
+    use snarkos_node_sync_locators::{BlockLocators, test_helpers::sample_block_locators};
+    use snarkvm::utilities::{FromBytes, ToBytes};
 
     use bytes::{Buf, BufMut, BytesMut};
-    use indexmap::IndexMap;
     use proptest::prelude::{BoxedStrategy, Strategy, any};
     use test_strategy::proptest;
 
@@ -139,44 +140,14 @@ pub mod prop_tests {
         assert_eq!(ping, decoded);
     }
 
-    /// The largest `Ping` the wire format permits: a full recent-block window, plus the
-    /// checkpoint ceiling `BlockLocators::read_le` itself enforces - not just the largest number
-    /// of entries `write_le` will emit, but one that actually satisfies `BlockLocators::new`'s own
-    /// validity rules, since `read_le` calls it and this needs to round-trip through the codec.
-    /// That means checkpoints genuinely spaced `CHECKPOINT_INTERVAL` apart (not just sequential
-    /// heights), with `recents` ending within one interval of the last checkpoint - so this is
-    /// only reachable at a chain height near `u32::MAX`, which is exactly the point.
-    ///
-    /// Content doesn't matter here beyond satisfying `BlockLocators::new`'s uniqueness
-    /// requirement (`recents` and, separately, `checkpoints` may not contain a repeated hash) -
-    /// so each entry's hash is just its own height embedded as a field element, which is cheap
-    /// and trivially unique within each map, rather than paying for hundreds of thousands of
-    /// fresh random field elements. Uniqueness is not required *across* the two maps, only
-    /// within each, and this construction never gives them an overlapping height anyway.
-    ///
-    /// Note this is `MAX_CHECKPOINTS`, not `MAX_CHECKPOINTS + 1`: the latter isn't a way to get a
-    /// frame that's too large for `MAX_PING_MESSAGE_SIZE` (there's real headroom between the two;
-    /// `MAX_PING_MESSAGE_SIZE`'s own doc comment has the arithmetic), it's a way to get a frame
-    /// that `BlockLocators::read_le` rejects for an unrelated reason - a different mechanism than
-    /// the one this cap is testing.
-    pub fn largest_possible_ping() -> Ping<CurrentNetwork> {
-        let hash_for = |height: u32| Field::<CurrentNetwork>::from_u64(height as u64).into();
-
-        let last_checkpoint_height = (MAX_CHECKPOINTS as u32 - 1) * CHECKPOINT_INTERVAL;
-        let checkpoints =
-            (0..MAX_CHECKPOINTS as u32).map(|i| (i * CHECKPOINT_INTERVAL, hash_for(i))).collect::<IndexMap<_, _>>();
-
-        // `recents` must end within [last_checkpoint_height, last_checkpoint_height +
-        // CHECKPOINT_INTERVAL) - put its window at the very top of that range.
-        let last_recent_height = last_checkpoint_height + CHECKPOINT_INTERVAL - 1;
-        let recents = ((last_recent_height + 1 - NUM_RECENT_BLOCKS as u32)..=last_recent_height)
-            .map(|h| (h, hash_for(h)))
-            .collect::<IndexMap<_, _>>();
-
+    /// The largest `Ping` the cap is sized to accept: the locators of a chain at
+    /// `MAX_PING_LOCATOR_HEIGHT`. The failure mode a too-tight cap causes is disconnecting honest
+    /// peers, which is worse than the DoS it exists to prevent, so this has to keep decoding.
+    pub fn largest_supported_ping() -> Ping<CurrentNetwork> {
         Ping {
             version: 0,
             node_type: snarkos_node_network::NodeType::Client,
-            block_locators: Some(BlockLocators { recents, checkpoints }),
+            block_locators: Some(sample_block_locators(MAX_PING_LOCATOR_HEIGHT)),
         }
     }
 }

--- a/node/src/validator/router.rs
+++ b/node/src/validator/router.rs
@@ -112,10 +112,10 @@ impl<N: Network, C: ConsensusStorage<N>> Reading for Validator<N, C> {
         // (`ConnectionMode::Gateway`); it never issues a `BlockRequest` over the router, so it
         // never has a legitimate reason to accept a `BlockResponse` there either. Excluding it
         // rejects one outright the moment its ID is visible, and shrinks this connection's frame
-        // ceiling from the general 128 MiB down to `Ping`'s (the largest type still allowed) - so
-        // an untrusted router peer can no longer use a claimed `BlockResponse` to force either a
-        // 128 MiB allocation or a successful decode that `block_response` below only rejects
-        // afterward.
+        // ceiling from the general 128 MiB down to `UnconfirmedTransaction`'s (the largest type
+        // still allowed, and one a validator must accept) - so an untrusted router peer can no
+        // longer use a claimed `BlockResponse` to force either a 128 MiB allocation or a
+        // successful decode that `block_response` below only rejects afterward.
         MessageCodec::excluding(&[MessageId::BlockResponse])
     }
 


### PR DESCRIPTION
## Motivation

`MAX_PING_MESSAGE_SIZE` was derived from the wire format's own ceiling - `MAX_CHECKPOINTS` checkpoints, a chain of 4.29 billion blocks, ~14.75 MiB rounded up to 16 MiB - rather than from any height a real chain reaches. That made `Ping` the largest type a validator's router codec accepts, so it set the frame ceiling for every untrusted P2P connection.

The `Ping` stuff must eventually be redesigned anyways, because currently it is tied to a linear checkpoint scheme instead of switching to an exponential checkpoint scheme after a while, and so as the blockchain grows, the size of ping messages will grow without bound. But this checkpoint scheme is actually enforced by the deserializer, not validated as part of business logic later, so changing the scheme actually changes the wire format.

2 MiB holds the locators of a 500M-block chain, 40+ years of headroom against mainnet's ~19.9M blocks and ~10.4M blocks/year, and drops the validator router ceiling to `UnconfirmedTransaction`'s 2,304,039 bytes, which is the floor - a validator must accept those.

This change technically shortens the amount of time we have before the code will completely break, but not meaningfully.

The test for the largest acceptable `Ping` now builds it with the existing `sample_block_locators` helper at that height, rather than hand-constructing the locators of a chain near `u32::MAX`.

Refs #4424 (action item 1), #4419, #4417.

## Test Plan

The tests from 4417 were updated for this change

## Backwards compatibility

This is backwards compatible for at least several decades more, and before then, we should address the items in #4424 