### PR TITLE
perf(bft): isolate block construction on a dedicated rayon pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5254,6 +5254,7 @@ dependencies = [
  "async-trait",
  "indexmap 2.14.0",
  "locktick",
+ "num_cpus",
  "parking_lot",
  "rand 0.10.2",
  "rayon",

--- a/node/bft/ledger-service/Cargo.toml
+++ b/node/bft/ledger-service/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2024"
 
 [features]
 default = [ ]
-ledger = [ "parking_lot", "rand", "rayon", "tokio", "tracing" ]
+ledger = [ "num_cpus", "parking_lot", "rand", "rayon", "tokio", "tracing" ]
 ledger-write = [ ]
 locktick = [
   "dep:locktick",
@@ -57,6 +57,10 @@ optional = true
 
 [dependencies.snarkos-utilities]
 workspace = true
+
+[dependencies.num_cpus]
+workspace = true
+optional = true
 
 [dependencies.parking_lot]
 workspace = true

--- a/node/bft/ledger-service/src/ledger.rs
+++ b/node/bft/ledger-service/src/ledger.rs
@@ -69,6 +69,29 @@ use rayon::prelude::*;
 
 use std::{fmt, ops::Range, sync::Arc};
 
+/// Stack size for the block-prep rayon pool, matching the process-wide pool in `cli`.
+const BLOCK_PREP_STACK_SIZE: usize = 8 * 1024 * 1024;
+
+/// Returns the shared block-prep rayon pool, creating it on first use.
+///
+/// Sized to half the logical cores so proposal-time work (`check_transaction_basic`,
+/// deserialization, etc.) can still run on the process-wide pool.
+fn block_prep_thread_pool() -> Arc<rayon::ThreadPool> {
+    static POOL: std::sync::OnceLock<Arc<rayon::ThreadPool>> = std::sync::OnceLock::new();
+    POOL.get_or_init(|| {
+        let num_threads = (num_cpus::get() / 2).max(1);
+        Arc::new(
+            rayon::ThreadPoolBuilder::new()
+                .thread_name(|index| format!("block-prep-{index}"))
+                .stack_size(BLOCK_PREP_STACK_SIZE)
+                .num_threads(num_threads)
+                .build()
+                .expect("Failed to build the block-prep rayon thread pool"),
+        )
+    })
+    .clone()
+}
+
 /// A core ledger service.
 #[allow(clippy::type_complexity)]
 pub struct CoreLedgerService<N: Network, C: ConsensusStorage<N>> {
@@ -76,12 +99,16 @@ pub struct CoreLedgerService<N: Network, C: ConsensusStorage<N>> {
     latest_leader: Arc<RwLock<Option<(u64, Address<N>)>>>,
     stoppable: Arc<dyn Stoppable>,
     update_lock: Arc<Mutex<()>>,
+    /// Dedicated rayon pool for block construction and next-block checks.
+    /// Nested snarkVM `par_iter` / `execute_with_max_available_threads` inherit this pool via `install`.
+    block_prep_pool: Arc<rayon::ThreadPool>,
 }
 
 /// A transactional update to the ledger.
 #[cfg(feature = "ledger-write")]
 pub struct LedgerUpdate<'a, N: Network, C: ConsensusStorage<N>> {
     ledger: Ledger<N, C>,
+    block_prep_pool: Arc<rayon::ThreadPool>,
     #[cfg(feature = "locktick")]
     _lock: LockGuard<MutexGuard<'a, ()>>,
     #[cfg(not(feature = "locktick"))]
@@ -99,13 +126,19 @@ impl<'a, N: Network, C: ConsensusStorage<N>> LedgerUpdateService<N> for LedgerUp
     }
 
     fn check_block_content(&self, block: PendingBlock<N>) -> Result<Block<N>, CheckBlockError<N>> {
-        self.ledger.check_block_content(block, &mut rand::rng())
+        // Clone the ledger so the closure does not capture `self` (`MutexGuard` is `!Send`).
+        let ledger = self.ledger.clone();
+        self.block_prep_pool.install(move || ledger.check_block_content(block, &mut rand::rng()))
     }
 
     /// Checks the given block is valid next block.
     fn check_next_block(&self, block: Block<N>) -> Result<Block<N>, CheckBlockError<N>> {
-        let pending = self.ledger.check_block_subdag(block, &[])?;
-        self.check_block_content(pending)
+        // Clone the ledger so the closure does not capture `self` (`MutexGuard` is `!Send`).
+        let ledger = self.ledger.clone();
+        self.block_prep_pool.install(move || {
+            let pending = ledger.check_block_subdag(block, &[])?;
+            ledger.check_block_content(pending, &mut rand::rng())
+        })
     }
 
     /// Returns a candidate for the next block in the ledger, using a committed subdag and its transmissions.
@@ -114,7 +147,10 @@ impl<'a, N: Network, C: ConsensusStorage<N>> LedgerUpdateService<N> for LedgerUp
         subdag: Subdag<N>,
         transmissions: IndexMap<TransmissionID<N>, Transmission<N>>,
     ) -> Result<Block<N>, CheckBlockError<N>> {
-        self.ledger.prepare_advance_to_next_quorum_block(subdag, transmissions, &mut rand::rng())
+        // Clone the ledger so the closure does not capture `self` (`MutexGuard` is `!Send`).
+        let ledger = self.ledger.clone();
+        self.block_prep_pool
+            .install(move || ledger.prepare_advance_to_next_quorum_block(subdag, transmissions, &mut rand::rng()))
     }
 
     /// Adds the given block as the next block in the ledger.
@@ -146,7 +182,13 @@ impl<N: Network, C: ConsensusStorage<N>> CoreLedgerService<N, C> {
         #[cfg(feature = "metrics")]
         metrics::gauge(metrics::bft::HEIGHT, ledger.latest_block().height() as f64);
 
-        Self { ledger, latest_leader: Default::default(), stoppable, update_lock: Default::default() }
+        Self {
+            ledger,
+            latest_leader: Default::default(),
+            stoppable,
+            update_lock: Default::default(),
+            block_prep_pool: block_prep_thread_pool(),
+        }
     }
 
     /// Returns the deterministic dev committee for rounds at or after the hotswap start,
@@ -528,7 +570,11 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for CoreLedgerService<
             return Err(BeginLedgerUpdateError::ShuttingDown);
         }
 
