### PR TITLE
test(rest): add a route-level test harness for the REST API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5389,6 +5389,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "snarkos-node-bft-ledger-service",
  "snarkos-node-cdn",
  "snarkos-node-consensus",
  "snarkos-node-network",

--- a/node/rest/Cargo.toml
+++ b/node/rest/Cargo.toml
@@ -129,5 +129,17 @@ workspace = true
 version = "0.5"
 features = ["util"]
 
+[dev-dependencies.snarkos-node-bft-ledger-service]
+workspace = true
+features = [ "mock" ]
+
+[dev-dependencies.snarkos-node-router]
+workspace = true
+features = [ "test-helpers" ]
+
+[dev-dependencies.snarkvm]
+workspace = true
+features = [ "test-helpers" ]
+
 [build-dependencies.built]
 workspace = true

--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -490,7 +490,7 @@ mod route_tests {
     use snarkos_node_network::ConnectionMode;
     use snarkos_node_router::test_helpers::{TestRouter, client, sample_genesis_block};
     use snarkvm::{
-        ledger::{committee::test_helpers::sample_committee, store::helpers::memory::ConsensusMemory},
+        ledger::{block::Header, committee::test_helpers::sample_committee, store::helpers::memory::ConsensusMemory},
         prelude::MainnetV0,
         utilities::TestRng,
     };
@@ -571,5 +571,98 @@ mod route_tests {
 
         let hashes: Vec<<CurrentNetwork as Network>::BlockHash> = serde_json::from_str(&body).unwrap();
         assert_eq!(hashes, vec![sample_genesis_block::<CurrentNetwork>().hash()]);
+    }
+
+    #[tokio::test]
+    async fn block_headers_returns_the_headers_in_the_range() {
+        let rest = sample_rest().await;
+
+        let (status, body) = get(&rest, "/blocks/headers?start=0&end=1").await;
+        assert_eq!(status, StatusCode::OK);
+
+        let headers: Vec<Header<CurrentNetwork>> = serde_json::from_str(&body).unwrap();
+        assert_eq!(headers, vec![*sample_genesis_block::<CurrentNetwork>().header()]);
+    }
+
+    #[tokio::test]
+    async fn block_state_roots_returns_the_state_roots_in_the_range() {
+        let rest = sample_rest().await;
+
+        let (status, body) = get(&rest, "/blocks/stateRoots?start=0&end=1").await;
+        assert_eq!(status, StatusCode::OK);
+
+        // The state root at a height is the root *after* that block, so it is not the genesis
+        // header's `previous_state_root`. Compare against what the ledger reports for the height.
+        let state_roots: Vec<<CurrentNetwork as Network>::StateRoot> = serde_json::from_str(&body).unwrap();
+        assert_eq!(state_roots, vec![rest.ledger.get_state_root(0).unwrap().unwrap()]);
+    }
+
+    #[tokio::test]
+    async fn an_empty_range_returns_an_empty_array() {
+        let rest = sample_rest().await;
+
+        for route in ["hashes", "headers", "stateRoots"] {
+            let (status, body) = get(&rest, &format!("/blocks/{route}?start=0&end=0")).await;
+            assert_eq!(status, StatusCode::OK, "{route} rejected an empty range");
+            assert_eq!(serde_json::from_str::<Vec<serde_json::Value>>(&body).unwrap(), Vec::<serde_json::Value>::new());
+        }
+    }
+
+    #[tokio::test]
+    async fn a_range_past_the_tip_is_not_found() {
+        let rest = sample_rest().await;
+
+        // The test ledger holds only the genesis block, so height 1 does not exist. The whole
+        // request fails rather than returning a short array, matching `/blocks`.
+        for route in ["hashes", "headers", "stateRoots"] {
+            let (status, _) = get(&rest, &format!("/blocks/{route}?start=0&end=2")).await;
+            assert_eq!(status, StatusCode::NOT_FOUND, "{route} did not report a missing height");
+        }
+    }
+
+    #[tokio::test]
+    async fn an_inverted_range_is_rejected() {
+        let rest = sample_rest().await;
+
+        for route in ["hashes", "headers", "stateRoots"] {
+            let (status, _) = get(&rest, &format!("/blocks/{route}?start=10&end=0")).await;
+            assert_eq!(status, StatusCode::BAD_REQUEST, "{route} accepted an inverted range");
+        }
+    }
+
+    #[tokio::test]
+    async fn a_range_over_the_maximum_is_rejected() {
+        let rest = sample_rest().await;
+
+        // One past each route's maximum. These are rejected before any lookup, so the fact that
+        // the test ledger has a single block does not matter.
+        for (route, over_max) in [("hashes", 5_001), ("headers", 321), ("stateRoots", 5_001)] {
+            let (status, body) = get(&rest, &format!("/blocks/{route}?start=0&end={over_max}")).await;
+            assert_eq!(status, StatusCode::BAD_REQUEST, "{route} accepted a range over its maximum");
+            assert!(body.contains("Cannot request more than"), "{route} gave an unexpected error: {body}");
+        }
+    }
+
+    #[tokio::test]
+    async fn a_range_at_the_maximum_is_accepted() {
+        let rest = sample_rest().await;
+
+        // Exactly each route's maximum passes the range check. The lookups then fail on the test
+        // ledger's single block, so a 404 here still proves the maximum itself was not the reason.
+        for (route, max) in [("hashes", 5_000), ("headers", 320), ("stateRoots", 5_000)] {
+            let (status, body) = get(&rest, &format!("/blocks/{route}?start=0&end={max}")).await;
+            assert_eq!(status, StatusCode::NOT_FOUND, "{route} rejected a range at its maximum");
+            assert!(!body.contains("Cannot request more than"), "{route} rejected its own maximum: {body}");
+        }
+    }
+
+    #[tokio::test]
+    async fn missing_or_invalid_range_parameters_are_rejected() {
+        let rest = sample_rest().await;
+
+        for query in ["", "?start=0", "?end=1", "?start=abc&end=1", "?start=0&end=-1"] {
+            let (status, _) = get(&rest, &format!("/blocks/hashes{query}")).await;
+            assert_eq!(status, StatusCode::BAD_REQUEST, "the query '{query}' was not rejected");
+        }
     }
 }

