### PR TITLE
fix(rest): raise body limit for current max transaction size

### DIFF
--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -323,8 +323,9 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         routes
             // Pass in `Rest` to make things convenient.
             .with_state(self.clone())
-            // Cap the request body size at 1.5MiB.
-            .layer(DefaultBodyLimit::max(2 * 768 * 1024))
+            // JSON encodings of transactions can exceed the binary size, so this is 2x
+            // `LATEST_MAX_TRANSACTION_SIZE`.
+            .layer(DefaultBodyLimit::max(2 * N::LATEST_MAX_TRANSACTION_SIZE()))
             .layer(GovernorLayer {
                 config: governor_config.into(),
             })


### PR DESCRIPTION
## Summary
- Raise the REST request body cap from 1.5MiB (`2 * 768 * 1024`, based on the old 768KB transaction limit) to `2 * LATEST_MAX_TRANSACTION_SIZE` (currently 4,608,000 bytes).
- Valid deployments and upgrades can already be up to 2,304,000 bytes, and their JSON representation can be larger, so the old cap rejected them before the binary size check.

## Backwards compatibility
The new limit is strictly higher than the previous one, and only impacts behaviour local to a node.