### PR TITLE
feat(bft): instrument the gateway's outbound queue and rate limiter

### DIFF
--- a/node/bft/Cargo.toml
+++ b/node/bft/Cargo.toml
@@ -32,7 +32,8 @@ metrics = [
   "dep:snarkos-node-metrics",
   "snarkos-node-bft-events/metrics",
   "snarkos-node-bft-ledger-service/metrics",
-  "snarkos-node-network/metrics"
+  "snarkos-node-network/metrics",
+  "snarkos-node-tcp/metrics"
 ]
 cuda = [
   "snarkvm/cuda",

--- a/node/bft/src/gateway.rs
+++ b/node/bft/src/gateway.rs
@@ -228,6 +228,9 @@ pub struct InnerGateway<N: Network> {
     resolver: RwLock<Resolver<N>>,
     /// The collection of both candidate and connected peers.
     peer_pool: RwLock<HashMap<SocketAddr, Peer<N>>>,
+    /// The deepest per-connection outbound queue seen since the node started, across all peers.
+    #[cfg(feature = "metrics")]
+    outbound_queue_high_water_mark: std::sync::atomic::AtomicUsize,
     /// The handle to the validator telemetry tracker.
     #[cfg(feature = "metrics")]
     validator_telemetry: Telemetry<N>,
@@ -343,6 +346,8 @@ impl<N: Network> Gateway<N> {
             cache: Default::default(),
             resolver: Default::default(),
             peer_pool: RwLock::new(initial_peers),
+            #[cfg(feature = "metrics")]
+            outbound_queue_high_water_mark: Default::default(),
             #[cfg(feature = "metrics")]
             validator_telemetry,
             #[cfg(feature = "metrics")]
@@ -593,6 +598,35 @@ impl<N: Network> Gateway<N> {
         if let Some(count) = self.number_of_connecting_peers() {
             metrics::gauge(metrics::bft::CONNECTING, count as f64);
         }
+        self.update_outbound_queue_metrics();
+    }
+
+    /// Samples the occupancy of every per-connection outbound queue.
+    ///
+    /// The high-water mark this publishes is maintained by [`Self::send_inner`], not by this
+    /// sampler: a queue that fills and drains between two ticks is invisible here.
+    #[cfg(feature = "metrics")]
+    fn update_outbound_queue_metrics(&self) {
+        let mut deepest = 0;
+        for (_peer_addr, depth, _capacity) in self.outbound_queue_occupancies() {
+            metrics::histogram(metrics::bft::GATEWAY_OUTBOUND_QUEUE_DEPTH, depth as f64);
+            deepest = deepest.max(depth);
+        }
+        metrics::gauge(metrics::bft::GATEWAY_OUTBOUND_QUEUE_DEPTH_MAX, deepest as f64);
+        metrics::gauge(metrics::bft::GATEWAY_OUTBOUND_QUEUE_CAPACITY, per_connection_queue_depth::<N>() as f64);
+        metrics::gauge(
+            metrics::bft::GATEWAY_OUTBOUND_QUEUE_HIGH_WATER_MARK,
+            self.outbound_queue_high_water_mark.load(std::sync::atomic::Ordering::Relaxed) as f64,
+        );
+    }
+
+    /// Raises the outbound queue high-water mark to the current depth of the given peer's queue,
+    /// if that is a new maximum.
+    #[cfg(feature = "metrics")]
+    fn record_outbound_queue_depth(&self, peer_addr: SocketAddr) {
+        if let Some((depth, _capacity)) = self.outbound_queue_occupancy(peer_addr) {
+            self.outbound_queue_high_water_mark.fetch_max(depth, std::sync::atomic::Ordering::Relaxed);
+        }
     }
 
     /// Inserts the given peer into the connected peers. This is only used in testing.
@@ -624,6 +658,8 @@ impl<N: Network> Gateway<N> {
         // Resolve the listener IP to the (ambiguous) peer address.
         let Some(peer_addr) = self.resolve_to_ambiguous(peer_ip) else {
             warn!("Unable to resolve the listener IP address '{peer_ip}'");
+            #[cfg(feature = "metrics")]
+            metrics::increment_counter_label(metrics::bft::GATEWAY_SEND_FAILURES, "reason", "unresolved");
             return None;
         };
         // Retrieve the event name.
@@ -632,10 +668,29 @@ impl<N: Network> Gateway<N> {
         trace!("{CONTEXT} Sending '{name}' to '{peer_ip}'");
         let result = self.unicast(peer_addr, event);
         // If the event was unable to be sent, disconnect.
-        if let Err(err) = &result {
-            warn!("{CONTEXT} Failed to send '{name}' to '{peer_ip}': {err:?}");
-            debug!("{CONTEXT} Disconnecting from '{peer_ip}' (unable to send)");
-            self.disconnect(peer_ip);
+        match &result {
+            Ok(_) => {
+                #[cfg(feature = "metrics")]
+                self.record_outbound_queue_depth(peer_addr);
+            }
+            Err(err) => {
+                #[cfg(feature = "metrics")]
+                metrics::increment_counter_label(
+                    metrics::bft::GATEWAY_SEND_FAILURES,
+                    "reason",
+                    send_failure_reason(err),
+                );
+                if err.kind() == io::ErrorKind::WouldBlock {
+                    warn!(
+                        "{CONTEXT} Failed to send '{name}' to '{peer_ip}': the outbound queue is full ({} slots)",
+                        per_connection_queue_depth::<N>()
+                    );
+                } else {
+                    warn!("{CONTEXT} Failed to send '{name}' to '{peer_ip}': {err:?}");
+                }
+                debug!("{CONTEXT} Disconnecting from '{peer_ip}' (unable to send)");
+                self.disconnect(peer_ip);
+            }
         }
         result.ok()
     }
@@ -1357,6 +1412,81 @@ impl<N: Network> Gateway<N> {
     }
 }
 
+/// Classifies an error from [`Writing::unicast`] into a stable label for
+/// [`metrics::bft::GATEWAY_SEND_FAILURES`].
+#[cfg(feature = "metrics")]
+fn send_failure_reason(err: &io::Error) -> &'static str {
+    match err.kind() {
+        // The per-connection outbound queue is at capacity.
+        io::ErrorKind::WouldBlock => "queue_full",
+        // The connection's writer task has already exited.
+        io::ErrorKind::BrokenPipe => "writer_gone",
+        // There is no outbound queue for this peer.
+        io::ErrorKind::NotConnected => "not_connected",
+        // `enable_writing` has not been called.
+        io::ErrorKind::Unsupported => "writing_disabled",
+        _ => "other",
+    }
+}
+
+/// Holds [`metrics::bft::GATEWAY_SENDS_IN_FLIGHT`] up for the lifetime of one
+/// [`Transport::send`] call.
+///
+/// Almost every caller of `Transport::send` spawns a task per event and drops the join handle, so
+/// this gauge is also the number of outstanding send tasks.
+#[cfg(feature = "metrics")]
+struct InFlightSendGuard;
+
+#[cfg(feature = "metrics")]
+impl InFlightSendGuard {
+    fn new() -> Self {
+        metrics::increment_gauge(metrics::bft::GATEWAY_SENDS_IN_FLIGHT, 1f64);
+        Self
+    }
+}
+
+#[cfg(feature = "metrics")]
+impl Drop for InFlightSendGuard {
+    fn drop(&mut self) {
+        metrics::decrement_gauge(metrics::bft::GATEWAY_SENDS_IN_FLIGHT, 1f64);
+    }
+}
+
+/// Accounts for one send parked in the outbound rate limiter's retry loop: it holds
+/// [`metrics::bft::GATEWAY_SENDS_RATE_LIMITED`] up while it lives, and records the total wait on
+/// drop.
+///
+/// A send parked in that loop is typically running in a spawned task whose join handle was
+/// dropped, so it can be cancelled at any await point. Doing this on drop rather than after the
+/// loop keeps the gauge balanced, and the wait recorded, when that happens.
+#[cfg(feature = "metrics")]
+struct RateLimitWaitGuard {
+    limit: &'static str,
+    start: std::time::Instant,
+}
+
+#[cfg(feature = "metrics")]
+impl RateLimitWaitGuard {
+    fn new(limit: &'static str) -> Self {
+        metrics::increment_gauge(metrics::bft::GATEWAY_SENDS_RATE_LIMITED, 1f64);
+        metrics::increment_counter_label(metrics::bft::GATEWAY_RATE_LIMITED_SENDS, "limit", limit);
+        Self { limit, start: std::time::Instant::now() }
+    }
+}
+
+#[cfg(feature = "metrics")]
+impl Drop for RateLimitWaitGuard {
+    fn drop(&mut self) {
+        metrics::decrement_gauge(metrics::bft::GATEWAY_SENDS_RATE_LIMITED, 1f64);
+        metrics::histogram_label(
+            metrics::bft::GATEWAY_RATE_LIMIT_DELAY,
+            "limit",
+            self.limit.to_string(),
+            self.start.elapsed().as_secs_f64(),
+        );
+    }
+}
+
 #[async_trait]
 impl<N: Network> Transport<N> for Gateway<N> {
     /// Sends the given event to specified peer.
@@ -1367,6 +1497,9 @@ impl<N: Network> Transport<N> for Gateway<N> {
     /// without waiting for the actual delivery; instead, the caller is provided with a [`oneshot::Receiver`]
     /// which can be used to determine when and whether the event has been delivered.
     async fn send(&self, peer_ip: SocketAddr, mut event: Event<N>) -> Option<oneshot::Receiver<io::Result<()>>> {
+        #[cfg(feature = "metrics")]
+        let _in_flight = InFlightSendGuard::new();
+
         // Serialize the payload here, rather than leaving it for the connection's writer task.
         //
         // `Data` defers serialization until the event is written to the stream, which puts it on
@@ -1393,12 +1526,22 @@ impl<N: Network> Transport<N> for Gateway<N> {
         }
 
         macro_rules! send {
-            ($self:ident, $cache_map:ident, $interval:expr, $freq:ident) => {{
+            ($self:ident, $cache_map:ident, $interval:expr, $freq:ident, $limit:literal) => {{
+                // Present only while this send is parked in the loop below.
+                #[cfg(feature = "metrics")]
+                let mut wait = None;
                 // Rate limit the number of certificate requests sent to the peer.
                 while $self.cache.$cache_map(peer_ip, $interval) > $self.$freq() {
+                    #[cfg(feature = "metrics")]
+                    {
+                        wait.get_or_insert_with(|| RateLimitWaitGuard::new($limit));
+                        metrics::increment_counter_label(metrics::bft::GATEWAY_RATE_LIMIT_SLEEPS, "limit", $limit);
+                    }
                     // Sleep for a short period of time to allow the cache to clear.
                     tokio::time::sleep(Duration::from_millis(10)).await;
                 }
+                #[cfg(feature = "metrics")]
+                drop(wait);
                 // Send the event to the peer.
                 $self.send_inner(peer_ip, event)
             }};
@@ -1410,23 +1553,35 @@ impl<N: Network> Transport<N> for Gateway<N> {
                 // Update the outbound event cache. This is necessary to ensure we don't under count the outbound events.
                 self.cache.insert_outbound_event(peer_ip, CACHE_EVENTS_INTERVAL);
                 // Send the event to the peer.
-                send!(self, insert_outbound_certificate, CACHE_REQUESTS_INTERVAL, max_cache_certificates)
+                send!(
+                    self,
+                    insert_outbound_certificate,
+                    CACHE_REQUESTS_INTERVAL,
+                    max_cache_certificates,
+                    "certificates"
+                )
             }
             Event::TransmissionRequest(_) | Event::TransmissionResponse(_) => {
                 // Update the outbound event cache. This is necessary to ensure we don't under count the outbound events.
                 self.cache.insert_outbound_event(peer_ip, CACHE_EVENTS_INTERVAL);
                 // Send the event to the peer.
-                send!(self, insert_outbound_transmission, CACHE_REQUESTS_INTERVAL, max_cache_transmissions)
+                send!(
+                    self,
+                    insert_outbound_transmission,
+                    CACHE_REQUESTS_INTERVAL,
+                    max_cache_transmissions,
+                    "transmissions"
+                )
             }
             Event::BlockRequest(request) => {
                 // Insert the outbound request so we can match it to responses.
                 self.cache.insert_outbound_block_request(peer_ip, request);
                 // Send the event to the peer and update the outbound event cache, use the general rate limit.
-                send!(self, insert_outbound_event, CACHE_EVENTS_INTERVAL, max_cache_events)
+                send!(self, insert_outbound_event, CACHE_EVENTS_INTERVAL, max_cache_events, "block_request")
             }
             _ => {
                 // Send the event to the peer, use the general rate limit.
-                send!(self, insert_outbound_event, CACHE_EVENTS_INTERVAL, max_cache_events)
+                send!(self, insert_outbound_event, CACHE_EVENTS_INTERVAL, max_cache_events, "events")
             }
         }
     }

--- a/node/metrics/src/lib.rs
+++ b/node/metrics/src/lib.rs
@@ -202,6 +202,11 @@ pub fn gauge_label<V: Into<f64>>(name: &'static str, label_key: &'static str, la
     ::metrics::gauge!(name, label_key => label_value).set(value.into());
 }
 
+/// Increments a labelled counter with the given name by one.
+pub fn increment_counter_label(name: &'static str, label_key: &'static str, label_value: &'static str) {
+    ::metrics::counter!(name, label_key => label_value).increment(1);
+}
+
 // Include the generated build information
 mod built_info {
     include!(concat!(env!("OUT_DIR"), "/built.rs"));

--- a/node/metrics/src/names.rs
+++ b/node/metrics/src/names.rs
@@ -13,10 +13,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub(super) const COUNTER_NAMES: [&str; 3] =
-    [bft::LEADERS_ELECTED, consensus::STALE_UNCONFIRMED_TRANSACTIONS, consensus::STALE_UNCONFIRMED_SOLUTIONS];
+pub(super) const COUNTER_NAMES: [&str; 5] = [
+    bft::LEADERS_ELECTED,
+    consensus::STALE_UNCONFIRMED_TRANSACTIONS,
+    consensus::STALE_UNCONFIRMED_SOLUTIONS,
+    tcp::WRITE_TIMEOUT_DISCONNECTS,
+    tcp::WRITE_ERROR_DISCONNECTS,
+];
 
-pub(super) const GAUGE_NAMES: [&str; 28] = [
+pub(super) const GAUGE_NAMES: [&str; 33] = [
     bft::CONNECTED,
     bft::CONNECTED_STAKE,
     bft::CONNECTED_STAKE_WITH_MATCHING_SHA,
@@ -27,6 +32,11 @@ pub(super) const GAUGE_NAMES: [&str; 28] = [
     bft::HEIGHT,
     bft::LAST_COMMITTED_ROUND,
     bft::IS_SYNCED,
+    bft::GATEWAY_OUTBOUND_QUEUE_CAPACITY,
+    bft::GATEWAY_OUTBOUND_QUEUE_DEPTH_MAX,
+    bft::GATEWAY_OUTBOUND_QUEUE_HIGH_WATER_MARK,
+    bft::GATEWAY_SENDS_IN_FLIGHT,
+    bft::GATEWAY_SENDS_RATE_LIMITED,
     blocks::SOLUTIONS,
     blocks::TRANSACTIONS,
     blocks::ACCEPTED_DEPLOY,
@@ -47,10 +57,11 @@ pub(super) const GAUGE_NAMES: [&str; 28] = [
     tcp::QUEUED_INBOUND_MESSAGES,
 ];
 
-pub(super) const HISTOGRAM_NAMES: [&str; 9] = [
+pub(super) const HISTOGRAM_NAMES: [&str; 10] = [
     bft::COMMIT_ROUNDS_LATENCY,
     bft::COMMIT_LEADER_CERTIFICATE_LATENCY,
     bft::BATCH_CERTIFICATION_LATENCY,
+    bft::GATEWAY_OUTBOUND_QUEUE_DEPTH,
     consensus::CERTIFICATE_COMMIT_LATENCY,
     consensus::BLOCK_LATENCY,
     consensus::BLOCK_LAG,
@@ -74,6 +85,33 @@ pub mod bft {
     pub const HEIGHT: &str = "snarkos_bft_height_total";
     pub const LAST_COMMITTED_ROUND: &str = "snarkos_bft_last_committed_round";
     pub const IS_SYNCED: &str = "snarkos_bft_is_synced";
+
+    /// The depth of the per-connection queue used to send outbound messages, sampled once per
+    /// peer per metrics tick.
+    pub const GATEWAY_OUTBOUND_QUEUE_DEPTH: &str = "snarkos_bft_gateway_outbound_queue_depth";
+    /// The deepest per-connection outbound queue at the most recent metrics tick.
+    pub const GATEWAY_OUTBOUND_QUEUE_DEPTH_MAX: &str = "snarkos_bft_gateway_outbound_queue_depth_max";
+    /// The deepest per-connection outbound queue observed since the node started, measured at
+    /// every send rather than sampled.
+    pub const GATEWAY_OUTBOUND_QUEUE_HIGH_WATER_MARK: &str = "snarkos_bft_gateway_outbound_queue_high_water_mark";
+    /// The capacity of each per-connection outbound queue, i.e. the depth at which a send fails
+    /// and the peer is disconnected.
+    pub const GATEWAY_OUTBOUND_QUEUE_CAPACITY: &str = "snarkos_bft_gateway_outbound_queue_capacity";
+    /// Outbound sends that could not be queued, labelled by `reason`. The `queue_full` label is
+    /// the per-connection outbound queue being at capacity.
+    pub const GATEWAY_SEND_FAILURES: &str = "snarkos_bft_gateway_send_failures_total";
+    /// Outbound sends that entered the rate limiter's retry loop, labelled by `limit`.
+    pub const GATEWAY_RATE_LIMITED_SENDS: &str = "snarkos_bft_gateway_rate_limited_sends_total";
+    /// Iterations of the rate limiter's retry loop, labelled by `limit`. Each iteration is one
+    /// backoff sleep.
+    pub const GATEWAY_RATE_LIMIT_SLEEPS: &str = "snarkos_bft_gateway_rate_limit_sleeps_total";
+    /// Time an outbound send spent in the rate limiter's retry loop, labelled by `limit`.
+    pub const GATEWAY_RATE_LIMIT_DELAY: &str = "snarkos_bft_gateway_rate_limit_delay_secs";
+    /// Outbound sends currently in `Transport::send`. Nearly every call site spawns a task per
+    /// send, so this is also the number of outstanding send tasks.
+    pub const GATEWAY_SENDS_IN_FLIGHT: &str = "snarkos_bft_gateway_sends_in_flight";
+    /// Outbound sends currently parked in the rate limiter's retry loop.
+    pub const GATEWAY_SENDS_RATE_LIMITED: &str = "snarkos_bft_gateway_sends_rate_limited";
 }
 
 pub mod blocks {
@@ -128,6 +166,10 @@ pub mod tcp {
     /// The number of inbound messages that have been read off a socket and are waiting to be
     /// processed, across all connections.
     pub const QUEUED_INBOUND_MESSAGES: &str = "snarkos_tcp_queued_inbound_messages";
+    /// Connections dropped because a single write to the socket exceeded `Writing::TIMEOUT`.
+    pub const WRITE_TIMEOUT_DISCONNECTS: &str = "snarkos_tcp_write_timeout_disconnects_total";
+    /// Connections dropped because a write to the socket failed for any other reason.
+    pub const WRITE_ERROR_DISCONNECTS: &str = "snarkos_tcp_write_error_disconnects_total";
 }
 
 pub mod build {

--- a/node/tcp/src/protocols/writing.rs
+++ b/node/tcp/src/protocols/writing.rs
@@ -115,7 +115,9 @@ where
     ///
     /// The following errors can be returned:
     /// - [`io::ErrorKind::NotConnected`] if the node is not connected to the provided address
-    /// - [`io::ErrorKind::Other`] if the outbound message queue for this address is full
+    /// - [`io::ErrorKind::WouldBlock`] if the outbound message queue for this address is full
+    /// - [`io::ErrorKind::BrokenPipe`] if the outbound message queue for this address is closed,
+    ///   i.e. the connection's writer task has already exited
     /// - [`io::ErrorKind::Unsupported`] if [`Writing::enable_writing`] hadn't been called yet
     fn unicast(&self, addr: SocketAddr, message: Self::Message) -> io::Result<oneshot::Receiver<io::Result<()>>> {
         // access the protocol handler
@@ -128,7 +130,10 @@ where
                     .map_err(|e| {
                         let conn_span = create_connection_span(addr, self.tcp().span());
                         error!(parent: conn_span, "can't send a message: {e}");
-                        io::ErrorKind::Other.into()
+                        match e {
+                            mpsc::error::TrySendError::Full(_) => io::Error::from(io::ErrorKind::WouldBlock),
+                            mpsc::error::TrySendError::Closed(_) => io::Error::from(io::ErrorKind::BrokenPipe),
+                        }
                     })
                     .map(|_| delivery)
             } else {
@@ -137,6 +142,36 @@ where
         } else {
             Err(io::ErrorKind::Unsupported.into())
         }
+    }
+
+    /// Returns the current occupancy of the outbound message queue for the given address, as a
+    /// `(depth, capacity)` pair, or `None` if the node is not connected to it.
+    ///
+    /// The capacity is [`Writing::message_queue_depth`] as it was when the connection was
+    /// established; a send that finds the queue at capacity fails with
+    /// [`io::ErrorKind::WouldBlock`].
+    fn outbound_queue_occupancy(&self, addr: SocketAddr) -> Option<(usize, usize)> {
+        let handler = self.tcp().protocols.writing.get()?;
+        let senders = handler.senders.read();
+        let sender = senders.get(&addr)?;
+        let capacity = sender.max_capacity();
+        Some((capacity.saturating_sub(sender.capacity()), capacity))
+    }
+
+    /// Returns the current occupancy of every outbound message queue, keyed by address. See
+    /// [`Writing::outbound_queue_occupancy`].
+    fn outbound_queue_occupancies(&self) -> Vec<(SocketAddr, usize, usize)> {
+        let Some(handler) = self.tcp().protocols.writing.get() else {
+            return Vec::new();
+        };
+        let senders = handler.senders.read();
+        senders
+            .iter()
+            .map(|(addr, sender)| {
+                let capacity = sender.max_capacity();
+                (*addr, capacity.saturating_sub(sender.capacity()), capacity)
+            })
+            .collect()
     }
 
     /// Broadcasts the provided message to all connected peers. Returns as soon as the message is queued to
@@ -253,6 +288,12 @@ impl<W: Writing> WritingInternal for W {
                     }
                     Err(e) => {
                         error!(parent: &conn_span, "couldn't send a message: {e}");
+                        #[cfg(feature = "metrics")]
+                        if e.kind() == io::ErrorKind::TimedOut {
+                            metrics::increment_counter(metrics::tcp::WRITE_TIMEOUT_DISCONNECTS);
+                        } else {
+                            metrics::increment_counter(metrics::tcp::WRITE_ERROR_DISCONNECTS);
+                        }
                         let _ = wrapped_msg.delivery_notification.send(Err(e));
                         break;
                     }
@@ -382,6 +423,62 @@ mod tests {
         let peer = *sender.tcp().connected_addrs().first().unwrap();
         flood(&sender, peer);
         assert!(disconnected(&sender, peer, Duration::from_secs(10)).await, "stalled peer not disconnected");
+    }
+
+    /// A node whose outbound queue is small enough to fill deterministically in a test.
+    #[derive(Clone)]
+    struct TinyQueueNode(Tcp);
+    impl P2P for TinyQueueNode {
+        fn tcp(&self) -> &Tcp {
+            &self.0
+        }
+    }
+    #[async_trait]
+    impl Writing for TinyQueueNode {
+        type Codec = BytesCodec;
+        type Message = Bytes;
+
+        // Long enough that the writer parks on the stalled socket rather than disconnecting.
+        const TIMEOUT: Duration = Duration::from_secs(60);
+
+        fn codec(&self, _a: SocketAddr, _s: ConnectionSide) -> Self::Codec {
+            Default::default()
+        }
+
+        fn message_queue_depth(&self) -> usize {
+            4
+        }
+    }
+
+    #[tokio::test]
+    async fn full_outbound_queue_is_reported_as_would_block() {
+        let sender = TinyQueueNode(Tcp::new(test_config()));
+        sender.tcp().enable_listener().await.unwrap();
+        sender.enable_writing().await;
+        let receiver = Tcp::new(test_config());
+        let ip = receiver.enable_listener().await.unwrap();
+        sender.tcp().connect(ip).await.unwrap();
+        let peer = *sender.tcp().connected_addrs().first().unwrap();
+
+        assert_eq!(sender.outbound_queue_occupancy(peer), Some((0, 4)));
+        let unconnected = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 1);
+        assert_eq!(sender.outbound_queue_occupancy(unconnected), None);
+
+        // The receiver never reads its socket, so the writer task stalls and the queue fills.
+        let msg = Bytes::from(vec![0u8; 1024 * 1024]);
+        let mut err = None;
+        for _ in 0..64 {
+            if let Err(e) = sender.unicast(peer, msg.clone()) {
+                err = Some(e);
+                break;
+            }
+        }
+        let err = err.expect("the outbound queue never filled");
+        assert_eq!(err.kind(), io::ErrorKind::WouldBlock);
+
+        let (depth, capacity) = sender.outbound_queue_occupancy(peer).unwrap();
+        assert_eq!(capacity, 4);
+        assert!(depth > 0, "a queue that just rejected a message should not be reported as empty");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Motivation

Closes #4427.

Review of #4394 stalled on a question nobody could answer from the code: do we ever actually hit the outbound rate limits, and is `send_inner`'s disconnect-on-full-queue a live path or a theoretical one? The derivation says the queue fills long before the limiter engages -- 400,000 permitted sends per 2-second window into a queue holding 12,240 slots -- but that is a derivation, not a measurement, and two significant decisions rest on it: whether to delete the rate limiter (#4429), and whether to retry instead of disconnecting (#4431).

This is measurement only; no send, disconnect or rate-limiting behaviour changes. It should land before those decisions so they are made on data.

* Outbound queue occupancy. `Writing` gains `outbound_queue_occupancy` and `outbound_queue_occupancies`, which read depth and capacity straight off the per-connection `mpsc::Sender`. The gateway's existing 1 Hz metrics loop samples every peer into a histogram and publishes the current maximum and the queue capacity, so the ratio against `per_connection_queue_depth()` is a PromQL expression. A queue that fills and drains between two ticks would be invisible to a sampler, so the high-water mark is instead maintained by `send_inner` on every successful send, where it costs one relaxed `fetch_max`.
* Queue-full disconnects. `unicast` collapsed `TrySendError::Full` and every other failure into `io::ErrorKind::Other`, so backpressure disconnects could not be told apart from any other cause. `Full` now maps to `WouldBlock` and `Closed` to `BrokenPipe`, and `send_inner` counts failures by reason. No caller matched on the old kind. The queue-full warning also now names the queue depth, since that case is finally distinguishable in the logs.
* Rate-limiter engagement. The `send!` macro takes a label for its limit class and counts sends that enter the retry loop at all, iterations of that loop, and the total wait, broken down by `certificates`, `transmissions`, `events` and `block_request` -- the last shares the general limit but is counted apart, as it is the path the sync layer drives. The accounting is a drop guard rather than a pair of statements around the loop: these sends run in spawned tasks whose join handles are dropped at the call site (#4428), so they can be cancelled at any await point, and a cancelled send would otherwise leak the gauge and lose its wait.
* Outstanding send tasks. A gauge held for the lifetime of each `Transport::send` call. Nearly every call site spawns one task per event, so this is the count the issue asks for, without having to instrument roughly fifteen spawn sites individually and keep them in sync.
* Write-timeout disconnects. The `node/tcp` writer task now separates `Writing::TIMEOUT` expiry from other write failures, so Mechanism B can be told apart from Mechanism A in production data. `snarkos-node-bft`'s `metrics` feature now enables `snarkos-node-tcp/metrics` so the two arrive together.

Test plan: `full_outbound_queue_is_reported_as_would_block` covers the one externally visible change, that a full queue is now reported as `WouldBlock` and that occupancy tracks it. `cargo test -p snarkos-node-tcp --lib` and `cargo test -p snarkos-node-bft --lib` pass, and clippy is clean for the touched crates both with and without the `metrics` feature.

## Test Plan

This is non-functional change, but we can test it using a local devnet

## Backwards compatibility

This doesn't change any existing metrics, and none of the existing metrics overlap this