--- a/node/rest/src/lib.rs
+++ b/node/rest/src/lib.rs
@@ -482,3 +482,94 @@ mod tests {
         assert_eq!(res.status(), StatusCode::SERVICE_UNAVAILABLE);
     }
 }
+
+#[cfg(test)]
+mod route_tests {
+    use super::*;
+    use snarkos_node_bft_ledger_service::MockLedgerService;
+    use snarkos_node_network::ConnectionMode;
+    use snarkos_node_router::test_helpers::{TestRouter, client, sample_genesis_block};
+    use snarkvm::{
+        ledger::{committee::test_helpers::sample_committee, store::helpers::memory::ConsensusMemory},
+        prelude::MainnetV0,
+        utilities::TestRng,
+    };
+
+    use aleo_std::StorageMode;
+    use axum::body::to_bytes;
+    use tower::ServiceExt; // for `oneshot`
+
+    type CurrentNetwork = MainnetV0;
+    type CurrentRest = Rest<CurrentNetwork, ConsensusMemory<CurrentNetwork>, TestRouter<CurrentNetwork>>;
+
+    /// The rate limit given to the router under test. The governor layer is applied by
+    /// `build_routes`, so this is set high enough that a test making several requests in quick
+    /// succession is never the thing that trips it.
+    const TEST_RPS: u32 = 1_000;
+
+    /// Builds a `Rest` over an in-memory ledger containing only the genesis block.
+    ///
+    /// This constructs the struct directly rather than calling `Rest::start`, which would bind a
+    /// port and spawn a server. None of the routes exercised here touch `consensus`, `cdn_sync`,
+    /// `routing` or `block_sync`; those fields exist only to satisfy the type.
+    async fn sample_rest() -> CurrentRest {
+        let rng = &mut TestRng::default();
+
+        // `Ledger::load` reaches snarkVM's sequential-operation thread and blocks on the reply,
+        // which panics if called from an async context. Production always drives these from a
+        // blocking task, so do the same here.
+        let ledger = tokio::task::spawn_blocking(|| {
+            Ledger::<CurrentNetwork, ConsensusMemory<CurrentNetwork>>::load(
+                sample_genesis_block::<CurrentNetwork>(),
+                StorageMode::new_test(None),
+            )
+        })
+        .await
+        .expect("the ledger task panicked")
+        .expect("couldn't load the test ledger");
+
+        let ledger_service = Arc::new(MockLedgerService::new(sample_committee(rng)));
+
+        Rest {
+            cdn_sync: None,
+            consensus: None,
+            ledger,
+            routing: Arc::new(client(0, 10, rng).await),
+            handles: Default::default(),
+            block_sync: Arc::new(BlockSync::new(ledger_service, ConnectionMode::Router)),
+            num_verifying_deploys: Arc::new(Semaphore::new(1)),
+            num_verifying_executions: Arc::new(Semaphore::new(1)),
+            num_verifying_solutions: Arc::new(Semaphore::new(1)),
+            block_cache: Arc::new(Mutex::new(LruCache::new(NonZeroUsize::new(BLOCK_CACHE_SIZE).unwrap()))),
+        }
+    }
+
+    /// Issues a GET request against the routes, without the network prefix that `spawn_server`
+    /// nests them under.
+    ///
+    /// The governor layer keys on the peer IP taken from `ConnectInfo`, which a request built by
+    /// hand does not carry, so this attaches one; without it every request fails the rate limiter's
+    /// key extractor rather than reaching a handler.
+    async fn get(rest: &CurrentRest, uri: &str) -> (StatusCode, String) {
+        let mut request = Request::builder().uri(uri).body(Body::empty()).unwrap();
+        request.extensions_mut().insert(ConnectInfo(SocketAddr::from(([127, 0, 0, 1], 4130))));
+
+        let response = rest.build_routes(TEST_RPS).oneshot(request).await.unwrap();
+        let status = response.status();
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+
+        (status, String::from_utf8(body.to_vec()).unwrap())
+    }
+
+    #[tokio::test]
+    async fn block_hashes_returns_the_hashes_in_the_range() {
+        let rest = sample_rest().await;
+
+        // The test ledger holds only the genesis block, so this is the one height available.
+        let (status, body) = get(&rest, "/blocks/hashes?start=0&end=1").await;
+        assert_eq!(status, StatusCode::OK);
+
+        let hashes: Vec<<CurrentNetwork as Network>::BlockHash> = serde_json::from_str(&body).unwrap();
+        assert_eq!(hashes, vec![sample_genesis_block::<CurrentNetwork>().hash()]);
+    }
+}

