### PR TITLE
feat: add subdag/DAG-density metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.helix/
 **/*.idea/
 **/target
 **.DS_Store
@@ -23,7 +24,7 @@ validator-*
 **.bft-storage-*/
 **jwt_secret*.txt
 
-# For release upgrde CI
+# For release upgrade CI
 .ci/release-snarkos
 .ci/release-snarkos-src
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8071,13 +8071,14 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wnaf"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab12e7090f27e2ffd9322651492942d50c2926094af30601e1964337db39daf1"
+checksum = "795ca18b3fdb5e62bf982199278341ddcf7ebf7d32e25e212ad05d496e95f6fa"
 dependencies = [
  "ff",
  "group",
  "hybrid-array",
+ "primefield",
 ]
 
 [[package]]

--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -751,25 +751,6 @@ impl<N: Network> BFT<N> {
             // Retrieve metadata about the subdag.
             let subdag_metadata = subdag.iter().map(|(round, c)| (*round, c.len())).collect::<Vec<_>>();
 
-            // Update subdag/DAG-density metrics.
-            #[cfg(feature = "metrics")]
-            {
-                metrics::histogram(metrics::bft::SUBDAG_ROUNDS_PER_BLOCK, subdag_metadata.len() as f64);
-                for (_, certs_in_round) in &subdag_metadata {
-                    metrics::histogram(metrics::bft::SUBDAG_CERTIFICATES_PER_ROUND, *certs_in_round as f64);
-                }
-                for certificate in commit_subdag.values().flatten() {
-                    metrics::histogram(
-                        metrics::bft::SUBDAG_CERTIFICATE_SIGNATURES,
-                        certificate.signatures().len() as f64,
-                    );
-                    metrics::histogram(
-                        metrics::bft::SUBDAG_CERTIFICATE_PREVIOUS_REFS,
-                        certificate.previous_certificate_ids().len() as f64,
-                    );
-                }
-            }
-
             // Ensure the subdag anchor round matches the leader round.
             ensure!(
                 anchor_round == leader_round,
@@ -780,8 +761,10 @@ impl<N: Network> BFT<N> {
             if !skip_consensus && let Some(consensus_sender) = self.consensus_sender.get() {
                 // Initialize a callback sender and receiver.
                 let (callback_sender, callback_receiver) = oneshot::channel();
+
                 // Send the subdag and transmissions to consensus.
                 consensus_sender.tx_consensus_subdag.send((subdag, transmissions, callback_sender)).await?;
+
                 // Await the callback to continue.
                 match callback_receiver.await {
                     Ok(Ok(_)) => (),
@@ -795,6 +778,25 @@ impl<N: Network> BFT<N> {
                         let err = err.context(format!("BFT failed to receive the callback for round {anchor_round}"));
                         error!("{}", flatten_error(err));
                         return Ok(());
+                    }
+                }
+
+                // Update subdag/DAG-density metrics.
+                #[cfg(feature = "metrics")]
+                {
+                    metrics::histogram(metrics::bft::SUBDAG_ROUNDS_PER_BLOCK, subdag_metadata.len() as f64);
+                    for (_, certs_in_round) in &subdag_metadata {
+                        metrics::histogram(metrics::bft::SUBDAG_CERTIFICATES_PER_ROUND, *certs_in_round as f64);
+                    }
+                    for certificate in commit_subdag.values().flatten() {
+                        metrics::histogram(
+                            metrics::bft::SUBDAG_CERTIFICATE_SIGNATURES,
+                            certificate.signatures().len() as f64,
+                        );
+                        metrics::histogram(
+                            metrics::bft::SUBDAG_CERTIFICATE_PREVIOUS_REFS,
+                            certificate.previous_certificate_ids().len() as f64,
+                        );
                     }
                 }
             }

--- a/node/bft/src/bft.rs
+++ b/node/bft/src/bft.rs
@@ -751,6 +751,25 @@ impl<N: Network> BFT<N> {
             // Retrieve metadata about the subdag.
             let subdag_metadata = subdag.iter().map(|(round, c)| (*round, c.len())).collect::<Vec<_>>();
 
+            // Update subdag/DAG-density metrics.
+            #[cfg(feature = "metrics")]
+            {
+                metrics::histogram(metrics::bft::SUBDAG_ROUNDS_PER_BLOCK, subdag_metadata.len() as f64);
+                for (_, certs_in_round) in &subdag_metadata {
+                    metrics::histogram(metrics::bft::SUBDAG_CERTIFICATES_PER_ROUND, *certs_in_round as f64);
+                }
+                for certificate in commit_subdag.values().flatten() {
+                    metrics::histogram(
+                        metrics::bft::SUBDAG_CERTIFICATE_SIGNATURES,
+                        certificate.signatures().len() as f64,
+                    );
+                    metrics::histogram(
+                        metrics::bft::SUBDAG_CERTIFICATE_PREVIOUS_REFS,
+                        certificate.previous_certificate_ids().len() as f64,
+                    );
+                }
+            }
+
             // Ensure the subdag anchor round matches the leader round.
             ensure!(
                 anchor_round == leader_round,

--- a/node/metrics/src/names.rs
+++ b/node/metrics/src/names.rs
@@ -47,10 +47,14 @@ pub(super) const GAUGE_NAMES: [&str; 28] = [
     tcp::QUEUED_INBOUND_MESSAGES,
 ];
 
-pub(super) const HISTOGRAM_NAMES: [&str; 9] = [
+pub(super) const HISTOGRAM_NAMES: [&str; 13] = [
     bft::COMMIT_ROUNDS_LATENCY,
     bft::COMMIT_LEADER_CERTIFICATE_LATENCY,
     bft::BATCH_CERTIFICATION_LATENCY,
+    bft::SUBDAG_CERTIFICATES_PER_ROUND,
+    bft::SUBDAG_CERTIFICATE_SIGNATURES,
+    bft::SUBDAG_CERTIFICATE_PREVIOUS_REFS,
+    bft::SUBDAG_ROUNDS_PER_BLOCK,
     consensus::CERTIFICATE_COMMIT_LATENCY,
     consensus::BLOCK_LATENCY,
     consensus::BLOCK_LAG,
@@ -74,6 +78,15 @@ pub mod bft {
     pub const HEIGHT: &str = "snarkos_bft_height_total";
     pub const LAST_COMMITTED_ROUND: &str = "snarkos_bft_last_committed_round";
     pub const IS_SYNCED: &str = "snarkos_bft_is_synced";
+    /// The number of certificates in a round of a committed subdag (one observation per round).
+    pub const SUBDAG_CERTIFICATES_PER_ROUND: &str = "snarkos_bft_subdag_certificates_per_round";
+    /// The number of signatures on a certificate in a committed subdag (one observation per certificate).
+    pub const SUBDAG_CERTIFICATE_SIGNATURES: &str = "snarkos_bft_subdag_certificate_signatures";
+    /// The number of previous-round certificate references on a certificate in a committed subdag
+    /// (one observation per certificate) — a proxy for DAG density/connectivity.
+    pub const SUBDAG_CERTIFICATE_PREVIOUS_REFS: &str = "snarkos_bft_subdag_certificate_previous_refs";
+    /// The number of rounds spanned by a committed subdag (one observation per committed block).
+    pub const SUBDAG_ROUNDS_PER_BLOCK: &str = "snarkos_bft_subdag_rounds_per_block";
 }
 
 pub mod blocks {


### PR DESCRIPTION
## Motivation

`ProvableHQ/snarkos-stress-testing` [PR #460](https://github.com/ProvableHQ/snarkos-stress-testing/pull/460) added consensus-metrics tooling that measures block times, latencies, connectivity, and DAG structure across test scenarios (baseline, network delay, validator offline). Everything it measures is already exposed by snarkOS as a Prometheus metric except subdag/DAG-density data (certificates per round, signatures per certificate, previous-round certificate references, rounds per committed block) — for that, the stress-testing script has to fetch and parse raw blocks over the REST API instead of scraping Prometheus like everything else. This PR closes that gap by exporting the missing data natively.

## Changes

- Added four new Prometheus histograms in the BFT commit path (`node/bft/src/bft.rs`, `commit_leader_certificate`): `snarkos_bft_subdag_certificates_per_round`, `snarkos_bft_subdag_certificate_signatures`, `snarkos_bft_subdag_certificate_previous_refs` (DAG-density proxy), and `snarkos_bft_subdag_rounds_per_block`.
- Registered the new metric names in `node/metrics/src/names.rs` (`bft` module + `HISTOGRAM_NAMES`) so they pre-register and appear on `/metrics` before the first observation.
- Reused data already computed in the commit path for an existing debug log (`subdag_metadata`) and existing certificate accessors (`signatures()`, `previous_certificate_ids()`) rather than recomputing anything.
- All emissions are gated behind `#[cfg(feature = "metrics")]`, consistent with existing metrics in this file.

## Test Plan

- `cargo check -p snarkos-node-bft` with and without `--features metrics`, both compile.
- `cargo test -p snarkos-node-bft --features metrics --lib bft::`, all 15 existing BFT commit-path tests pass.
- Ran a local 4-validator devnet and scraped each validator's `/metrics` endpoint after 11+ committed blocks. All four new series appear as Prometheus summaries with plausible values. Observation counts increase in lockstep across all 4 validators as blocks commit, confirming the metrics are recorded consistently network-wide, not just locally.

## Documentation

No user-facing docs to update. Internal metrics reference docs (if any list all `snarkos_*` metric names) should add these four.

## Backwards compatibility

Purely additive: new metric names/observations only, no changes to consensus logic, message formats, or ledger data. No `ConsensusVersion` gate needed.