### PR TITLE
Chore/bump rust 1.96

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -8,6 +8,3 @@ rustflags = [
     # you explicitly set target-cpu yourself when building.
     "-C", "link-arg=-fuse-ld=lld", "-C", "target-cpu=skylake"
 ]
-
-[env]
-CXXFLAGS = "-include cstdint" #TODO: remove once RocksDB 0.24 is released

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ executors:
   # The default docker image used in the main-workflow
   rust-docker:
      docker:
-      - image: cimg/rust:1.88.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
+      - image: cimg/rust:1.96.0 # Attention - Change the MSRV in Cargo.toml and rust-toolchain as well
   # The default VM used for devnet tests
   ubuntu-vm:
       machine:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5533,7 +5533,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -5558,7 +5558,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5586,7 +5586,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms-cuda"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "blst",
  "cc",
@@ -5597,7 +5597,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -5611,7 +5611,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
@@ -5621,7 +5621,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -5631,7 +5631,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -5641,7 +5641,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "anyhow",
  "indexmap 2.14.0",
@@ -5661,12 +5661,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -5677,7 +5677,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -5691,7 +5691,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -5706,7 +5706,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5719,7 +5719,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -5728,7 +5728,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5738,7 +5738,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5750,7 +5750,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5762,7 +5762,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5773,7 +5773,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5785,7 +5785,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -5798,7 +5798,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -5809,7 +5809,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "blake2s_simd",
  "hex",
@@ -5826,7 +5826,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "aleo-std",
  "locktick",
@@ -5840,7 +5840,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "anyhow",
  "enum-iterator",
@@ -5860,7 +5860,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "anyhow",
  "bech32",
@@ -5878,7 +5878,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -5899,7 +5899,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -5914,7 +5914,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5925,7 +5925,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -5933,7 +5933,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "smallvec",
  "snarkvm-console-network-environment",
@@ -5944,7 +5944,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5955,7 +5955,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5966,7 +5966,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5977,7 +5977,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5988,7 +5988,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "rand 0.10.2",
  "rustc_version",
@@ -6001,7 +6001,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -6018,7 +6018,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -6051,7 +6051,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "anyhow",
  "rand 0.10.2",
@@ -6063,7 +6063,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "anyhow",
  "indexmap 2.14.0",
@@ -6087,7 +6087,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "anyhow",
  "indexmap 2.14.0",
@@ -6106,7 +6106,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -6119,7 +6119,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "indexmap 2.14.0",
  "rayon",
@@ -6132,7 +6132,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "indexmap 2.14.0",
  "rayon",
@@ -6144,7 +6144,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "bytes",
  "serde_json",
@@ -6155,7 +6155,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "indexmap 2.14.0",
  "rayon",
@@ -6170,7 +6170,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "bytes",
  "serde_json",
@@ -6183,7 +6183,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -6192,7 +6192,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -6213,7 +6213,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -6236,7 +6236,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6253,7 +6253,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -6283,7 +6283,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-test-helpers"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -6301,7 +6301,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "metrics",
 ]
@@ -6309,7 +6309,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -6332,7 +6332,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-slipstream-plugin-interface"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "anyhow",
 ]
@@ -6340,7 +6340,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-slipstream-plugin-manager"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "anyhow",
  "json5",
@@ -6354,7 +6354,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -6390,7 +6390,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-error"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "anyhow",
  "snarkvm-circuit-environment",
@@ -6402,7 +6402,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "aleo-std",
  "colored 3.1.1",
@@ -6429,7 +6429,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "enum-iterator",
  "indexmap 2.14.0",
@@ -6450,7 +6450,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "bincode",
  "serde_json",
