### PR TITLE
feat(rest): serve block hashes, headers, and state roots over a height range

### DIFF
--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -256,6 +256,9 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
             // GET misc endpoints.
             .route("/version", get(Self::get_version))
             .route("/blocks", get(Self::get_blocks))
+            .route("/blocks/hashes", get(Self::get_block_hashes))
+            .route("/blocks/headers", get(Self::get_block_headers))
+            .route("/blocks/stateRoots", get(Self::get_block_state_roots))
             .route("/height/{hash}", get(Self::get_height))
             .route("/memoryPool/transmissions", get(Self::get_memory_pool_transmissions))
             .route("/memoryPool/solutions", get(Self::get_memory_pool_solutions))

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -118,13 +118,50 @@ where
     Ok(if s.trim().is_empty() { Vec::new() } else { s.split(',').map(|x| x.trim().to_string()).collect() })
 }
 
-/// The `get_blocks` query object.
-#[derive(Deserialize, Serialize)]
+/// The query object for the routes serving a range of block heights.
+#[derive(Copy, Clone, Deserialize, Serialize)]
 pub(crate) struct BlockRange {
     /// The starting block height (inclusive).
     start: u32,
     /// The ending block height (exclusive).
     end: u32,
+}
+
+/// The maximum number of blocks that `get_blocks` serves in one request.
+const MAX_BLOCK_RANGE: u32 = 50;
+
+/// The maximum number of block hashes that `get_block_hashes` serves in one request.
+const MAX_BLOCK_HASH_RANGE: u32 = 5_000;
+
+/// The maximum number of block headers that `get_block_headers` serves in one request.
+const MAX_BLOCK_HEADER_RANGE: u32 = 320;
+
+/// The maximum number of state roots that `get_block_state_roots` serves in one request.
+const MAX_STATE_ROOT_RANGE: u32 = 5_000;
+
+/// Validates a block range against the given maximum, and returns `(start, end)`.
+///
+/// Each route serving a range picks its own maximum, sized so that the largest response it can
+/// produce stays on the order of a single block. A block hash and a header are several orders of
+/// magnitude smaller than the block they belong to, so applying the `get_blocks` maximum to them
+/// would bound those responses far below what the node already serves in one request.
+fn check_block_range(block_range: BlockRange, max_block_range: u32) -> Result<(u32, u32), RestError> {
+    let (start_height, end_height) = (block_range.start, block_range.end);
+
+    // Ensure the end height is greater than the start height.
+    if start_height > end_height {
+        return Err(RestError::bad_request(anyhow!("Invalid block range")));
+    }
+
+    // Ensure the block range is bounded.
+    if end_height - start_height > max_block_range {
+        return Err(RestError::bad_request(anyhow!(
+            "Cannot request more than {max_block_range} blocks per call (requested {})",
+            end_height - start_height
+        )));
+    }
+
+    Ok((start_height, end_height))
 }
 
 #[derive(Deserialize, Serialize)]