--- a/node/router/Cargo.toml
+++ b/node/router/Cargo.toml
@@ -18,6 +18,10 @@ edition = "2024"
 
 [features]
 test = [ ]
+test-helpers = [
+  "snarkos-node-bft-ledger-service/mock",
+  "snarkvm/test-helpers"
+]
 locktick = [
   "dep:locktick",
   "snarkos-node-tcp/locktick",
@@ -138,7 +142,7 @@ features = [ "test" ]
 
 [dev-dependencies.snarkos-node-router]
 path = "."
-features = [ "test" ]
+features = [ "test", "test-helpers" ]
 
 [dev-dependencies.snarkos-node-router-messages]
 workspace = true

--- a/node/router/src/lib.rs
+++ b/node/router/src/lib.rs
@@ -43,6 +43,9 @@ pub use outbound::*;
 mod routing;
 pub use routing::*;
 
+#[cfg(feature = "test-helpers")]
+pub mod test_helpers;
+
 mod writing;
 
 use crate::messages::{BlockRequest, Message, MessageCodec};

--- a/node/router/src/test_helpers.rs
+++ b/node/router/src/test_helpers.rs
@@ -13,9 +13,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::common::sample_genesis_block;
-use snarkos_node_network::{NodeType, Peer, PeerPoolHandling, Resolver};
-use snarkos_node_router::{
+//! Test helpers for exercising a `Router` and anything generic over [`Routing`].
+//!
+//! This module is gated behind the `test-helpers` feature so that other crates can build a node
+//! component that requires `R: Routing<N>` without standing up a real node. It is the single
+//! definition of `TestRouter`; the router's own integration tests re-export it from here.
+
+use snarkos_account::Account;
+use snarkos_node_bft_ledger_service::MockLedgerService;
+use snarkos_utilities::NodeDataDir;
+use snarkvm::{
+    prelude::{FromBytes, MainnetV0 as CurrentNetwork, PrivateKey},
+    utilities::TestRng,
+};
+use std::net::{IpAddr, Ipv4Addr};
+
+use crate::{
     Heartbeat,
     Inbound,
     Outbound,
@@ -32,6 +45,7 @@ use snarkos_node_router::{
         UnconfirmedTransaction,
     },
 };
+use snarkos_node_network::{NodeType, Peer, PeerPoolHandling, Resolver};
 use snarkos_node_tcp::{
     ConnectError,
     Connection,
@@ -55,7 +69,7 @@ use async_trait::async_trait;
 use locktick::parking_lot::RwLock;
 #[cfg(not(feature = "locktick"))]
 use parking_lot::RwLock;
-use std::{collections::HashMap, io, net::SocketAddr, str::FromStr};
+use std::{collections::HashMap, io, net::SocketAddr, str::FromStr, sync::Arc};
 use tracing::*;
 
 #[derive(Clone)]
@@ -265,4 +279,66 @@ impl<N: Network> Inbound<N> for TestRouter<N> {
     ) -> bool {
         true
     }
+}
+
+/// Returns a fixed account.
+pub fn sample_account(rng: &mut TestRng) -> Account<CurrentNetwork> {
+    let private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
+    Account::<CurrentNetwork>::try_from(&private_key).unwrap()
+}
+
+/// Loads the current network's genesis block.
+pub fn sample_genesis_block<N: Network>() -> Block<N> {
+    Block::<N>::from_bytes_le(N::genesis_bytes()).unwrap()
+}
+
+/// Initializes a router of the given node type.
+///
+/// Setting `listening_port = 0` results in a random port being assigned. No listener is bound
+/// until `initialize_routing` is called, so a router built here does not touch the network.
+pub async fn sample_router(
+    node_type: NodeType,
+    listening_port: u16,
+    max_peers: u16,
+    trusted_peers: &[SocketAddr],
+    trusted_peers_only: bool,
+    rng: &mut TestRng,
+) -> TestRouter<CurrentNetwork> {
+    let committee = snarkvm::ledger::committee::test_helpers::sample_committee(rng);
+    let ledger_service = Arc::new(MockLedgerService::new(committee));
+    Router::new(
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), listening_port),
+        node_type,
+        sample_account(rng),
+        ledger_service,
+        trusted_peers,
+        max_peers,
+        trusted_peers_only,
+        NodeDataDir::new_test(None),
+        true,
+    )
+    .await
+    .expect("couldn't create router")
+    .into()
+}
+
+/// Initializes a client router. Setting the `listening_port = 0` will result in a random port being assigned.
+pub async fn client(listening_port: u16, max_peers: u16, rng: &mut TestRng) -> TestRouter<CurrentNetwork> {
+    sample_router(NodeType::Client, listening_port, max_peers, &[], false, rng).await
+}
+
+/// Initializes a prover router. Setting the `listening_port = 0` will result in a random port being assigned.
+pub async fn prover(listening_port: u16, max_peers: u16, rng: &mut TestRng) -> TestRouter<CurrentNetwork> {
+    sample_router(NodeType::Prover, listening_port, max_peers, &[], false, rng).await
+}
+
+/// Initializes a validator router. Setting the `listening_port = 0` will result in a random port being assigned.
+pub async fn validator(
+    listening_port: u16,
+    max_peers: u16,
+    trusted_peers: &[SocketAddr],
+    trusted_peers_only: bool,
+    rng: &mut TestRng,
+) -> TestRouter<CurrentNetwork> {
+    sample_router(NodeType::Validator, listening_port, max_peers, trusted_peers, trusted_peers_only, rng).await
 }

