### PR TITLE
build: disable incremental compilation for the release and bench profiles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -406,7 +406,7 @@ version = "2"
 [profile.release]
 opt-level = 3
 lto = "thin"
-incremental = true
+incremental = false
 # uncomment the 2 lines below when building with the locktick feature or use the `release-locktick` profile
 # debug = "line-tables-only"
 # strip = "none"
@@ -421,7 +421,7 @@ opt-level = 3
 debug = false
 rpath = false
 lto = "thin"
-incremental = true
+incremental = false
 debug-assertions = false
 
 [profile.dev]


### PR DESCRIPTION
## Motivation

Mirrors ProvableHQ/snarkVM#3402, which made the same change to snarkVM's workspace profiles.

See there for rationale

## Test Plan

Manifest-only change; CI's release build exercises it.