-        Ok(Box::new(LedgerUpdate { ledger: self.ledger.clone(), _lock: self.update_lock.lock() }))
+        Ok(Box::new(LedgerUpdate {
+            ledger: self.ledger.clone(),
+            block_prep_pool: self.block_prep_pool.clone(),
+            _lock: self.update_lock.lock(),
+        }))
     }
 
     /// Returns the spend for a transaction in microcredits.
@@ -555,5 +601,14 @@ impl<N: Network, C: ConsensusStorage<N>> LedgerService<N> for CoreLedgerService<
 
     fn is_stopped(&self) -> bool {
         self.stoppable.is_stopped()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn block_prep_pool_uses_half_of_logical_cores() {
+        let pool = super::block_prep_thread_pool();
+        assert_eq!(pool.current_num_threads(), (num_cpus::get() / 2).max(1));
     }
 }


### PR DESCRIPTION
## Summary

- Adds a process-wide block-prep `rayon::ThreadPool` (50% of logical cores, 8 MiB stacks) and stores `Arc<ThreadPool>` on `CoreLedgerService` / `LedgerUpdate`.
- Runs `prepare_advance_to_next_quorum_block`, `check_next_block`, and `check_block_content` inside `pool.install(...)` so nested snarkVM `par_iter` / `execute_with_max_available_threads` inherit that pool instead of saturating the global one.
- Leaves proposal-time work (`check_transaction_basic`, `rayon::spawn_fifo` deserialization, etc.) on the process-wide pool, with the goal of reducing latency variance while a block is being constructed.

@niklaslong @ljedrz — would you be up for running this on a DPS client to evaluate the impact on latency variance?

A GitHub Actions benchmark run is being dispatched on this branch (`workflow_dispatch` of `.github/workflows/benchmarks.yml`). Results stay in the workflow summary and are not pushed to `gh-pages`.

## Test plan

- [x] `cargo +nightly fmt`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test -p snarkos-node-bft-ledger-service --features ledger,ledger-write --lib block_prep_pool`
- [x] `cargo test -p snarkos-node-bft --lib`
- [ ] GitHub Actions snarkOS benchmarks on this branch
- [ ] DPS client run to compare proposal / commit latency variance vs staging
- [ ] Optional before merge: `.ci/test_devnet.sh` (not run locally)


Made with [Cursor](https://cursor.com)