--- a/node/router/tests/common/mod.rs
+++ b/node/router/tests/common/mod.rs
@@ -13,25 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[allow(dead_code)]
-pub mod router;
-pub use router::*;
+//! Shared helpers for the router's integration tests.
+//!
+//! `TestRouter` and the router constructors live in `snarkos_node_router::test_helpers` so that
+//! other crates can use them too; this module only re-exports them.
 
-use std::{
-    net::{IpAddr, Ipv4Addr, SocketAddr},
-    sync::Arc,
-};
-
-use snarkos_account::Account;
-use snarkos_node_bft_ledger_service::MockLedgerService;
-use snarkos_node_network::NodeType;
-use snarkos_node_router::Router;
-use snarkos_utilities::NodeDataDir;
-
-use snarkvm::{
-    prelude::{FromBytes, MainnetV0 as CurrentNetwork, Network, PrivateKey, block::Block},
-    utilities::TestRng,
-};
+pub use snarkos_node_router::test_helpers::*;
 
 /// A helper macro to print the TCP listening address, along with the connected and connecting peers.
 #[macro_export]
@@ -44,83 +31,4 @@ macro_rules! print_tcp {
             $node.tcp().connecting_addrs()
         );
     };
-}
-
-/// Returns a fixed account.
-pub fn sample_account(rng: &mut TestRng) -> Account<CurrentNetwork> {
-    let private_key = PrivateKey::<CurrentNetwork>::new(rng).unwrap();
-    Account::<CurrentNetwork>::try_from(&private_key).unwrap()
-}
-
-/// Loads the current network's genesis block.
-pub fn sample_genesis_block<N: Network>() -> Block<N> {
-    Block::<N>::from_bytes_le(N::genesis_bytes()).unwrap()
-}
-
-/// Initializes a client router. Setting the `listening_port = 0` will result in a random port being assigned.
-pub async fn client(listening_port: u16, max_peers: u16, rng: &mut TestRng) -> TestRouter<CurrentNetwork> {
-    let committee = snarkvm::ledger::committee::test_helpers::sample_committee(rng);
-    let ledger_service = Arc::new(MockLedgerService::new(committee));
-    Router::new(
-        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), listening_port),
-        NodeType::Client,
-        sample_account(rng),
-        ledger_service,
-        &[],
-        max_peers,
-        false,
-        NodeDataDir::new_test(None),
-        true,
-    )
-    .await
-    .expect("couldn't create client router")
-    .into()
-}
-
-/// Initializes a prover router. Setting the `listening_port = 0` will result in a random port being assigned.
-#[allow(dead_code)]
-pub async fn prover(listening_port: u16, max_peers: u16, rng: &mut TestRng) -> TestRouter<CurrentNetwork> {
-    let committee = snarkvm::ledger::committee::test_helpers::sample_committee(rng);
-    let ledger_service = Arc::new(MockLedgerService::new(committee));
-    Router::new(
-        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), listening_port),
-        NodeType::Prover,
-        sample_account(rng),
-        ledger_service,
-        &[],
-        max_peers,
-        false,
-        NodeDataDir::new_test(None),
-        true,
-    )
-    .await
-    .expect("couldn't create prover router")
-    .into()
-}
-
-/// Initializes a validator router. Setting the `listening_port = 0` will result in a random port being assigned.
-#[allow(dead_code)]
-pub async fn validator(
-    listening_port: u16,
-    max_peers: u16,
-    trusted_peers: &[SocketAddr],
-    trusted_peers_only: bool,
-    rng: &mut TestRng,
-) -> TestRouter<CurrentNetwork> {
-    let committee = snarkvm::ledger::committee::test_helpers::sample_committee(rng);
-    let ledger_service = Arc::new(MockLedgerService::new(committee));
-    Router::new(
-        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), listening_port),
-        NodeType::Validator,
-        sample_account(rng),
-        ledger_service,
-        trusted_peers,
-        max_peers,
-        trusted_peers_only,
-        NodeDataDir::new_test(None),
-        true,
-    )
-    .await
-    .expect("couldn't create validator router")
-    .into()
 }


