### PR TITLE
build: improve dev compile times

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -404,9 +404,7 @@ version = "0.9"
 version = "2"
 
 [profile.release]
-opt-level = 3
 lto = "thin"
-incremental = false
 # uncomment the 2 lines below when building with the locktick feature or use the `release-locktick` profile
 # debug = "line-tables-only"
 # strip = "none"
@@ -416,25 +414,11 @@ inherits = "release"
 debug = "line-tables-only"
 strip = "none"
 
-[profile.bench]
-opt-level = 3
-debug = false
-rpath = false
-lto = "thin"
-incremental = false
-debug-assertions = false
-
 [profile.dev]
 debug = "line-tables-only"
-lto = "off"
-incremental = true
 
 [profile.test]
 opt-level = 2
-lto = "off"
-incremental = true
-debug = true
-debug-assertions = true
 
 [package.metadata.cargo-machete]
 ignored = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -425,7 +425,7 @@ incremental = false
 debug-assertions = false
 
 [profile.dev]
-opt-level = 2
+debug = "line-tables-only"
 lto = "off"
 incremental = true
 


### PR DESCRIPTION
## Summary

Changes the dev profile configuration to improve compile times. Also removes profile configuration that is redundant.

## Changes

- Changed the dev profile optimization level to 0. Improved compile time (full build) from 3m24s to 2m32s.
- Changed the dev profile debug info to line tables only. Higher levels of debug info are only useful for interactive debuggers. Improved compile time (full build) from 2m32s to 2m05s.
- Overall improved compile times for full builds by 39%. (measured with a single run though)
- Removed all configuration that was equal to the default profile values already. https://doc.rust-lang.org/cargo/reference/profiles.html#default-profiles