@@ -278,23 +315,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         State(rest): State<Self>,
         Query(block_range): Query<BlockRange>,
     ) -> Result<ErasedJson, RestError> {
-        let start_height = block_range.start;
-        let end_height = block_range.end;
-
-        const MAX_BLOCK_RANGE: u32 = 50;
-
-        // Ensure the end height is greater than the start height.
-        if start_height > end_height {
-            return Err(RestError::bad_request(anyhow!("Invalid block range")));
-        }
-
-        // Ensure the block range is bounded.
-        if end_height - start_height > MAX_BLOCK_RANGE {
-            return Err(RestError::bad_request(anyhow!(
-                "Cannot request more than {MAX_BLOCK_RANGE} blocks per call (requested {})",
-                end_height - start_height
-            )));
-        }
+        let (start_height, end_height) = check_block_range(block_range, MAX_BLOCK_RANGE)?;
 
         // Prepare a closure for the blocking work.
         let get_json_blocks = move || -> Result<ErasedJson, RestError> {
@@ -313,6 +334,111 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
 
                 Err(RestError::internal_server_error(
                     err.context(format!("Failed to get blocks '{start_height}..{end_height}'")),
+                ))
+            }
+        }
+    }
+
+    /// GET /<network>/blocks/hashes?start={start_height}&end={end_height}
+    pub(crate) async fn get_block_hashes(
+        State(rest): State<Self>,
+        Query(block_range): Query<BlockRange>,
+    ) -> Result<ErasedJson, RestError> {
+        let (start_height, end_height) = check_block_range(block_range, MAX_BLOCK_HASH_RANGE)?;
+
+        // Prepare a closure for the blocking work.
+        //
+        // Unlike `get_blocks`, this stays sequential: each height is a single point lookup in the
+        // block ID map, which is cheaper than the work of handing it to another thread, and this
+        // range is large enough that saturating the rayon pool would contend with consensus.
+        let get_json_hashes = move || -> Result<ErasedJson, RestError> {
+            let hashes = (start_height..end_height)
+                .map(|height| rest.ledger.get_hash(height).map_err(map_missing_resource_error))
+                .collect::<Result<Vec<_>, _>>()?;
+
+            Ok(ErasedJson::pretty(hashes))
+        };
+
+        // Fetch the block hashes from the ledger and serialize to json.
+        match tokio::task::spawn_blocking(get_json_hashes).await {
+            Ok(json) => json,
+            Err(err) => {
+                let err: anyhow::Error = err.into();
+
+                Err(RestError::internal_server_error(
+                    err.context(format!("Failed to get block hashes '{start_height}..{end_height}'")),
+                ))
+            }
+        }
+    }
+
+    /// GET /<network>/blocks/headers?start={start_height}&end={end_height}
+    pub(crate) async fn get_block_headers(
+        State(rest): State<Self>,
+        Query(block_range): Query<BlockRange>,
+    ) -> Result<ErasedJson, RestError> {
+        let (start_height, end_height) = check_block_range(block_range, MAX_BLOCK_HEADER_RANGE)?;
+
+        // Prepare a closure for the blocking work. Each height is two point lookups: the block ID
+        // map, then the header map. See `get_block_hashes` for why this is sequential.
+        let get_json_headers = move || -> Result<ErasedJson, RestError> {
+            let headers = (start_height..end_height)
+                .map(|height| rest.ledger.get_header(height).map_err(map_missing_resource_error))
+                .collect::<Result<Vec<_>, _>>()?;
+
+            Ok(ErasedJson::pretty(headers))
+        };
+
+        // Fetch the block headers from the ledger and serialize to json.
+        match tokio::task::spawn_blocking(get_json_headers).await {
+            Ok(json) => json,
+            Err(err) => {
+                let err: anyhow::Error = err.into();
+
+                Err(RestError::internal_server_error(
+                    err.context(format!("Failed to get block headers '{start_height}..{end_height}'")),
+                ))
+            }
+        }
+    }
+
+    /// GET /<network>/blocks/stateRoots?start={start_height}&end={end_height}
+    ///
+    /// Each entry is the state root *after* the block at that height, matching the singular
+    /// `/stateRoot/{height}` route. Note that this is not the root a header carries: a header holds
+    /// `previous_state_root`, so the root for height `h` appears in the header of height `h + 1`.
+    pub(crate) async fn get_block_state_roots(
+        State(rest): State<Self>,
+        Query(block_range): Query<BlockRange>,
+    ) -> Result<ErasedJson, RestError> {
+        let (start_height, end_height) = check_block_range(block_range, MAX_STATE_ROOT_RANGE)?;
+
+        // Prepare a closure for the blocking work. The state root map is keyed by height directly,
+        // so each height is a single point lookup. See `get_block_hashes` for why this is
+        // sequential.
+        let get_json_state_roots = move || -> Result<ErasedJson, RestError> {
+            let state_roots = (start_height..end_height)
+                .map(|height| {
+                    // Unlike the other getters, this one reports a missing height as `None` rather
+                    // than as an error, so translate it to stay consistent with the other routes.
+                    rest.ledger
+                        .get_state_root(height)
+                        .map_err(RestError::from)?
+                        .ok_or_else(|| RestError::not_found(anyhow!("Missing state root for block {height}")))
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+
+            Ok(ErasedJson::pretty(state_roots))
+        };
+
+        // Fetch the state roots from the ledger and serialize to json.
+        match tokio::task::spawn_blocking(get_json_state_roots).await {
+            Ok(json) => json,
+            Err(err) => {
+                let err: anyhow::Error = err.into();
+
+                Err(RestError::internal_server_error(
+                    err.context(format!("Failed to get state roots '{start_height}..{end_height}'")),
                 ))
             }
         }
@@ -1549,5 +1675,92 @@ mod route_error_tests {
         let err = map_missing_resource_error(anyhow::anyhow!(message));
         assert_eq!(err, StatusCode::INTERNAL_SERVER_ERROR);
         assert_eq!(err.to_string(), message);
+    }
+}
+
+#[cfg(test)]
+mod range_tests {
+    use super::*;
+
+    const MAX: u32 = 50;
+
+    fn range(start: u32, end: u32) -> BlockRange {
+        BlockRange { start, end }
+    }
+
+    #[test]
+    fn accepts_a_range_within_the_maximum() {
+        assert_eq!(check_block_range(range(10, 20), MAX).unwrap(), (10, 20));
+    }
+
+    #[test]
+    fn accepts_a_range_of_exactly_the_maximum() {
+        assert_eq!(check_block_range(range(10, 10 + MAX), MAX).unwrap(), (10, 10 + MAX));
+    }
+
+    #[test]
+    fn accepts_an_empty_range() {
+        assert_eq!(check_block_range(range(10, 10), MAX).unwrap(), (10, 10));
+    }
+
+    #[test]
+    fn rejects_an_inverted_range() {
+        // This must be rejected before the width check, which would otherwise underflow.
+        let err = check_block_range(range(20, 10), MAX).unwrap_err();
+        assert_eq!(err, StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn rejects_a_range_over_the_maximum() {
+        let err = check_block_range(range(10, 11 + MAX), MAX).unwrap_err();
+        assert_eq!(err, StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn rejects_a_range_spanning_the_whole_height_space() {
+        let err = check_block_range(range(0, u32::MAX), MAX).unwrap_err();
+        assert_eq!(err, StatusCode::BAD_REQUEST);
+    }
+
+    /// The json size of one item of each kind, measured on mainnet block 21,815,000. A header is
+    /// rounded up to 1 KiB to cover both pretty-printing and the blocks whose `solutions_root` is
+    /// populated, which the measured block's was not.
+    const BLOCK_HASH_BYTES: u32 = 63;
+    const STATE_ROOT_BYTES: u32 = 63;
+    const BLOCK_HEADER_BYTES: u32 = 1_024;
+    const BLOCK_BYTES: u32 = 337_511;
+
+    #[test]
+    fn each_maximum_bounds_its_response_to_at_most_one_block() {
+        // Every route added here serves a projection of a block, so none of them should be able to
+        // produce a response larger than the single block `get_blocks` already serves. If a
+        // maximum is raised past that point, it is no longer free from the node's perspective.
+        let largest_get_blocks_response = MAX_BLOCK_RANGE * BLOCK_BYTES;
+
+        for (name, max, item_bytes) in [
+            ("hashes", MAX_BLOCK_HASH_RANGE, BLOCK_HASH_BYTES),
+            ("headers", MAX_BLOCK_HEADER_RANGE, BLOCK_HEADER_BYTES),
+            ("stateRoots", MAX_STATE_ROOT_RANGE, STATE_ROOT_BYTES),
+        ] {
+            let largest_response = max * item_bytes;
+            assert!(
+                largest_response <= BLOCK_BYTES,
+                "the {name} maximum can serve {largest_response} bytes, more than the {BLOCK_BYTES} bytes of one block"
+            );
+            assert!(largest_response < largest_get_blocks_response);
+        }
+    }
+
+    #[test]
+    fn each_maximum_improves_on_fetching_whole_blocks() {
+        // The point of these routes is that syncing a projection over the whole chain costs far
+        // fewer requests than syncing the blocks that contain it. Guard that they are worth having.
+        for (name, max) in [
+            ("hashes", MAX_BLOCK_HASH_RANGE),
+            ("headers", MAX_BLOCK_HEADER_RANGE),
+            ("stateRoots", MAX_STATE_ROOT_RANGE),
+        ] {
+            assert!(max > MAX_BLOCK_RANGE, "the {name} maximum is no better than fetching whole blocks");
+        }
     }
 }

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -347,6 +347,11 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
     ///
     /// `start` is inclusive and `end` is exclusive, as in `get_blocks`, so `start == end` returns
     /// an empty array rather than the hash at that height.
+    ///
+    /// A height the node does not have is a 404, and the whole request fails rather than returning
+    /// a short array. Note that this is only visible on `/v2`: on the default and `/v1` prefixes
+    /// the v1 error middleware replaces the status with a 500, so a caller that needs to tell a
+    /// not-yet-synced height apart from a fault has to use `/v2`.
     pub(crate) async fn get_block_hashes(
         State(rest): State<Self>,
         Query(block_range): Query<BlockRange>,
@@ -382,6 +387,11 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
     /// GET /<network>/blocks/headers?start={start_height}&end={end_height}
     ///
     /// `start` is inclusive and `end` is exclusive, as in `get_blocks`.
+    ///
+    /// A height the node does not have is a 404, and the whole request fails rather than returning
+    /// a short array. Note that this is only visible on `/v2`: on the default and `/v1` prefixes
+    /// the v1 error middleware replaces the status with a 500, so a caller that needs to tell a
+    /// not-yet-synced height apart from a fault has to use `/v2`.
     pub(crate) async fn get_block_headers(
         State(rest): State<Self>,
         Query(block_range): Query<BlockRange>,
@@ -423,7 +433,8 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
     /// A height with no stored root is deliberately a 404 here, whereas the singular route serves
     /// `null` for it. Returning `null` inside an array would make a gap indistinguishable from a
     /// root that is genuinely absent, so this matches the other range routes and fails the whole
-    /// request instead.
+    /// request instead. As above, that 404 is only visible on `/v2`; the default and `/v1`
+    /// prefixes replace it with a 500.
     pub(crate) async fn get_block_state_roots(
         State(rest): State<Self>,
         Query(block_range): Query<BlockRange>,

--- a/node/rest/src/routes.rs
+++ b/node/rest/src/routes.rs
@@ -145,7 +145,11 @@ const MAX_STATE_ROOT_RANGE: u32 = 5_000;
 /// produce stays on the order of a single block. A block hash and a header are several orders of
 /// magnitude smaller than the block they belong to, so applying the `get_blocks` maximum to them
 /// would bound those responses far below what the node already serves in one request.
-fn check_block_range(block_range: BlockRange, max_block_range: u32) -> Result<(u32, u32), RestError> {
+///
+/// `item` names what the route serves, so that a caller who exceeds the maximum is told the limit
+/// in the unit it applies to. On the default and `/v1` prefixes this text is the only diagnostic
+/// the caller receives, since `v1_error_middleware` replaces the status code.
+fn check_block_range(block_range: BlockRange, max_block_range: u32, item: &str) -> Result<(u32, u32), RestError> {
     let (start_height, end_height) = (block_range.start, block_range.end);
 
     // Ensure the end height is greater than the start height.
@@ -156,7 +160,7 @@ fn check_block_range(block_range: BlockRange, max_block_range: u32) -> Result<(u
     // Ensure the block range is bounded.
     if end_height - start_height > max_block_range {
         return Err(RestError::bad_request(anyhow!(
-            "Cannot request more than {max_block_range} blocks per call (requested {})",
+            "Cannot request more than {max_block_range} {item} per call (requested {})",
             end_height - start_height
         )));
     }
@@ -315,7 +319,7 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
         State(rest): State<Self>,
         Query(block_range): Query<BlockRange>,
     ) -> Result<ErasedJson, RestError> {
-        let (start_height, end_height) = check_block_range(block_range, MAX_BLOCK_RANGE)?;
+        let (start_height, end_height) = check_block_range(block_range, MAX_BLOCK_RANGE, "blocks")?;
 
         // Prepare a closure for the blocking work.
         let get_json_blocks = move || -> Result<ErasedJson, RestError> {
@@ -340,11 +344,14 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
     }
 
     /// GET /<network>/blocks/hashes?start={start_height}&end={end_height}
+    ///
+    /// `start` is inclusive and `end` is exclusive, as in `get_blocks`, so `start == end` returns
+    /// an empty array rather than the hash at that height.
     pub(crate) async fn get_block_hashes(
         State(rest): State<Self>,
         Query(block_range): Query<BlockRange>,
     ) -> Result<ErasedJson, RestError> {
-        let (start_height, end_height) = check_block_range(block_range, MAX_BLOCK_HASH_RANGE)?;
+        let (start_height, end_height) = check_block_range(block_range, MAX_BLOCK_HASH_RANGE, "block hashes")?;
 
         // Prepare a closure for the blocking work.
         //
@@ -373,11 +380,13 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
     }
 
     /// GET /<network>/blocks/headers?start={start_height}&end={end_height}
+    ///
+    /// `start` is inclusive and `end` is exclusive, as in `get_blocks`.
     pub(crate) async fn get_block_headers(
         State(rest): State<Self>,
         Query(block_range): Query<BlockRange>,
     ) -> Result<ErasedJson, RestError> {
-        let (start_height, end_height) = check_block_range(block_range, MAX_BLOCK_HEADER_RANGE)?;
+        let (start_height, end_height) = check_block_range(block_range, MAX_BLOCK_HEADER_RANGE, "block headers")?;
 
         // Prepare a closure for the blocking work. Each height is two point lookups: the block ID
         // map, then the header map. See `get_block_hashes` for why this is sequential.
@@ -404,14 +413,22 @@ impl<N: Network, C: ConsensusStorage<N>, R: Routing<N>> Rest<N, C, R> {
 
     /// GET /<network>/blocks/stateRoots?start={start_height}&end={end_height}
     ///
-    /// Each entry is the state root *after* the block at that height, matching the singular
-    /// `/stateRoot/{height}` route. Note that this is not the root a header carries: a header holds
-    /// `previous_state_root`, so the root for height `h` appears in the header of height `h + 1`.
+    /// `start` is inclusive and `end` is exclusive, as in `get_blocks`.
+    ///
+    /// Each entry is the state root *after* the block at that height, the same root the singular
+    /// `/stateRoot/{height}` route returns. Note that this is not the root a header carries: a
+    /// header holds `previous_state_root`, so the root for height `h` appears in the header of
+    /// height `h + 1`.
+    ///
+    /// A height with no stored root is deliberately a 404 here, whereas the singular route serves
+    /// `null` for it. Returning `null` inside an array would make a gap indistinguishable from a
+    /// root that is genuinely absent, so this matches the other range routes and fails the whole
+    /// request instead.
     pub(crate) async fn get_block_state_roots(
         State(rest): State<Self>,
         Query(block_range): Query<BlockRange>,
     ) -> Result<ErasedJson, RestError> {
-        let (start_height, end_height) = check_block_range(block_range, MAX_STATE_ROOT_RANGE)?;
+        let (start_height, end_height) = check_block_range(block_range, MAX_STATE_ROOT_RANGE, "state roots")?;
 
         // Prepare a closure for the blocking work. The state root map is keyed by height directly,
         // so each height is a single point lookup. See `get_block_hashes` for why this is
@@ -1690,44 +1707,49 @@ mod range_tests {
 
     #[test]
     fn accepts_a_range_within_the_maximum() {
-        assert_eq!(check_block_range(range(10, 20), MAX).unwrap(), (10, 20));
+        assert_eq!(check_block_range(range(10, 20), MAX, "blocks").unwrap(), (10, 20));
     }
 
     #[test]
     fn accepts_a_range_of_exactly_the_maximum() {
-        assert_eq!(check_block_range(range(10, 10 + MAX), MAX).unwrap(), (10, 10 + MAX));
+        assert_eq!(check_block_range(range(10, 10 + MAX), MAX, "blocks").unwrap(), (10, 10 + MAX));
     }
 
     #[test]
     fn accepts_an_empty_range() {
-        assert_eq!(check_block_range(range(10, 10), MAX).unwrap(), (10, 10));
+        assert_eq!(check_block_range(range(10, 10), MAX, "blocks").unwrap(), (10, 10));
     }
 
     #[test]
     fn rejects_an_inverted_range() {
         // This must be rejected before the width check, which would otherwise underflow.
-        let err = check_block_range(range(20, 10), MAX).unwrap_err();
+        let err = check_block_range(range(20, 10), MAX, "blocks").unwrap_err();
         assert_eq!(err, StatusCode::BAD_REQUEST);
     }
 
     #[test]
     fn rejects_a_range_over_the_maximum() {
-        let err = check_block_range(range(10, 11 + MAX), MAX).unwrap_err();
+        let err = check_block_range(range(10, 11 + MAX), MAX, "blocks").unwrap_err();
         assert_eq!(err, StatusCode::BAD_REQUEST);
     }
 
     #[test]
     fn rejects_a_range_spanning_the_whole_height_space() {
-        let err = check_block_range(range(0, u32::MAX), MAX).unwrap_err();
+        let err = check_block_range(range(0, u32::MAX), MAX, "blocks").unwrap_err();
         assert_eq!(err, StatusCode::BAD_REQUEST);
     }
 
-    /// The json size of one item of each kind, measured on mainnet block 21,815,000. A header is
-    /// rounded up to 1 KiB to cover both pretty-printing and the blocks whose `solutions_root` is
-    /// populated, which the measured block's was not.
-    const BLOCK_HASH_BYTES: u32 = 63;
-    const STATE_ROOT_BYTES: u32 = 63;
-    const BLOCK_HEADER_BYTES: u32 = 1_024;
+    /// The json size of one *array element* of each kind, measured on mainnet block 21,815,000 as
+    /// the routes serve it: pretty-printed, so each element carries its own indent, comma and
+    /// newline. These are deliberately not the sizes of the bare values (a block hash is 63 bytes
+    /// as a quoted string but 67 as an element), because it is the response that has to fit.
+    ///
+    /// The header figure is the worst case rather than the measured one: the sampled block had an
+    /// empty `solutions_root` of `"0field"`, and a populated root brings the element from 965 to
+    /// 1,040 bytes.
+    const BLOCK_HASH_BYTES: u32 = 67;
+    const STATE_ROOT_BYTES: u32 = 67;
+    const BLOCK_HEADER_BYTES: u32 = 1_040;
     const BLOCK_BYTES: u32 = 337_511;
 
     #[test]
@@ -1748,6 +1770,12 @@ mod range_tests {
                 "the {name} maximum can serve {largest_response} bytes, more than the {BLOCK_BYTES} bytes of one block"
             );
             assert!(largest_response < largest_get_blocks_response);
+
+            // The headroom above is thin by design, so confirm the guard is load-bearing: the
+            // next maximum that would round up to another whole block must fail it.
+            let too_wide = BLOCK_BYTES / item_bytes + 1;
+            assert!(too_wide * item_bytes > BLOCK_BYTES, "the {name} guard would not catch a raised maximum");
+            assert!(max <= BLOCK_BYTES / item_bytes, "the {name} maximum is already over the limit");
         }
     }
 


### PR DESCRIPTION
## Motivation

Adds three routes that return a range of data the node already indexes:

```
    GET /<network>/blocks/hashes?start={h}&end={h}      -> [BlockHash]
    GET /<network>/blocks/headers?start={h}&end={h}     -> [Header]
    GET /<network>/blocks/stateRoots?start={h}&end={h}  -> [StateRoot]
```

Today the only way to obtain a block hash is to fetch the block that contains it. A block is ~337 KB and 99.6% of that is `authority`, so a consumer that needs every block hash on the chain -- one building the global state tree, whose root must equal the state root -- downloads several terabytes to keep well under a gigabyte. This change adds some new routes which are more efficient when you don't need the authority data.

Each route is a range loop over an existing index. `IDMap` and `StateRootMap` are keyed by height, `HeaderMap` by hash, and all three already have public getters on `Ledger`. No new storage, no new serialization, and strictly cheaper for the node to serve than the `/blocks` call each one replaces.

The range check is factored out of `get_blocks` into `check_block_range` so each route can carry its own maximum. Inheriting the 50-block maximum would bound these responses far below what the node already serves in a single request: a hash is ~5,300x smaller than its block. The maximums are instead sized so that the largest response each route can produce still fits inside one block, which a test asserts.

Unlike `get_blocks`, the new loops are sequential. Each height is one or two point lookups, cheaper than handing the work to another thread, and the ranges are wide enough that saturating the rayon pool would contend with consensus.

## Test Plan

Unit tests cover the extracted check_block_range function. We tested this in a deployed dev network. 

It appears that we do not currently exercise any of the REST routes in testing. This is unfortunate -- there are facilities like `axum-test` that I've used before to do that, and we could make an in-memory ledger cheaply. The point of such testing is that we can ensure that responses are formatted as expected, and that errors like unknown route or missing data lead to expected error codes. However, adding that test harness should be a second PR imo because it has to touch a bunch of other crates. That PR will be stacked on this one.

## Documentation

This adds a few simple REST API endpoints. It appears that we don't document that stuff using swagger / openAPI or anything like that. The other REST API endpoints are documented by doc comments on their handlers.

If a public REST endpoint reference is maintained outside this repo and AleoNet/welcome, these three routes should be added there.

## Backwards compatibility

This is only additive so it should be backwards compatible.