### PR DESCRIPTION
## Motivation

Second in the stack, on top of #4447. That PR's Test Plan noted that we do not exercise any REST route in testing, and that adding a harness would have to touch other crates and so belonged in its own PR. This is that PR.

Nothing today drives a request through a real handler. The existing tests in `node/rest` cover the error middleware against a synthetic router of dummy handlers, plus a few pure helpers -- useful, but they cannot catch a path typo, a route conflict, a bad query rejection, or a wrong status code.

The obstacle was `Rest<N, C, R>`, which requires `R: Routing<N>`. That trait is `P2P + Disconnect + OnConnect + Handshake + Inbound + Outbound + Heartbeat`, and the only non-production implementation is `TestRouter`, which lived in the router crate's integration-test directory where no other crate could reach it. None of the REST handlers touch `routing` at all; it is purely that `Rest` is one struct with one type parameter for it.

So `TestRouter` is promoted to `snarkos_node_router::test_helpers` behind a new `test-helpers` feature, the three near-identical `client`/`prover`/`validator` constructors collapse onto one `sample_router`, and the router's own `tests/common/router.rs` becomes a re-export so there is still a single definition. The self dev-dependency pattern this needs is already established in that crate.

Note that `test-helpers` is deliberately **not** the existing `test` feature. That one relaxes `MAX_CONNECTION_ATTEMPTS` and skips IP banning (`lib.rs` L147, `handshake.rs` L105). Exposing test helpers should not change how a router behaves, so enabling one must not enable the other.

