### PR TITLE
perf(bft): use BatchCertificate's cached signers instead of re-deriving

### DIFF
--- a/node/bft/src/helpers/storage.rs
+++ b/node/bft/src/helpers/storage.rs
@@ -564,9 +564,8 @@ impl<N: Network> Storage<N> {
         let committee_lookback = self.ledger.get_committee_lookback_for_round(certificate_round)?;
 
         // Ensure that the signers of the certificate reach the quorum threshold.
-        // Note that certificate.signatures() only returns the endorsing signatures, not the author's signature.
-        let mut signers: HashSet<Address<N>> =
-            certificate.signatures().map(|signature| signature.to_address()).collect();
+        // Note that certificate.signers() only returns the endorsing signers, not the author.
+        let mut signers: HashSet<Address<N>> = certificate.signers().iter().copied().collect();
         signers.insert(certificate_author);
         ensure!(
             committee_lookback.is_quorum_threshold_reached(&signers),
@@ -647,14 +646,12 @@ impl<N: Network> Storage<N> {
         };
 
         // Initialize a set of the signers.
-        let mut signers = HashSet::with_capacity(certificate.signatures().len() + 1);
+        let mut signers = HashSet::with_capacity(certificate.signers().len() + 1);
         // Append the batch author.
         signers.insert(certificate.author());
 
-        // Iterate over the signatures.
-        for signature in certificate.signatures() {
-            // Retrieve the signer.
-            let signer = signature.to_address();
+        // Iterate over the signers.
+        for signer in certificate.signers().iter().copied() {
             // Ensure the signer is in the committee.
             if !committee_lookback.is_committee_member(signer) {
                 bail!("Signer {signer} is not in the committee for round {round} {gc_log}")

--- a/node/bft/src/helpers/telemetry.rs
+++ b/node/bft/src/helpers/telemetry.rs
@@ -164,10 +164,7 @@ impl<N: Network> CertificateMetadata<N> {
     /// Derives the telemetry metadata for the given certificate.
     fn new(certificate: &BatchCertificate<N>) -> Self {
         let author = certificate.author();
-        let signers = [author]
-            .into_iter()
-            .chain(certificate.signatures().map(|signature| signature.to_address()))
-            .collect::<Vec<_>>();
+        let signers = [author].into_iter().chain(certificate.signers().iter().copied()).collect::<Vec<_>>();
 
         Self { round: certificate.round(), id: certificate.id(), author, signers }
     }


### PR DESCRIPTION
Follow-on to [ProvableHQ/snarkVM#3364](https://github.com/ProvableHQ/snarkVM/pull/3364), which caches the recovered signer addresses on `BatchCertificate` and exposes them as `signers()`.

Recovering a signer's address from its signature is not the cheap accessor it looks like: `Signature::to_address` -> `ComputeKey::to_address` performs a fixed-base scalar multiplication, measured at ~39us per signature at opt-level=2.

Before the snarkVM change, the same address was derived about five times per signature on the incoming-certificate path: twice inside `BatchCertificate::from`, and three more times here in snarkOS. That PR removed the first two. This one turns the remaining three into cache reads:

- `CertificateMetadata::new` (`node/bft/src/helpers/telemetry.rs`)
- `check_incoming_certificate` (`node/bft/src/helpers/storage.rs`)
- `check_certificate` (`node/bft/src/helpers/storage.rs`)

`check_incoming_certificate` and `check_certificate` run back to back on every received certificate — `primary.rs` calls the former, then `insert_certificate` calls the latter — so a received certificate previously paid full address recovery twice and now pays zero times.

### Notes

- No bump commit. Staging already pins snarkVM `e0f68fae`, which contains SnarkVM #3364, so this is code-only: no `Cargo.toml` or `Cargo.lock` changes.
- No behavior change. `signers()` returns the same addresses the old code derived, in the same order, and continues to exclude the author — both call sites still insert the author explicitly.
- The two remaining `to_address()` calls in `node/` (`signed_proposals.rs:36`, `primary.rs:1180`) are on a standalone `BatchSignature`, not a `BatchCertificate`, so the cache does not apply to them.

### Testing

`cargo check -p snarkos-node-bft` passes clean against staging's current snarkVM pin.
