### PR TITLE
fix(tcp): stop the inbound queue gauge from drifting upward forever

### DIFF
--- a/node/metrics/snarkOS-grafana.json
+++ b/node/metrics/snarkOS-grafana.json
@@ -2272,7 +2272,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "snarkos_tcp_tasks_total",
+          "expr": "snarkos_tcp_queued_inbound_messages",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,

--- a/node/metrics/src/names.rs
+++ b/node/metrics/src/names.rs
@@ -44,7 +44,7 @@ pub(super) const GAUGE_NAMES: [&str; 28] = [
     router::CONNECTED,
     router::CANDIDATE,
     router::RESTRICTED,
-    tcp::TCP_TASKS,
+    tcp::QUEUED_INBOUND_MESSAGES,
 ];
 
 pub(super) const HISTOGRAM_NAMES: [&str; 9] = [
@@ -125,7 +125,9 @@ pub mod router {
 }
 
 pub mod tcp {
-    pub const TCP_TASKS: &str = "snarkos_tcp_tasks_total";
+    /// The number of inbound messages that have been read off a socket and are waiting to be
+    /// processed, across all connections.
+    pub const QUEUED_INBOUND_MESSAGES: &str = "snarkos_tcp_queued_inbound_messages";
 }
 
 pub mod build {

--- a/node/tcp/src/protocols/reading.rs
+++ b/node/tcp/src/protocols/reading.rs
@@ -221,8 +221,6 @@ impl<R: Reading> ReadingInternal for R {
                             warn_about_dropped_messages(&conn_span, &mut dropped_count, &mut last_drop_log);
                             debug!(parent: &conn_span, "the inbound queue is no longer saturated");
                         }
-                        #[cfg(feature = "metrics")]
-                        metrics::increment_gauge(metrics::tcp::TCP_TASKS, 1f64);
                     }
                     Some(Err(e)) => {
                         error!(parent: &conn_span, "can't read: {e}");
@@ -294,16 +292,19 @@ impl<D: Decoder> Decoder for CountingCodec<D> {
     }
 }
 
-/// Decrements the TCP_TASKS gauge on drop. Paired with each queued message so the gauge stays
-/// balanced whether the message is processed normally or discarded when the inbound channel is
-/// dropped (e.g. on connection abort). The caller must hold this guard until processing is
-/// complete; dropping it earlier will decrement the gauge prematurely.
+/// Maintains the [`metrics::tcp::QUEUED_INBOUND_MESSAGES`] gauge. Paired with each queued message
+/// so the gauge stays balanced whether the message is processed normally or discarded when the
+/// inbound channel is dropped (e.g. on connection abort). The caller must hold this guard until
+/// processing is complete; dropping it earlier will decrement the gauge prematurely.
+///
+/// This is the only thing that may touch the gauge: a second increment anywhere else makes it
+/// drift upward forever, since nothing else decrements it.
 struct QueuedMessageGuard;
 
 impl QueuedMessageGuard {
     fn new() -> Self {
         #[cfg(feature = "metrics")]
-        metrics::increment_gauge(metrics::tcp::TCP_TASKS, 1f64);
+        metrics::increment_gauge(metrics::tcp::QUEUED_INBOUND_MESSAGES, 1f64);
         Self
     }
 }
@@ -311,7 +312,7 @@ impl QueuedMessageGuard {
 impl Drop for QueuedMessageGuard {
     fn drop(&mut self) {
         #[cfg(feature = "metrics")]
-        metrics::decrement_gauge(metrics::tcp::TCP_TASKS, 1f64);
+        metrics::decrement_gauge(metrics::tcp::QUEUED_INBOUND_MESSAGES, 1f64);
     }
 }
 


### PR DESCRIPTION
## Motivation

`snarkos_tcp_tasks_total` is incremented twice per inbound message and decremented once, so it climbs monotonically at the inbound message rate and never comes back down. It does not report a queue depth; it reports roughly "messages ever received". The Grafana panel that plots it, titled "TCP Queue Depth", has been drawing a ramp rather than a depth.

How it got there. The gauge was added in 93660f2a0 with a matched pair: an increment where the message is enqueued in the reader loop, and a decrement where the processing loop dequeues it. 0c8b839aa then replaced that pair with `QueuedMessageGuard`, so that a message discarded without being processed is also counted -- deleting both of the original statements. The two designs were each correct, and each balanced.

They then met in the merge 214299c2e, whose two parents held one design each. The resolution kept the old design's increment alongside the new design's guard, while the old design's decrement stayed deleted. Neither parent was wrong; the merge produced a line neither of them had. The gauge has been unbalanced since.

The fix is to delete the resurrected increment, leaving `QueuedMessageGuard` as the only thing that touches the gauge -- which is what makes it balanced by construction, so its doc comment now says so.

Renaming it while we are here. `snarkos_tcp_tasks_total` misdescribes the metric twice over: it counts queued messages, not tasks, and the `_total` suffix is the Prometheus convention for a monotonic counter, which this gauge was only ever accidentally behaving as. It becomes `snarkos_tcp_queued_inbound_messages`, and the constant becomes `tcp::QUEUED_INBOUND_MESSAGES`. The Grafana dashboard's query is updated to match. (note, i'm not sure how this is actually synced to anything or if it is just stale)

Operators with their own dashboards or alerts on `snarkos_tcp_tasks_total` need to update them: the series is renamed, and its values change shape from a ramp to a depth that sits near zero in steady state.

## Test Plan

do an actual deployment with metrics

## Backwards compatibility

Just a metrics fixup