### PR TITLE
build: remove lld from cargo config

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,10 +1,7 @@
 [target.x86_64-unknown-linux-gnu]
 rustflags = [
-    # LLD is generally faster and might be the default for Rust in the future.
-    # See here: https://github.com/rust-lang/rust/issues/71515
-    #
     # skylake CPU family includes most SSE and AVX2 instructions from about 10 years ago
     # without this, optimization cannot use almost any vector instructions, unless
     # you explicitly set target-cpu yourself when building.
-    "-C", "link-arg=-fuse-ld=lld", "-C", "target-cpu=skylake"
+    "-C", "target-cpu=skylake"
 ]


### PR DESCRIPTION
## Summary

Removes the lld linker configuration from the cargo build settings. No longer necessary since #4432 because lld became the default in Rust 1.90.0.

https://blog.rust-lang.org/2025/09/18/Rust-1.90.0/#lld-is-now-the-default-linker-on-x86-64-unknown-linux-gnu