On top of that, `node/rest` gains a harness and tests for the three routes from #4447. Two details are worth knowing before extending it:

- `Rest` is built as a struct literal rather than via `Rest::start`, which would bind a port and spawn a server.
- `build_routes` applies the governor layer, which keys on the peer IP from `ConnectInfo`. A hand-built request carries none, so the extractor fails and the error handler maps it to a 500 rather than the request reaching a handler. The harness attaches one. This is almost certainly why the existing tests use a synthetic router -- it sidesteps the problem.

Loading the ledger happens inside `spawn_blocking`, because `Ledger::load` blocks on snarkVM's sequential-operation thread and that panics in an async context. snarkVM's own comment says production only drives these from blocking tasks, so the harness does the same. This is not optional -- the first version of the test died on exactly that.

## Test Plan

`cargo test -p snarkos-node-rest --lib` -- 22 tests, up from 13. Nine of the new ones are route-level, covering the three range routes:

- each returns the expected values for a real height
- an empty range returns `[]` rather than an error
- a range past the tip is a 404 for the whole request, not a short array
- an inverted range, and a range one past the maximum, are both 400
- a range at exactly the maximum passes the range check
- missing, non-numeric and negative parameters are all 400

`cargo test -p snarkos-node-router` -- all six test binaries still pass, so moving `TestRouter` out of the integration-test directory did not regress the suite that already used it.

The maximum cases assert on the error text as well as the status, because the at-maximum case legitimately returns a 404: the range check passes, then the lookup fails on the test ledger's single block. Asserting only the status would make "accepted the range" and "rejected the range" indistinguishable.

## Documentation

Nothing user-facing. The new `test-helpers` feature is a development concern; the module carries a doc comment explaining what it is for and that it is the single definition of `TestRouter`.

## Backwards compatibility

No `ConsensusVersion` guard is needed, and there are no production behavior changes at all. The diff is dev-dependencies, one opt-in feature that is off by default, a `#[cfg(feature = "test-helpers")]` module declaration, and test code. `Rest`, `build_routes` and every handler are untouched.