@@ -6463,7 +6463,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -6486,7 +6486,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "4.9.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=7c302e635#7c302e63518ee48879b3b62804849a463b34fffe"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?rev=e0f68fae#e0f68fae7d9c45e5efd22400b31c5b4d7989cea5"
 dependencies = [
  "proc-macro2",
  "quote 1.0.47",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ keywords = [
 categories = [ "cryptography", "cryptography::cryptocurrencies", "os" ]
 license = "Apache-2.0"
 edition = "2024"
-rust-version = "1.88.0" # Attention - Change the MSRV in rust-toolchain and in .circleci/config.yml as well
+rust-version = "1.96.0" # Attention - Change the MSRV in rust-toolchain and in .circleci/config.yml as well
 
 [workspace]
 members = [
@@ -48,7 +48,7 @@ default-features = false
 [workspace.dependencies.snarkvm]
 #path = "../snarkVM"
 git = "https://github.com/ProvableHQ/snarkVM.git"
-rev = "7c302e635" #staging
+rev = "e0f68fae" #staging
 #version = "=4.9.0"
 default-features = false
 

--- a/cli/src/commands/developer/decrypt.rs
+++ b/cli/src/commands/developer/decrypt.rs
@@ -101,8 +101,7 @@ mod tests {
                 vec![
                     (Identifier::from_str("a")?, Entry::Private(Plaintext::from(Literal::Field(Field::rand(rng))))),
                     (Identifier::from_str("b")?, Entry::Private(Plaintext::from(Literal::Scalar(Scalar::rand(rng))))),
-                ]
-                .into_iter(),
+                ],
             ),
             N::g_scalar_multiply(&randomizer),
             version,

--- a/cli/src/commands/developer/decrypt.rs
+++ b/cli/src/commands/developer/decrypt.rs
@@ -97,12 +97,10 @@ mod tests {
         };
         let record = Record::<N, Plaintext<N>>::from_plaintext(
             owner,
-            IndexMap::from_iter(
-                vec![
-                    (Identifier::from_str("a")?, Entry::Private(Plaintext::from(Literal::Field(Field::rand(rng))))),
-                    (Identifier::from_str("b")?, Entry::Private(Plaintext::from(Literal::Scalar(Scalar::rand(rng))))),
-                ],
-            ),
+            IndexMap::from_iter(vec![
+                (Identifier::from_str("a")?, Entry::Private(Plaintext::from(Literal::Field(Field::rand(rng))))),
+                (Identifier::from_str("b")?, Entry::Private(Plaintext::from(Literal::Scalar(Scalar::rand(rng))))),
+            ]),
             N::g_scalar_multiply(&randomizer),
             version,
         )?;

--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -758,29 +758,27 @@ impl<N: Network> BFT<N> {
             );
 
             // Trigger consensus (skipped if the round was already committed by a prior call).
-            if !skip_consensus
-                && let Some(consensus_sender) = self.consensus_sender.get() {
-                    // Initialize a callback sender and receiver.
-                    let (callback_sender, callback_receiver) = oneshot::channel();
-                    // Send the subdag and transmissions to consensus.
-                    consensus_sender.tx_consensus_subdag.send((subdag, transmissions, callback_sender)).await?;
-                    // Await the callback to continue.
-                    match callback_receiver.await {
-                        Ok(Ok(_)) => (),
-                        Ok(Err(err)) => {
-                            let err = err.context(format!("BFT failed to advance the subdag for round {anchor_round}"));
-                            error!("{}", &flatten_error(err));
-                            return Ok(());
-                        }
-                        Err(err) => {
-                            let err: anyhow::Error = err.into();
-                            let err =
-                                err.context(format!("BFT failed to receive the callback for round {anchor_round}"));
-                            error!("{}", flatten_error(err));
-                            return Ok(());
-                        }
+            if !skip_consensus && let Some(consensus_sender) = self.consensus_sender.get() {
+                // Initialize a callback sender and receiver.
+                let (callback_sender, callback_receiver) = oneshot::channel();
+                // Send the subdag and transmissions to consensus.
+                consensus_sender.tx_consensus_subdag.send((subdag, transmissions, callback_sender)).await?;
+                // Await the callback to continue.
+                match callback_receiver.await {
+                    Ok(Ok(_)) => (),
+                    Ok(Err(err)) => {
+                        let err = err.context(format!("BFT failed to advance the subdag for round {anchor_round}"));
+                        error!("{}", &flatten_error(err));
+                        return Ok(());
+                    }
+                    Err(err) => {
+                        let err: anyhow::Error = err.into();
+                        let err = err.context(format!("BFT failed to receive the callback for round {anchor_round}"));
+                        error!("{}", flatten_error(err));
+                        return Ok(());
                     }
                 }
+            }
 
             info!(
                 "Committing a subDAG with anchor round {anchor_round} and {num_transmissions} transmissions: {subdag_metadata:?}",

--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -758,8 +758,8 @@ impl<N: Network> BFT<N> {
             );
 
             // Trigger consensus (skipped if the round was already committed by a prior call).
-            if !skip_consensus {
-                if let Some(consensus_sender) = self.consensus_sender.get() {
+            if !skip_consensus
+                && let Some(consensus_sender) = self.consensus_sender.get() {
                     // Initialize a callback sender and receiver.
                     let (callback_sender, callback_receiver) = oneshot::channel();
                     // Send the subdag and transmissions to consensus.
@@ -781,7 +781,6 @@ impl<N: Network> BFT<N> {
                         }
                     }
                 }
-            }
 
             info!(
                 "Committing a subDAG with anchor round {anchor_round} and {num_transmissions} transmissions: {subdag_metadata:?}",

--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -1572,16 +1572,14 @@ impl<N: Network> Disconnect for Gateway<N> {
 #[async_trait]
 impl<N: Network> OnConnect for Gateway<N> {
     async fn on_connect(&self, peer_addr: SocketAddr) {
-        if let Some(listener_addr) = self.resolve_to_listener(&peer_addr) {
-            if let Some(peer) = self.get_connected_peer(listener_addr) {
-                if peer.node_type == NodeType::BootstrapClient {
+        if let Some(listener_addr) = self.resolve_to_listener(&peer_addr)
+            && let Some(peer) = self.get_connected_peer(listener_addr)
+                && peer.node_type == NodeType::BootstrapClient {
                     self.cache.increment_outbound_validators_requests(listener_addr);
                     let _ =
                         <Self as Transport<N>>::send(self, listener_addr, Event::ValidatorsRequest(ValidatorsRequest))
                             .await;
                 }
-            }
-        }
     }
 }
 

--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -1574,12 +1574,12 @@ impl<N: Network> OnConnect for Gateway<N> {
     async fn on_connect(&self, peer_addr: SocketAddr) {
         if let Some(listener_addr) = self.resolve_to_listener(&peer_addr)
             && let Some(peer) = self.get_connected_peer(listener_addr)
-                && peer.node_type == NodeType::BootstrapClient {
-                    self.cache.increment_outbound_validators_requests(listener_addr);
-                    let _ =
-                        <Self as Transport<N>>::send(self, listener_addr, Event::ValidatorsRequest(ValidatorsRequest))
-                            .await;
-                }
+            && peer.node_type == NodeType::BootstrapClient
+        {
+            self.cache.increment_outbound_validators_requests(listener_addr);
+            let _ =
+                <Self as Transport<N>>::send(self, listener_addr, Event::ValidatorsRequest(ValidatorsRequest)).await;
+        }
     }
 }
 

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -2048,6 +2048,7 @@ impl<N: Network> Primary<N> {
         }
 
         // Fetch the missing previous certificates.
+        #[allow(clippy::mutable_key_type)]
         let missing_previous_certificates =
             self.fetch_missing_certificates(peer_ip, round, batch_header.previous_certificate_ids()).await?;
         if !missing_previous_certificates.is_empty() {
@@ -2070,6 +2071,7 @@ impl<N: Network> Primary<N> {
         // Initialize a list for the missing certificates.
         let mut fetch_certificates = FuturesUnordered::new();
         // Initialize a set for the missing certificates.
+        #[allow(clippy::mutable_key_type)]
         let mut missing_certificates = HashSet::default();
         // Iterate through the certificate IDs.
         for certificate_id in certificate_ids {

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -623,9 +623,10 @@ impl<N: Network> proposal_task::BatchPropose for Primary<N> {
             {
                 // If we are using a hotswapped dev committee, use simplified checks to more easily advance.
                 if let Some(dev_committee) = self.ledger.dev_committee_for_round(previous_round)?
-                    && round <= dev_committee.starting_round() {
-                        is_ready = true;
-                    }
+                    && round <= dev_committee.starting_round()
+                {
+                    is_ready = true;
+                }
             }
         }
         // If the batch is not ready to be proposed, return early.

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -95,8 +95,7 @@ use tokio::sync::RwLock as TRwLock;
 use tokio::{sync::Notify, task::JoinHandle};
 
 /// The state of the primary's batch proposal.
-#[derive(Debug, PartialEq, Eq)]
-#[derive(Default)]
+#[derive(Debug, Default, PartialEq, Eq)]
 pub enum ProposedBatchState<N: Network> {
     /// No batch is currently being proposed.
     #[default]
@@ -107,7 +106,6 @@ pub enum ProposedBatchState<N: Network> {
     /// Carries the batch ID so late-arriving signatures can be recognized and silently dropped.
     Certified(Field<N>),
 }
-
 
 impl<N: Network> ProposedBatchState<N> {
     /// Returns `true` if the primary has no active batch proposal.

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -96,8 +96,10 @@ use tokio::{sync::Notify, task::JoinHandle};
 
 /// The state of the primary's batch proposal.
 #[derive(Debug, PartialEq, Eq)]
+#[derive(Default)]
 pub enum ProposedBatchState<N: Network> {
     /// No batch is currently being proposed.
+    #[default]
     None,
     /// A batch is being proposed and awaiting signatures.
     Certifying(Box<Proposal<N>>),
@@ -106,11 +108,6 @@ pub enum ProposedBatchState<N: Network> {
     Certified(Field<N>),
 }
 
-impl<N: Network> Default for ProposedBatchState<N> {
-    fn default() -> Self {
-        Self::None
-    }
-}
 
 impl<N: Network> ProposedBatchState<N> {
     /// Returns `true` if the primary has no active batch proposal.

--- a/node/bft/src/primary.rs
+++ b/node/bft/src/primary.rs
@@ -622,11 +622,10 @@ impl<N: Network> proposal_task::BatchPropose for Primary<N> {
             #[cfg(feature = "test_network")]
             {
                 // If we are using a hotswapped dev committee, use simplified checks to more easily advance.
-                if let Some(dev_committee) = self.ledger.dev_committee_for_round(previous_round)? {
-                    if round <= dev_committee.starting_round() {
+                if let Some(dev_committee) = self.ledger.dev_committee_for_round(previous_round)?
+                    && round <= dev_committee.starting_round() {
                         is_ready = true;
                     }
-                }
             }
         }
         // If the batch is not ready to be proposed, return early.

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -143,7 +143,7 @@ impl<N: Network> Sync<N> {
 
     /// Returns `None` if the node is already synced.
     /// Otherwise, returns a future that completes once the node becomes synced.
-    pub fn wait_for_synced_if_syncing(&self) -> Option<futures::future::BoxFuture<()>> {
+    pub fn wait_for_synced_if_syncing(&self) -> Option<futures::future::BoxFuture<'_, ()>> {
         self.block_sync.wait_for_synced_if_syncing()
     }
 

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -1208,10 +1208,12 @@ mod tests {
 
         // Sample 5 rounds of batch certificates starting at the genesis round from a static set of 4 authors.
         let (round_to_certificates_map, committee) = {
-            let addresses = [Address::try_from(private_keys[0]).unwrap(),
+            let addresses = [
+                Address::try_from(private_keys[0]).unwrap(),
                 Address::try_from(private_keys[1]).unwrap(),
                 Address::try_from(private_keys[2]).unwrap(),
-                Address::try_from(private_keys[3]).unwrap()];
+                Address::try_from(private_keys[3]).unwrap(),
+            ];
 
             let committee = ledger.latest_committee().unwrap();
 

--- a/node/bft/src/sync/mod.rs
+++ b/node/bft/src/sync/mod.rs
@@ -1208,12 +1208,10 @@ mod tests {
 
         // Sample 5 rounds of batch certificates starting at the genesis round from a static set of 4 authors.
         let (round_to_certificates_map, committee) = {
-            let addresses = vec![
-                Address::try_from(private_keys[0]).unwrap(),
+            let addresses = [Address::try_from(private_keys[0]).unwrap(),
                 Address::try_from(private_keys[1]).unwrap(),
                 Address::try_from(private_keys[2]).unwrap(),
-                Address::try_from(private_keys[3]).unwrap(),
-            ];
+                Address::try_from(private_keys[3]).unwrap()];
 
             let committee = ledger.latest_committee().unwrap();
 
@@ -1296,7 +1294,7 @@ mod tests {
 
         // Create a list of all certificates.
         let certificates: Vec<_> =
-            round_to_certificates_map.into_iter().flat_map(|(_, certificates)| certificates.into_iter()).collect();
+            round_to_certificates_map.into_values().flat_map(|certificates| certificates.into_iter()).collect();
 
         // insert all certificates into storage.
         for certificate in certificates.iter() {

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -486,15 +486,17 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
 
         // Fall back to the unconfirmed transaction ID.
         if let Some(unconfirmed) = rest.ledger.try_get_unconfirmed_transaction(tx_id)?
-            && let Some(reason) = store.get_rejected_reason(&*unconfirmed.id())? {
-                return Ok(Some(reason));
-            }
+            && let Some(reason) = store.get_rejected_reason(&*unconfirmed.id())?
+        {
+            return Ok(Some(reason));
+        }
 
         // Fall back to the confirmed (fee) transaction ID.
         if let Some(confirmed) = rest.ledger.try_get_confirmed_transaction(tx_id)?
-            && let Some(reason) = store.get_rejected_reason(&*confirmed.id())? {
-                return Ok(Some(reason));
-            }
+            && let Some(reason) = store.get_rejected_reason(&*confirmed.id())?
+        {
+            return Ok(Some(reason));
+        }
 
         Ok(None)
     }

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -485,18 +485,16 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         }
 
         // Fall back to the unconfirmed transaction ID.
-        if let Some(unconfirmed) = rest.ledger.try_get_unconfirmed_transaction(tx_id)? {
-            if let Some(reason) = store.get_rejected_reason(&*unconfirmed.id())? {
+        if let Some(unconfirmed) = rest.ledger.try_get_unconfirmed_transaction(tx_id)?
+            && let Some(reason) = store.get_rejected_reason(&*unconfirmed.id())? {
                 return Ok(Some(reason));
             }
-        }
 
         // Fall back to the confirmed (fee) transaction ID.
-        if let Some(confirmed) = rest.ledger.try_get_confirmed_transaction(tx_id)? {
-            if let Some(reason) = store.get_rejected_reason(&*confirmed.id())? {
+        if let Some(confirmed) = rest.ledger.try_get_confirmed_transaction(tx_id)?
+            && let Some(reason) = store.get_rejected_reason(&*confirmed.id())? {
                 return Ok(Some(reason));
             }
-        }
 
         Ok(None)
     }

--- a/node/router/messages/src/lib.rs
+++ b/node/router/messages/src/lib.rs
@@ -232,9 +232,10 @@ impl<N: Network> Message<N> {
         }
 
         if let Some(id) = MessageId::peek(bytes)
-            && bytes.len() > id.max_size::<N>() {
-                return Err(io::Error::new(io::ErrorKind::InvalidData, "message is too large for its type"));
-            }
+            && bytes.len() > id.max_size::<N>()
+        {
+            return Err(io::Error::new(io::ErrorKind::InvalidData, "message is too large for its type"));
+        }
 
         Ok(())
     }

--- a/node/router/messages/src/lib.rs
+++ b/node/router/messages/src/lib.rs
@@ -231,11 +231,10 @@ impl<N: Network> Message<N> {
             return Err(io::Error::new(io::ErrorKind::InvalidData, "invalid message"));
         }
 
-        if let Some(id) = MessageId::peek(bytes) {
-            if bytes.len() > id.max_size::<N>() {
+        if let Some(id) = MessageId::peek(bytes)
+            && bytes.len() > id.max_size::<N>() {
                 return Err(io::Error::new(io::ErrorKind::InvalidData, "message is too large for its type"));
             }
-        }
 
         Ok(())
     }

--- a/node/src/bootstrap_client/handshake.rs
+++ b/node/src/bootstrap_client/handshake.rs
@@ -466,17 +466,14 @@ impl<N: Network> BootstrapClient<N> {
                 }
 
                 // Reject validators that aren't members of the committee.
-                if msg.node_type == NodeType::Validator {
-                    if let Some(current_committee) =
+                if msg.node_type == NodeType::Validator
+                    && let Some(current_committee) =
                         self.get_or_update_committee().await.map_err(|_| io_error("Couldn't load the committee"))?
-                    {
-                        if !current_committee.contains(&msg.address) {
+                        && !current_committee.contains(&msg.address) {
                             let msg = Message::Disconnect::<N>(messages::DisconnectReason::ProtocolViolation.into());
                             send_msg!(msg, framed, peer_addr)?;
                             return Ok(false);
                         }
-                    }
-                }
             }
             MessageOrEvent::Event(Event::ChallengeRequest(msg)) => {
                 log_repo_sha_comparison(peer_addr, &msg.snarkos_sha, Self::OWNER);
@@ -490,13 +487,11 @@ impl<N: Network> BootstrapClient<N> {
                 // Reject validators that aren't members of the committee.
                 if let Some(current_committee) =
                     self.get_or_update_committee().await.map_err(|_| io_error("Couldn't load the committee"))?
-                {
-                    if !current_committee.contains(&msg.address) {
+                    && !current_committee.contains(&msg.address) {
                         let msg = Message::Disconnect::<N>(messages::DisconnectReason::ProtocolViolation.into());
                         send_msg!(msg, framed, peer_addr)?;
                         return Ok(false);
                     }
-                }
             }
             _ => unreachable!(),
         }

--- a/node/src/bootstrap_client/handshake.rs
+++ b/node/src/bootstrap_client/handshake.rs
@@ -469,11 +469,12 @@ impl<N: Network> BootstrapClient<N> {
                 if msg.node_type == NodeType::Validator
                     && let Some(current_committee) =
                         self.get_or_update_committee().await.map_err(|_| io_error("Couldn't load the committee"))?
-                        && !current_committee.contains(&msg.address) {
-                            let msg = Message::Disconnect::<N>(messages::DisconnectReason::ProtocolViolation.into());
-                            send_msg!(msg, framed, peer_addr)?;
-                            return Ok(false);
-                        }
+                    && !current_committee.contains(&msg.address)
+                {
+                    let msg = Message::Disconnect::<N>(messages::DisconnectReason::ProtocolViolation.into());
+                    send_msg!(msg, framed, peer_addr)?;
+                    return Ok(false);
+                }
             }
             MessageOrEvent::Event(Event::ChallengeRequest(msg)) => {
                 log_repo_sha_comparison(peer_addr, &msg.snarkos_sha, Self::OWNER);
@@ -487,11 +488,12 @@ impl<N: Network> BootstrapClient<N> {
                 // Reject validators that aren't members of the committee.
                 if let Some(current_committee) =
                     self.get_or_update_committee().await.map_err(|_| io_error("Couldn't load the committee"))?
-                    && !current_committee.contains(&msg.address) {
-                        let msg = Message::Disconnect::<N>(messages::DisconnectReason::ProtocolViolation.into());
-                        send_msg!(msg, framed, peer_addr)?;
-                        return Ok(false);
-                    }
+                    && !current_committee.contains(&msg.address)
+                {
+                    let msg = Message::Disconnect::<N>(messages::DisconnectReason::ProtocolViolation.into());
+                    send_msg!(msg, framed, peer_addr)?;
+                    return Ok(false);
+                }
             }
             _ => unreachable!(),
         }

--- a/node/src/client/mod.rs
+++ b/node/src/client/mod.rs
@@ -224,13 +224,12 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
         }
 
         // Set up everything else after CDN sync is done.
-        if let Some(cdn_sync) = cdn_sync {
-            if let Err(error) = cdn_sync.wait().await.with_context(|| "Failed to synchronize from the CDN") {
+        if let Some(cdn_sync) = cdn_sync
+            && let Err(error) = cdn_sync.wait().await.with_context(|| "Failed to synchronize from the CDN") {
                 crate::log_clean_error(&storage_mode);
                 node.shut_down().await;
                 return Err(error);
             }
-        }
 
         // Initialize the routing.
         node.initialize_routing().await;

--- a/node/src/client/mod.rs
+++ b/node/src/client/mod.rs
@@ -225,11 +225,12 @@ impl<N: Network, C: ConsensusStorage<N>> Client<N, C> {
 
         // Set up everything else after CDN sync is done.
         if let Some(cdn_sync) = cdn_sync
-            && let Err(error) = cdn_sync.wait().await.with_context(|| "Failed to synchronize from the CDN") {
-                crate::log_clean_error(&storage_mode);
-                node.shut_down().await;
-                return Err(error);
-            }
+            && let Err(error) = cdn_sync.wait().await.with_context(|| "Failed to synchronize from the CDN")
+        {
+            crate::log_clean_error(&storage_mode);
+            node.shut_down().await;
+            return Err(error);
+        }
 
         // Initialize the routing.
         node.initialize_routing().await;

--- a/node/src/node.rs
+++ b/node/src/node.rs
@@ -132,11 +132,10 @@ impl<N: Network> Node<N> {
         let node = Self::Validator(validator.clone());
 
         // Perform automatic ledger checkpoints.
-        if let Some(path) = auto_db_checkpoints {
-            if let Some(handle) = node.perform_auto_checkpoints(path)? {
+        if let Some(path) = auto_db_checkpoints
+            && let Some(handle) = node.perform_auto_checkpoints(path)? {
                 validator.handles.lock().push(handle);
             }
-        }
 
         #[cfg(feature = "metrics")]
         if let Some(handle) = node.spawn_rocksdb_metrics_polling() {
@@ -211,11 +210,10 @@ impl<N: Network> Node<N> {
         let node = Self::Client(client.clone());
 
         // Perform automatic ledger checkpoints.
-        if let Some(path) = auto_db_checkpoints {
-            if let Some(handle) = node.perform_auto_checkpoints(path)? {
+        if let Some(path) = auto_db_checkpoints
+            && let Some(handle) = node.perform_auto_checkpoints(path)? {
                 client.handles.lock().push(handle);
             }
-        }
 
         #[cfg(feature = "metrics")]
         if let Some(handle) = node.spawn_rocksdb_metrics_polling() {
@@ -482,11 +480,10 @@ impl<N: Network> Node<N> {
                 // If we have a sufficient number of checkpoints, delete the oldest one(s).
                 let surplus_checkpoints = existing_checkpoints.len().saturating_sub(MAX_AUTO_CHECKPOINTS);
                 for _ in 0..surplus_checkpoints {
-                    if let Some((checkpoint_path, _)) = existing_checkpoints.pop() {
-                        if let Err(e) = fs::remove_dir_all(checkpoint_path) {
+                    if let Some((checkpoint_path, _)) = existing_checkpoints.pop()
+                        && let Err(e) = fs::remove_dir_all(checkpoint_path) {
                             warn!("Couldn't remove an automatic ledger checkpoint: {e}");
                         }
-                    }
                 }
             }
         });

--- a/node/src/node.rs
+++ b/node/src/node.rs
@@ -133,9 +133,10 @@ impl<N: Network> Node<N> {
 
         // Perform automatic ledger checkpoints.
         if let Some(path) = auto_db_checkpoints
-            && let Some(handle) = node.perform_auto_checkpoints(path)? {
-                validator.handles.lock().push(handle);
-            }
+            && let Some(handle) = node.perform_auto_checkpoints(path)?
+        {
+            validator.handles.lock().push(handle);
+        }
 
         #[cfg(feature = "metrics")]
         if let Some(handle) = node.spawn_rocksdb_metrics_polling() {
@@ -211,9 +212,10 @@ impl<N: Network> Node<N> {
 
         // Perform automatic ledger checkpoints.
         if let Some(path) = auto_db_checkpoints
-            && let Some(handle) = node.perform_auto_checkpoints(path)? {
-                client.handles.lock().push(handle);
-            }
+            && let Some(handle) = node.perform_auto_checkpoints(path)?
+        {
+            client.handles.lock().push(handle);
+        }
 
         #[cfg(feature = "metrics")]
         if let Some(handle) = node.spawn_rocksdb_metrics_polling() {
@@ -481,9 +483,10 @@ impl<N: Network> Node<N> {
                 let surplus_checkpoints = existing_checkpoints.len().saturating_sub(MAX_AUTO_CHECKPOINTS);
                 for _ in 0..surplus_checkpoints {
                     if let Some((checkpoint_path, _)) = existing_checkpoints.pop()
-                        && let Err(e) = fs::remove_dir_all(checkpoint_path) {
-                            warn!("Couldn't remove an automatic ledger checkpoint: {e}");
-                        }
+                        && let Err(e) = fs::remove_dir_all(checkpoint_path)
+                    {
+                        warn!("Couldn't remove an automatic ledger checkpoint: {e}");
+                    }
                 }
             }
         });

--- a/node/src/validator/mod.rs
+++ b/node/src/validator/mod.rs
@@ -210,13 +210,12 @@ impl<N: Network, C: ConsensusStorage<N>> Validator<N, C> {
         }
 
         // Set up everything else after CDN sync is done.
-        if let Some(cdn_sync) = cdn_sync {
-            if let Err(error) = cdn_sync.wait().await.with_context(|| "Failed to synchronize from the CDN") {
+        if let Some(cdn_sync) = cdn_sync
+            && let Err(error) = cdn_sync.wait().await.with_context(|| "Failed to synchronize from the CDN") {
                 crate::log_clean_error(&storage_mode);
                 node.shut_down().await;
                 return Err(error);
             }
-        }
 
         // Start the BFT and consensus handlers now that CDN sync is complete. This ensures that
         // committed subdags are only processed after the initial sync from the CDN has finished.

--- a/node/src/validator/mod.rs
+++ b/node/src/validator/mod.rs
@@ -211,11 +211,12 @@ impl<N: Network, C: ConsensusStorage<N>> Validator<N, C> {
 
         // Set up everything else after CDN sync is done.
         if let Some(cdn_sync) = cdn_sync
-            && let Err(error) = cdn_sync.wait().await.with_context(|| "Failed to synchronize from the CDN") {
-                crate::log_clean_error(&storage_mode);
-                node.shut_down().await;
-                return Err(error);
-            }
+            && let Err(error) = cdn_sync.wait().await.with_context(|| "Failed to synchronize from the CDN")
+        {
+            crate::log_clean_error(&storage_mode);
+            node.shut_down().await;
+            return Err(error);
+        }
 
         // Start the BFT and consensus handlers now that CDN sync is complete. This ensures that
         // committed subdags are only processed after the initial sync from the CDN has finished.

--- a/node/sync/src/block_sync.rs
+++ b/node/sync/src/block_sync.rs
@@ -333,7 +333,7 @@ impl<N: Network> BlockSync<N> {
     /// # Concurrency
     /// * This method is atomic, unlike calling `is_synced` and `wait_for_synced` sequentially.
     /// * Multiple tasks can wait on this at the same time safely.
-    pub fn wait_for_synced_if_syncing(&self) -> Option<BoxFuture<()>> {
+    pub fn wait_for_synced_if_syncing(&self) -> Option<BoxFuture<'_, ()>> {
         let mut notified = Box::pin(self.synced_notify.notified());
 
         {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel="1.88"
+channel="1.96"
 components=["cargo", "rustc", "rust-std", "clippy", "rustfmt"]


### PR DESCRIPTION
* Bump snarkVM to latest staging
* Bump rust to 1.96 in toolchain and MSRV (otherwise snarkVM doesn't build)
* `clippy fix --workspace`
* Manually ignore the mutable key error after reviewing the possible impact