### PR TITLE
WIP feat(router): rate-limit inbound Ping, and floor the interval between sent pings

### DIFF
--- a/node/router/src/helpers/cache.rs
+++ b/node/router/src/helpers/cache.rs
@@ -48,6 +48,8 @@ pub struct Cache<N: Network> {
     seen_inbound_block_requests: RwLock<HashMap<SocketAddr, VecDeque<OffsetDateTime>>>,
     /// The map of peer IPs to their recent unconfirmed solution timestamps.
     seen_inbound_unconfirmed_solutions: RwLock<HashMap<SocketAddr, VecDeque<OffsetDateTime>>>,
+    /// The map of peer IPs to their recent ping timestamps.
+    seen_inbound_pings: RwLock<HashMap<SocketAddr, VecDeque<OffsetDateTime>>>,
     /// The map of solution IDs to their last seen timestamp.
     seen_inbound_solutions: RwLock<LinkedHashMap<SolutionKey<N>, OffsetDateTime>>,
     /// The map of transaction IDs to their last seen timestamp.
@@ -73,6 +75,7 @@ impl<N: Network> Default for Cache<N> {
 
 impl<N: Network> Cache<N> {
     const INBOUND_BLOCK_REQUEST_INTERVAL: i64 = 60;
+    const INBOUND_PING_INTERVAL: i64 = 60;
     const INBOUND_PUZZLE_REQUEST_INTERVAL: i64 = 60;
     const INBOUND_UNCONFIRMED_SOLUTION_INTERVAL: i64 = 60;
 
@@ -84,6 +87,7 @@ impl<N: Network> Cache<N> {
             seen_inbound_puzzle_requests: Default::default(),
             seen_inbound_block_requests: Default::default(),
             seen_inbound_unconfirmed_solutions: Default::default(),
+            seen_inbound_pings: Default::default(),
             seen_inbound_solutions: RwLock::new(LinkedHashMap::with_capacity(MAX_CACHE_SIZE)),
             seen_inbound_transactions: RwLock::new(LinkedHashMap::with_capacity(MAX_CACHE_SIZE)),
             seen_outbound_block_requests: Default::default(),
@@ -123,6 +127,11 @@ impl<N: Network> Cache<N> {
             peer_ip,
             Self::INBOUND_UNCONFIRMED_SOLUTION_INTERVAL,
         )
+    }
+
+    /// Inserts a new timestamp for the given peer IP, returning the number of recent pings.
+    pub fn insert_inbound_ping(&self, peer_ip: SocketAddr) -> usize {
+        Self::retain_and_insert(&self.seen_inbound_pings, peer_ip, Self::INBOUND_PING_INTERVAL)
     }
 
     /// Inserts a solution ID into the cache, returning the previously seen timestamp if it existed.
@@ -239,6 +248,7 @@ impl<N: Network> Cache<N> {
             &self.seen_inbound_unconfirmed_solutions,
             Self::INBOUND_UNCONFIRMED_SOLUTION_INTERVAL,
         );
+        Self::clear_expired_entries(&self.seen_inbound_pings, Self::INBOUND_PING_INTERVAL);
     }
 }
 
@@ -385,6 +395,19 @@ mod tests {
 
         assert_eq!(cache.insert_inbound_unconfirmed_solution(peer_ip), 1);
         assert_eq!(cache.insert_inbound_unconfirmed_solution(peer_ip), 2);
+    }
+
+    #[test]
+    fn test_inbound_ping() {
+        let cache = Cache::<CurrentNetwork>::default();
+        let peer_ip = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 1234);
+
+        assert_eq!(cache.insert_inbound_ping(peer_ip), 1);
+        assert_eq!(cache.insert_inbound_ping(peer_ip), 2);
+
+        // A different peer has its own count.
+        let other_peer_ip = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 1235);
+        assert_eq!(cache.insert_inbound_ping(other_peer_ip), 1);
     }
 
     #[test]
@@ -586,6 +609,8 @@ mod tests {
             map.insert(peer_ip, VecDeque::from([old]));
             let mut map = cache.seen_inbound_unconfirmed_solutions.write();
             map.insert(peer_ip, VecDeque::from([old]));
+            let mut map = cache.seen_inbound_pings.write();
+            map.insert(peer_ip, VecDeque::from([old]));
             let mut map = cache.seen_inbound_connections.write();
             map.insert(peer_ip.ip(), VecDeque::from([old]));
         }
@@ -594,9 +619,10 @@ mod tests {
         assert_eq!(cache.seen_inbound_block_requests.read().len(), 1);
         assert_eq!(cache.seen_inbound_puzzle_requests.read().len(), 1);
         assert_eq!(cache.seen_inbound_unconfirmed_solutions.read().len(), 1);
+        assert_eq!(cache.seen_inbound_pings.read().len(), 1);
         assert_eq!(cache.seen_inbound_connections.read().len(), 1);
 
-        // 120s is older than every window of (10, 5) and the internal Self::INBOUND_*_INTERVAL constants (60). So all 5 must reap.
+        // 120s is older than every window of (10, 5) and the internal Self::INBOUND_*_INTERVAL constants (60). So all 6 must reap.
         cache.clear_stale_entries(10, 5);
 
         // assert that all maps are empty
@@ -604,6 +630,7 @@ mod tests {
         assert!(cache.seen_inbound_block_requests.read().is_empty());
         assert!(cache.seen_inbound_puzzle_requests.read().is_empty());
         assert!(cache.seen_inbound_unconfirmed_solutions.read().is_empty());
+        assert!(cache.seen_inbound_pings.read().is_empty());
         assert!(cache.seen_inbound_connections.read().is_empty());
     }
 }

--- a/node/router/src/inbound.rs
+++ b/node/router/src/inbound.rs
@@ -52,8 +52,22 @@ pub trait Inbound<N: Network>: Reading + Outbound<N> {
     const MAXIMUM_BLOCK_REQUESTS_PER_INTERVAL: usize = 256;
     /// The maximum number of unconfirmed solutions per interval (~3800 per hour at 60s interval).
     const MAXIMUM_UNCONFIRMED_SOLUTIONS_PER_INTERVAL: usize = 64;
-    /// The duration in seconds to sleep in between ping requests with a connected peer.
-    const PING_SLEEP_IN_SECS: u64 = 20; // 20 seconds
+    /// The maximum number of pings per interval (60 seconds).
+    ///
+    /// This is sized for the transition, not for hardening. A peer running
+    /// `snarkos_node_sync::Ping` sends at most one ping per second per peer, i.e. 60 per interval,
+    /// but a peer predating that floor re-pings on every batch of newly synced blocks - paced only
+    /// by the round trip to us - so one catching up over a low-latency link can legitimately burst
+    /// far above the steady-state rate of three per minute. Dropping such a peer mid-sync is worse
+    /// than the looser bound, the more so because its entry outlives the disconnect: the window is
+    /// keyed by listener address and deliberately not cleared by `Cache::clear_peer_entries`, so a
+    /// peer dropped for this re-trips on its first message back - a reconnecting peer's first
+    /// router message is a `Ping` - and stays unusable for the rest of the interval. Clearing the
+    /// window on disconnect is not the fix: it would let a peer reset its budget by reconnecting,
+    /// which is why none of the sibling counters are cleared there either.
+    ///
+    /// Once the floor is ubiquitous this can drop to ~120, which is where it bounds anything.
+    const MAXIMUM_PINGS_PER_INTERVAL: usize = 1200;
     /// The maximum number of messages accepted within `MESSAGE_LIMIT_TIME_FRAME_IN_SECS`.
     const MESSAGE_LIMIT: usize = 500;
 
@@ -189,6 +203,13 @@ pub trait Inbound<N: Network>: Reading + Outbound<N> {
                 // Ensure the message protocol version is not outdated.
                 if !self.is_valid_message_version(message.version) {
                     bail!("Dropping '{peer_ip}' on message version {} (outdated)", message.version);
+                }
+
+                // Insert the ping for the peer, and fetch the recent frequency.
+                let frequency = self.router().cache.insert_inbound_ping(peer_ip);
+                // Check if the number of pings is within the limit.
+                if frequency > Self::MAXIMUM_PINGS_PER_INTERVAL {
+                    bail!("Peer '{peer_ip}' is not following the protocol (excessive pings)")
                 }
 
                 // If the peer is a client or validator, ensure there are block locators.

--- a/node/sync/src/ping.rs
+++ b/node/sync/src/ping.rs
@@ -22,7 +22,7 @@ use locktick::parking_lot::Mutex;
 #[cfg(not(feature = "locktick"))]
 use parking_lot::Mutex;
 use std::{
-    collections::BTreeMap,
+    collections::HashMap,
     net::SocketAddr,
     sync::Arc,
     time::{Duration, Instant},
@@ -31,14 +31,21 @@ use tokio::{sync::Notify, time::timeout};
 
 /// Internal state of the ping logic
 ///
-/// Essentially, ping keeps an ordered map `next_ping` of time(rs) to peer IPs.
+/// Essentially, ping keeps a map `next_ping` of peer IPs to the time they should next be pinged.
 /// When a new peer connects or a Pong message is received, an entry in next ping is created
 /// for when a peer should next be pinged.
-///
-/// TODO (kaimast): maybe keep track of the last ping too, to not trigger spam detection?
 struct PingInner<N: Network> {
     /// The next time we should ping a peer.
-    next_ping: BTreeMap<Instant, SocketAddr>,
+    ///
+    /// Keyed by peer, so a peer holds exactly one entry however many `Pong`s it sends - nothing
+    /// checks that a `Pong` was solicited, and an entry per `Pong` would earn the sender a
+    /// correspondingly large `Ping` per entry on the next block.
+    next_ping: HashMap<SocketAddr, Instant>,
+    /// The last time each peer was pinged.
+    ///
+    /// Entries older than `MAX_PING_INTERVAL` are pruned on every pass: past that point every
+    /// peer satisfies `MIN_PING_INTERVAL` anyway, so a missing entry means "may be pinged now".
+    last_ping: HashMap<SocketAddr, Instant>,
     /// The most recent block locators.
     /// (or None if this node does not offer block sync)
     block_locators: Option<BlockLocators<N>>,
@@ -53,13 +60,19 @@ pub struct Ping<N: Network> {
 
 impl<N: Network> PingInner<N> {
     fn new(block_locators: Option<BlockLocators<N>>) -> Self {
-        Self { block_locators, next_ping: Default::default() }
+        Self { block_locators, next_ping: Default::default(), last_ping: Default::default() }
     }
 }
 
 impl<N: Network> Ping<N> {
     /// The duration in seconds to wait between sending ping requests to a peer.
     const MAX_PING_INTERVAL: Duration = Duration::from_secs(20);
+    /// The shortest interval at which a peer may be pinged.
+    ///
+    /// New blocks trigger a ping to every peer, and during catch-up they arrive in batches limited
+    /// only by how fast responses can be processed, so without this floor the rate at which a peer
+    /// is pinged is bounded by the round trip to it rather than by anything on this node.
+    const MIN_PING_INTERVAL: Duration = Duration::from_secs(1);
 
     /// Create a new instance of the ping logic.
     /// There should only be one per node.
@@ -108,7 +121,7 @@ impl<N: Network> Ping<N> {
         let now = Instant::now();
         let mut inner = self.inner.lock();
 
-        inner.next_ping.insert(now + Self::MAX_PING_INTERVAL, peer_ip);
+        inner.next_ping.insert(peer_ip, now + Self::MAX_PING_INTERVAL);
 
         // self.notify.notify() is not needed as ping_task wakes up every MAX_PING_INTERVAL
     }
@@ -116,8 +129,9 @@ impl<N: Network> Ping<N> {
     /// Notify the ping logic that a new peer connected.
     pub fn on_peer_connected(&self, peer_ip: SocketAddr) {
         // Send the first ping.
-        let locators = self.inner.lock().block_locators.clone();
-        if !self.router.send_ping(peer_ip, locators) {
+        let now = Instant::now();
+        let mut inner = self.inner.lock();
+        if !Self::dispatch_ping(now, &mut inner, &self.router, peer_ip) {
             warn!("Peer {peer_ip} connected and immediately disconnected?");
         }
     }
@@ -144,19 +158,21 @@ impl<N: Network> Ping<N> {
                 let mut inner = inner.lock();
                 let now = Instant::now();
 
+                // Drop ping times too old to constrain anything, bounding the map by peer count.
+                inner.last_ping.retain(|_, time| now.saturating_duration_since(*time) < Self::MAX_PING_INTERVAL);
+
                 // Ping peers.
                 if new_block {
-                    Self::ping_all_peers(&mut inner, router);
+                    Self::ping_all_peers(now, &mut inner, router);
                     new_block = false;
                 } else {
                     Self::ping_expired_peers(now, &mut inner, router);
                 }
 
                 // Figure out how long to sleep.
-                if let Some((time, _)) = inner.next_ping.first_key_value() {
-                    time.saturating_duration_since(now)
-                } else {
-                    Self::MAX_PING_INTERVAL
+                match inner.next_ping.values().min() {
+                    Some(time) => time.saturating_duration_since(now),
+                    None => Self::MAX_PING_INTERVAL,
                 }
             };
 
@@ -170,43 +186,60 @@ impl<N: Network> Ping<N> {
 
     /// Ping all peers that have an expired timer.
     fn ping_expired_peers(now: Instant, inner: &mut PingInner<N>, router: &Router<N>) {
-        loop {
-            // Find next peer to contact.
-            let peer_ip = {
-                let Some((time, peer_ip)) = inner.next_ping.first_key_value() else {
-                    return;
-                };
+        let due =
+            inner.next_ping.iter().filter(|(_, time)| **time <= now).map(|(peer_ip, _)| *peer_ip).collect::<Vec<_>>();
 
-                if *time > now {
-                    return;
-                }
-
-                *peer_ip
-            };
-
-            // Send new ping
-            let locators = inner.block_locators.clone();
-            let success = router.send_ping(peer_ip, locators.clone());
-            inner.next_ping.pop_first();
-
-            if !success {
-                trace!("Failed to send ping to peer {peer_ip}. Disconnected.");
-            }
-        }
+        Self::ping_peers(now, inner, router, due);
     }
 
     /// Ping all known peers.
-    fn ping_all_peers(inner: &mut PingInner<N>, router: &Router<N>) {
-        let peers: Vec<SocketAddr> = inner.next_ping.values().copied().collect();
-        inner.next_ping.clear();
+    fn ping_all_peers(now: Instant, inner: &mut PingInner<N>, router: &Router<N>) {
+        let peers = inner.next_ping.keys().copied().collect::<Vec<_>>();
 
+        Self::ping_peers(now, inner, router, peers);
+    }
+
+    /// Pings each of `peers` that `MIN_PING_INTERVAL` permits, and reschedules the rest for the
+    /// moment it does permit them.
+    ///
+    /// Rescheduling rather than leaving the existing timer is what keeps the floor cheap: the
+    /// announcement a suppressed ping would have carried is what a peer most wants when a burst of
+    /// new blocks ends, so it is delayed by the floor rather than by the peer's full
+    /// `MAX_PING_INTERVAL`.
+    fn ping_peers(now: Instant, inner: &mut PingInner<N>, router: &Router<N>, peers: Vec<SocketAddr>) {
         for peer_ip in peers {
-            let locators = inner.block_locators.clone();
-            let success = router.send_ping(peer_ip, locators);
-
-            if !success {
-                trace!("Failed to send ping to peer {peer_ip}. Disconnected.");
+            if let Some(earliest) = Self::next_permitted_ping(now, inner, &peer_ip) {
+                inner.next_ping.insert(peer_ip, earliest);
+                continue;
             }
+
+            inner.next_ping.remove(&peer_ip);
+            Self::dispatch_ping(now, inner, router, peer_ip);
+        }
+    }
+
+    /// Returns the earliest time `peer_ip` may be pinged, or `None` if it may be pinged now.
+    ///
+    /// A peer with no recorded ping - including one whose entry was pruned for being older than
+    /// `MAX_PING_INTERVAL` - may always be pinged.
+    fn next_permitted_ping(now: Instant, inner: &PingInner<N>, peer_ip: &SocketAddr) -> Option<Instant> {
+        let earliest = *inner.last_ping.get(peer_ip)? + Self::MIN_PING_INTERVAL;
+        (earliest > now).then_some(earliest)
+    }
+
+    /// Sends a ping to the peer, recording the time so that `MIN_PING_INTERVAL` can be enforced.
+    /// Returns `false` if the peer is no longer connected.
+    fn dispatch_ping(now: Instant, inner: &mut PingInner<N>, router: &Router<N>, peer_ip: SocketAddr) -> bool {
+        let locators = inner.block_locators.clone();
+
+        if router.send_ping(peer_ip, locators) {
+            inner.last_ping.insert(peer_ip, now);
+            true
+        } else {
+            // Leave `last_ping` alone: the periodic prune reclaims it, and dropping it here would
+            // let a peer that failed once be re-sent to without regard for the floor.
+            trace!("Failed to send ping to peer {peer_ip}. Disconnected.");
+            false
         }
     }
 }


### PR DESCRIPTION
**WIP, I'm still iterating on this**

Action item 2 from #4424. `Ping` had no per-type inbound counter, so its only bound was the generic `MESSAGE_LIMIT` of 500 messages per 5 seconds - 100/s. `Ping` is the most expensive message to parse per byte on the untrusted path: it is the only message whose size is unbounded by a fixed shape, and `BlockLocators::read_le` does a multi-pass structural validation of ~73 KiB at today's mainnet height. 100/s of that is ~7 MB/s of locator parsing per peer.

Two halves, because the limit is not safe without the second.

Receiver side: a `seen_inbound_pings` counter alongside the existing per-type counters (`insert_inbound_ping`, 60-second window), checked in the `Message::Ping` arm and swept by `clear_stale_entries` like its siblings.

Sender side: `Ping::ping_all_peers` pings every peer on every batch of newly synced blocks. During catch-up those batches are paced only by how fast block responses arrive, and a peer becomes re-pingable as soon as its `Pong` lands, so the rate at which we ping a given peer is bounded by the round trip to it rather than by anything on this node. This is the spam-detection hazard the `PingInner` TODO flagged; `MIN_PING_INTERVAL` (1s) now floors it, and the TODO is resolved.

Enforcing that needs the ping times themselves, so `PingInner` gains `last_ping`, pruned each pass of entries older than `MAX_PING_INTERVAL` - past which every peer satisfies the floor anyway, so a missing entry reads as "may be pinged now" and the map stays bounded by peer count without a disconnect hook. Deriving eligibility from the schedule key instead would be wrong: a deferred peer must be rescheduled at `last_ping + MIN_PING_INTERVAL` rather than left on its `pong + MAX_PING_INTERVAL` timer, because the announcement it would have carried is what peers most want when a burst of new blocks *ends*, and the old timer delays it ~19s instead of ~1s.

`next_ping` is now keyed by peer (`HashMap<SocketAddr, Instant>`) rather than by instant. That fixes two things. An instant-keyed map silently dropped a peer's ping whenever two peers were scheduled for the same instant, with nothing to reschedule it. And nothing checks that a `Pong` was solicited - `inbound.rs` forwards every one to `on_pong_received` - so a peer could accumulate a schedule entry per `Pong` and collect one ~73 KiB `Ping` per entry on the next block, turning cheap inbound pongs into unbounded outbound bandwidth. One entry per peer is now structural rather than something the ping paths have to maintain.

`MAXIMUM_PINGS_PER_INTERVAL` is 1200 per 60s, sized for the transition rather than for hardening: peers predating the floor can still legitimately burst, and dropping one mid-sync is worse than the looser bound - the more so because the window is keyed by listener address and outlives the disconnect, so such a peer re-trips on its first message back and stays unusable for the rest of the interval. Clearing it on disconnect would let a peer reset its budget by reconnecting, which is why no sibling counter is cleared there either. Once the floor is ubiquitous this drops to ~120, which is where it bounds anything.

Also drops `Inbound::PING_SLEEP_IN_SECS`, which has had no references since the cadence moved to `Ping::MAX_PING_INTERVAL` and duplicated its value.

Refs #4424.


Claude-Session: https://claude.ai/code/session_01ET44Km85Tt1Ar7SqeoQzN6

<!-- Thank you for submitting the PR! We appreciate you spending the time to work on these changes! -->

## Motivation

Write your motivation here, make sure to link related issues and PRs.

## Test Plan

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!

## Documentation

If this PR adds or changes functionality, consider clarifying which docs need to be updated, e.g. on [AleoNet/welcome](https://github.com/AleoNet/welcome).

## Backwards compatibility

Please review backwards compatibility. Does any functionality need to be guarded by an existing or new `ConsensusVersion`?
